### PR TITLE
Align columns in EXPLAIN command

### DIFF
--- a/core/vdbe.rs
+++ b/core/vdbe.rs
@@ -269,8 +269,8 @@ pub struct Program {
 
 impl Program {
     pub fn explain(&self) {
-        println!("addr  opcode         p1    p2    p3    p4             p5  comment");
-        println!("----  -------------  ----  ----  ----  -------------  --  -------");
+        println!("addr  opcode             p1    p2    p3    p4             p5  comment");
+        println!("----  -----------------  ----  ----  ----  -------------  --  -------");
         let mut indent_count: usize = 0;
         let indent = "  ";
         let mut prev_insn: Option<&Insn> = None;
@@ -972,8 +972,8 @@ fn insn_to_str(addr: BranchOffset, insn: &Insn, indent: String) -> String {
             ),
         };
     format!(
-        "{:<4} {}{:<13}  {:<4}  {:<4}  {:<4}  {:<13}  {:<2}  {}",
-        addr, indent, opcode, p1, p2, p3, p4, p5, comment
+        "{:<4}  {:<17}  {:<4}  {:<4}  {:<4}  {:<13}  {:<2}  {}",
+        addr, &(indent + opcode), p1, p2, p3, p4.to_string(), p5, comment
     )
 }
 


### PR DESCRIPTION
Fixes #112 

Apart from indenting only the opcode value:
1. Increased the space for opcode column from 13 to 17
2. Changed p4 to p4.to_string() to maintain the spacing and align columns correctly

Sample output after these changes:
```
> explain select max(price) from users, products limit 1;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     21    0                    0   Start at 21
1     Integer            0     1     0                    0
2     OpenReadAsync      0     2     0                    0   root=2
3     OpenReadAwait      0     0     0                    0
4     OpenReadAsync      1     3     0                    0   root=3
5     OpenReadAwait      0     0     0                    0
6     RewindAsync        0     0     0                    0
7     RewindAwait        0     17    0                    0
8       RewindAsync      1     0     0                    0
9       RewindAwait      1     15    0                    0
10        Column         1     2     2                    0   r[2]= cursor 1 column 2
11        RealAffinity   2     0     0                    0
12        AggStep        0     2     1     max            0   accum=r[1] step(2)
13      NextAsync        1     0     0                    0
14      NextAwait        1     9     0                    0
15    NextAsync          0     0     0                    0
16    NextAwait          0     7     0                    0
17    AggFinal           0     1     0     max            0   accum=r[1]
18    ResultRow          1     1     0                    0   output=r[1..2]
19    DecrJumpZero       0     20    0                    0
20    Halt               0     0     0                    0
21    Transaction        0     0     0                    0
22    Goto               0     1     0                    0
``` 