### PR TITLE
core: fix evaluating columns a part from agg

### DIFF
--- a/core/translate.rs
+++ b/core/translate.rs
@@ -229,15 +229,7 @@ fn translate_columns(
 
     let mut target = register_start;
     for (col, info) in select.columns.iter().zip(select.column_info.iter()) {
-        translate_column(
-            program,
-            cursor_id,
-            select.from,
-            col,
-            info,
-            select.exist_aggregation,
-            target,
-        );
+        translate_column(program, cursor_id, select.from, col, info, target);
         target += info.columns_to_allocate;
     }
     (register_start, register_end)
@@ -249,14 +241,8 @@ fn translate_column(
     table: Option<&crate::schema::Table>,
     col: &sqlite3_parser::ast::ResultColumn,
     info: &ColumnInfo,
-    exist_aggregation: bool, // notify this column there is aggregation going on in other columns (or this one)
     target_register: usize, // where to store the result, in case of star it will be the start of registers added
 ) {
-    if exist_aggregation && !info.is_aggregation_function() {
-        // FIXME: let's do nothing
-        return;
-    }
-
     match col {
         sqlite3_parser::ast::ResultColumn::Expr(expr, _) => {
             if info.is_aggregation_function() {


### PR DESCRIPTION
For now this works:

```sql
> select avg(age), 2 from users
50.4915|2
```
This case must be optimized in the future:
```sql
> select avg(age), id from users
50.4915|10000
> explain select avg(age), id from users
addr  opcode         p1    p2    p3    p4             p5  comment
----  -------------  ----  ----  ----  -------------  --  -------
0     Init           0     13    0                    0   Start at 13
1     OpenReadAsync  0     2     0                    0   root=2
2     OpenReadAwait  0     0     0                    0
3     RewindAsync    0     0     0                    0
4     RewindAwait    0     12    0                    0
5     Column         0     9     2                    0   r[2]= cursor 0 column 9
6     AggStep        0     2     0     avg            0   accum=r[0] step(2)
7     RowId          0     1     0                    0
8     NextAsync      0     0     0                    0
9     NextAwait      0     4     0                    0
10    AggFinal       0     0     0     avg            0   accum=r[0]
11    ResultRow      0     2     0                    0   output=r[0..2]
12    Halt           0     0     0                    0
13    Transaction    0     0     0                    0
14    Goto           0     1     0                    0

```
as you can see `id` column must could be skipped from being read until last iteration:

```sql
sqlite> explain select avg(age), id from users;
addr  opcode         p1    p2    p3    p4             p5  comment
----  -------------  ----  ----  ----  -------------  --  -------------
0     Init           0     15    0                    0   Start at 15
1     Integer        0     4     0                    0   r[4]=0
2     Null           0     1     3                    0   r[1..3]=NULL
3     OpenRead       0     2     0     10             0   root=2 iDb=0; users
4     Rewind         0     11    0                    0
5       Column         0     9     5                    0   r[5]= cursor 0 column 9
6       AggStep        0     5     1     avg(1)         1   accum=r[1] step(r[5])
7       If             4     9     0                    0
8       Rowid          0     2     0                    0   r[2]=users.rowid
9       Integer        1     4     0                    0   r[4]=1
10    Next           0     5     0                    1
11    AggFinal       1     1     0     avg(1)         0   accum=r[1] N=1
12    Copy           1     6     1                    0   r[6..7]=r[1..2]
13    ResultRow      6     2     0                    0   output=r[6..7]
14    Halt           0     0     0                    0
15    Transaction    0     0     1     0              1   usesStmtJournal=0
16    Goto           0     1     0                    0

```

fixes #65 