### PR TITLE
wait for the read completion

### DIFF
--- a/core/io/linux.rs
+++ b/core/io/linux.rs
@@ -31,7 +31,7 @@ impl IO for LinuxIO {
     fn run_once(&self) -> Result<()> {
         trace!("run_once()");
         let mut ring = self.ring.borrow_mut();
-        ring.submit_and_wait(0)?;
+        ring.submit_and_wait(1)?;
         loop {
             match ring.completion().next() {
                 Some(cqe) => {


### PR DESCRIPTION
The submit_and_wait command waits for `n` completion events. We were providing an incorrect argument, which caused the issue.

Fixes #74