### PR TITLE
Implement coalesce && refactor/rename a few things in the labeling system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +787,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,9 +973,11 @@ dependencies = [
  "log",
  "mimalloc",
  "ordered-multimap",
+ "polling",
  "pprof",
  "rstest",
  "rusqlite",
+ "rustix",
  "sieve-cache",
  "sqlite3-parser",
  "thiserror",
@@ -1227,6 +1244,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polling"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.4.0",
+ "pin-project-lite",
+ "rustix",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1755,6 +1787,22 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "uncased"

--- a/core/function.rs
+++ b/core/function.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum AggFunc {
     Avg,
@@ -21,6 +23,34 @@ impl AggFunc {
             AggFunc::StringAgg => "string_agg",
             AggFunc::Sum => "sum",
             AggFunc::Total => "total",
+        }
+    }
+}
+
+pub enum SingleRowFunc {
+    Coalesce,
+}
+
+pub enum Func {
+    Agg(AggFunc),
+    SingleRow(SingleRowFunc),
+}
+
+impl FromStr for Func {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "avg" => Ok(Func::Agg(AggFunc::Avg)),
+            "count" => Ok(Func::Agg(AggFunc::Count)),
+            "group_concat" => Ok(Func::Agg(AggFunc::GroupConcat)),
+            "max" => Ok(Func::Agg(AggFunc::Max)),
+            "min" => Ok(Func::Agg(AggFunc::Min)),
+            "string_agg" => Ok(Func::Agg(AggFunc::StringAgg)),
+            "sum" => Ok(Func::Agg(AggFunc::Sum)),
+            "total" => Ok(Func::Agg(AggFunc::Total)),
+            "coalesce" => Ok(Func::SingleRow(SingleRowFunc::Coalesce)),
+            _ => Err(()),
         }
     }
 }

--- a/testing/all.test
+++ b/testing/all.test
@@ -146,3 +146,31 @@ do_execsql_test where-clause-no-table-unary-true {
 do_execsql_test where-clause-no-table-unary-false {
     select 1 where 0;
 } {}
+
+do_execsql_test coalesce {
+    select coalesce(NULL, 1);
+} {1}
+
+do_execsql_test coalesce-2 {
+    select coalesce(NULL, NULL, 1);
+} {1}
+
+do_execsql_test coalesce-null {
+    select coalesce(NULL, NULL, NULL);
+} {NULL}
+
+do_execsql_test coalesce-first {
+    select coalesce(1, 2, 3);
+} {1}
+
+do_execsql_test coalesce-from-table {
+    select coalesce(NULL, 1) from users limit 1;
+} {1}
+
+do_execsql_test coalesce-from-table-column {
+    select coalesce(NULL, age) from users where age = 94 limit 1;
+} {94}
+
+do_execsql_test coalesce-from-table-multiple-columns {
+    select coalesce(NULL, age), coalesce(NULL, id) from users where age = 94 limit 1;
+} {94|1}


### PR DESCRIPTION
New features:

- Adds `coalesce()`
- adds enum `Func` with variants `AggFunc` (existing) and `SingleRowFunc` (new)

---
Jump handling changes:

- Rename `ProgramBuilder.add_label()` to `ProgramBuilder.add_label_dependency()` (reflects what the method does better)
- Add `ProgramBuilder.preassign_label_to_next_insn()` (needed in e.g. the `coalesce` implementation -- we know we need to jump to "the part after coalesce", but we don't / can't know exactly where that is -- depends on the query)
- Add `ProgramBuilder.emit_insn_with_label_dependency()` (every `program.add_label()` was followed by an `.emit_insn()` so this is a helper to do those two things together)

---
EXPLAIN outputs:

limbo:

```
> explain select id, coalesce(age, 100) from users limit 1;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     15    0                    0   Start at 15
1     Integer            0     1     0                    0   
2     OpenReadAsync      0     2     0                    0   root=2
3     OpenReadAwait      0     0     0                    0   
4     RewindAsync        0     0     0                    0   
5     RewindAwait        0     13    0                    0   
6       RowId            0     1     0                    0   
7       Column           0     9     2                    0   r[2]= cursor 0 column 9
8       NotNull          2     10    0                    0   r[2] -> 10
9       Integer          2     100   0                    0   
10      ResultRow        1     2     0                    0   output=r[1..3]
11      DecrJumpZero     0     14    0                    0   
12    NextAsync          0     0     0                    0   
13    NextAwait          0     5     0                    0   
14    Halt               0     0     0                    0   
15    Transaction        0     0     0                    0   
16    Goto               0     1     0                    0 
```

sqlite3:

```
sqlite> explain select id, coalesce(age, 100) from users limit 1;
addr  opcode         p1    p2    p3    p4             p5  comment      
----  -------------  ----  ----  ----  -------------  --  -------------
0     Init           0     12    0                    0   Start at 12
1     Integer        1     1     0                    0   r[1]=1; LIMIT counter
2     OpenRead       0     2     0     10             0   root=2 iDb=0; users
3     Rewind         0     11    0                    0   
4       Rowid          0     2     0                    0   r[2]=users.rowid
5       Column         0     9     3                    0   r[3]= cursor 0 column 9
6       NotNull        3     8     0                    0   if r[3]!=NULL goto 8
7       Integer        100   3     0                    0   r[3]=100
8       ResultRow      2     2     0                    0   output=r[2..3]
9       DecrJumpZero   1     11    0                    0   if (--r[1])==0 goto 11
10    Next           0     4     0                    1   
11    Halt           0     0     0                    0   
12    Transaction    0     0     2     0              1   usesStmtJournal=0
13    Goto           0     1     0                    0 
```