### PR TITLE
fix: unhanded empty args in aggregate function

### DIFF
--- a/core/translate.rs
+++ b/core/translate.rs
@@ -438,7 +438,8 @@ fn translate_aggregation(
     let _ = expr;
     assert!(info.func.is_some());
     let func = info.func.as_ref().unwrap();
-    let args = info.args.as_ref().unwrap();
+    let empty_args = &Vec::<ast::Expr>::new();
+    let args = info.args.as_ref().unwrap_or_else(|| empty_args);
     let dest = match func {
         AggFunc::Avg => {
             if args.len() != 1 {


### PR DESCRIPTION
When the args are empty in aggregate function like

```sql
SELECT COUNT() FROM users; // This is valid
SELECT AVG() from users; // this must give error
```

The value of info.args.as_ref() is None which make the program crash due to unwrap().
All the implementation till now of aggrigate function check the args using args.len() then are assuming that the args after unwrap will be an empty array. But that not the case as we have explained before.

This pr, created an empty args vector then the args is None.

![image](https://github.com/penberg/limbo/assets/82411321/2bedfba8-6012-48d3-b5fa-0e281fd177bd)

