### PR TITLE
core: apply Real affinity on columns stored as int

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -190,7 +190,7 @@ fn query(
                             match value {
                                 Value::Null => print!("NULL"),
                                 Value::Integer(i) => print!("{}", i),
-                                Value::Float(f) => print!("{}", f),
+                                Value::Float(f) => print!("{:?}", f),
                                 Value::Text(s) => print!("{}", s),
                                 Value::Blob(b) => print!("{:?}", b),
                             }

--- a/core/translate.rs
+++ b/core/translate.rs
@@ -401,17 +401,19 @@ fn translate_table_star(
         .unwrap()
         .open_cursor;
     for (i, col) in table.columns().iter().enumerate() {
+        let col_target_register = target_register + i;
         if table.column_is_rowid_alias(col) {
             program.emit_insn(Insn::RowId {
                 cursor_id: table_cursor,
-                dest: target_register + i,
+                dest: col_target_register,
             });
         } else {
             program.emit_insn(Insn::Column {
                 column: i,
-                dest: target_register + i,
+                dest: col_target_register,
                 cursor_id: table_cursor,
             });
+            maybe_apply_affinity(col, col_target_register, program);
         }
     }
 }
@@ -516,6 +518,7 @@ fn translate_expr(
                     cursor_id,
                 });
             }
+            maybe_apply_affinity(col, target_register, program);
             Ok(target_register)
         }
         ast::Expr::InList { .. } => todo!(),
@@ -770,5 +773,14 @@ fn update_pragma(name: &str, value: i64, header: Rc<RefCell<DatabaseHeader>>, pa
             pager.change_page_cache_size(cache_size);
         }
         _ => todo!(),
+    }
+}
+
+fn maybe_apply_affinity(col: &Column, target_register: usize, program: &mut ProgramBuilder) {
+    match col.ty {
+        crate::schema::Type::Real => program.emit_insn(Insn::RealAffinity {
+            register: target_register,
+        }),
+        _ => {}
     }
 }

--- a/testing/all.test
+++ b/testing/all.test
@@ -68,8 +68,12 @@ do_execsql_test pragma-cache-size {
 
 do_execsql_test cross-join {
     select * from users, products limit 1;
-} {1|Jamie|Foster|dylan00@example.com|496-522-9493|62375\ Johnson\ Rest\ Suite\ 322|West\ Lauriestad|IL|35865|94|1|hat|79}
+} {1|Jamie|Foster|dylan00@example.com|496-522-9493|62375\ Johnson\ Rest\ Suite\ 322|West\ Lauriestad|IL|35865|94|1|hat|79.0}
 
 do_execsql_test cross-join-specific-columns {
     select first_name, price from users, products limit 1;
-} {Jamie|79}
+} {Jamie|79.0}
+
+do_execsql_test realify {
+    select price from products limit 1;
+} {79.0}


### PR DESCRIPTION
Values in sqlite3, as expected, can be stored in different formats to optimize disk usage. In this case, a 79.0 float will be transformed to a u8.

sqlite3 deals with this by adding a RealAffinity op after each column that might need it. Therefore, in this pr we do exactly that :).

### sqlite3 explain
```sql
sqlite> explain select price from products limit 1;
addr  opcode         p1    p2    p3    p4             p5  comment
----  -------------  ----  ----  ----  -------------  --  -------------
0     Init           0     10    0                    0   Start at 10
1     Integer        1     1     0                    0   r[1]=1; LIMIT counter
2     OpenRead       0     3     0     3              0   root=3 iDb=0; products
3     Rewind         0     9     0                    0
4       Column         0     2     2                    0   r[2]= cursor 0 column 2
5       RealAffinity   2     0     0                    0
6       ResultRow      2     1     0                    0   output=r[2]
7       DecrJumpZero   1     9     0                    0   if (--r[1])==0 goto 9
8     Next           0     4     0                    1
9     Halt           0     0     0                    0
10    Transaction    0     0     2     0              1   usesStmtJournal=0
11    Goto           0     1     0                    0
```
### limbo explain
```sql
> explain select price from products limit 1;
addr  opcode         p1    p2    p3    p4             p5  comment
----  -------------  ----  ----  ----  -------------  --  -------
0    Init           0     13    0       0   Start at 13
1    Integer        0     1     0       0
2    OpenReadAsync  0     3     0       0   root=3
3    OpenReadAwait  0     0     0       0
4    RewindAsync    0     0     0       0
5    RewindAwait    0     12    0       0
6      Column         0     2     1       0   r[1]= cursor 0 column 2
7      RealAffinity   1     0     0       0
8      ResultRow      1     1     0       0   output=r[1..2]
9      DecrJumpZero   0     12    0       0
10   NextAsync      0     0     0       0
11   NextAwait      0     5     0       0
12   Halt           0     0     0       0
13   Transaction    0     0     0       0
14   Goto           0     1     0       0
```

Fixes #114 