### PR TITLE
core: labels system and limit refactor

### DIFF
--- a/core/vdbe.rs
+++ b/core/vdbe.rs
@@ -295,12 +295,12 @@ impl ProgramBuilder {
             "Forbidden resolve of an unexistent label!"
         );
 
-        let label_references = &self.unresolved_labels[self.label_to_index(label)];
+        let label_references = &mut self.unresolved_labels[label_index];
         assert!(
             label_references.len() > 0,
             "Trying to resolve an empty created label, all labels must be resolved for now."
         );
-        for insn_reference in label_references {
+        for insn_reference in label_references.iter() {
             let insn = &mut self.insns[*insn_reference];
             match insn {
                 Insn::Init { target_pc } => {
@@ -386,6 +386,7 @@ impl ProgramBuilder {
                 }
             }
         }
+        label_references.clear();
     }
 
     pub fn build(self) -> Program {

--- a/core/vdbe.rs
+++ b/core/vdbe.rs
@@ -6,15 +6,16 @@ use crate::types::{AggContext, Cursor, CursorResult, OwnedRecord, OwnedValue, Re
 use anyhow::Result;
 use std::borrow::BorrowMut;
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
 
-pub type BranchOffset = usize;
+pub type BranchOffset = i64;
 
 pub type CursorID = usize;
 
 pub type PageIdx = usize;
 
+#[derive(Debug)]
 pub enum Insn {
     // Initialize the program state and jump to the given PC.
     Init {
@@ -205,18 +206,25 @@ pub enum Insn {
     },
 }
 
+// Index of insn in list of insns
+type InsnReference = usize;
+
 pub struct ProgramBuilder {
     next_free_register: usize,
+    next_free_label: BranchOffset,
     next_free_cursor_id: usize,
     insns: Vec<Insn>,
+    unresolved_labels: HashMap<BranchOffset, Vec<InsnReference>>,
 }
 
 impl ProgramBuilder {
     pub fn new() -> Self {
         Self {
             next_free_register: 0,
+            next_free_label: 0,
             next_free_cursor_id: 0,
             insns: Vec::new(),
+            unresolved_labels: HashMap::new(),
         }
     }
 
@@ -252,12 +260,124 @@ impl ProgramBuilder {
         self.insns.push(insn);
     }
 
-    pub fn fixup_insn(&mut self, offset: usize, insn: Insn) {
-        self.insns[offset] = insn;
+    pub fn offset(&self) -> BranchOffset {
+        self.insns.len() as BranchOffset
     }
 
-    pub fn offset(&self) -> usize {
-        self.insns.len()
+    pub fn allocate_label(&mut self) -> BranchOffset {
+        self.next_free_label -= 1;
+        self.unresolved_labels
+            .insert(self.next_free_label, Vec::new());
+        self.next_free_label
+    }
+
+    pub fn add_label(&mut self, label: BranchOffset, insn_reference: BranchOffset) {
+        assert!(insn_reference >= 0);
+        assert!(label < 0);
+        let insn_reference = insn_reference as InsnReference;
+        let label_references = self.unresolved_labels.get_mut(&label);
+        if let Some(label_references) = label_references {
+            label_references.push(insn_reference);
+        } else {
+            self.unresolved_labels.insert(label, vec![insn_reference]);
+        }
+    }
+
+    pub fn resolve_label(&mut self, label: BranchOffset, to_offset: BranchOffset) {
+        assert!(label < 0);
+        assert!(to_offset >= 0);
+        let label_references = self.unresolved_labels.get_mut(&label);
+        if label_references.is_none() {
+            unreachable!("Forbidden resolve of an unexistent label!");
+        }
+        let label_references = label_references.unwrap();
+
+        for insn_reference in label_references {
+            let insn = &mut self.insns[*insn_reference];
+            match insn {
+                Insn::Init { target_pc } => {
+                    assert!(*target_pc < 0);
+                    *target_pc = to_offset;
+                }
+                Insn::Eq {
+                    lhs,
+                    rhs,
+                    target_pc,
+                } => {
+                    assert!(*target_pc < 0);
+                    *target_pc = to_offset;
+                }
+                Insn::Ne {
+                    lhs,
+                    rhs,
+                    target_pc,
+                } => {
+                    assert!(*target_pc < 0);
+                    *target_pc = to_offset;
+                }
+                Insn::Lt {
+                    lhs,
+                    rhs,
+                    target_pc,
+                } => {
+                    assert!(*target_pc < 0);
+                    *target_pc = to_offset;
+                }
+                Insn::Le {
+                    lhs,
+                    rhs,
+                    target_pc,
+                } => {
+                    assert!(*target_pc < 0);
+                    *target_pc = to_offset;
+                }
+                Insn::Gt {
+                    lhs,
+                    rhs,
+                    target_pc,
+                } => {
+                    assert!(*target_pc < 0);
+                    *target_pc = to_offset;
+                }
+                Insn::Ge {
+                    lhs,
+                    rhs,
+                    target_pc,
+                } => {
+                    assert!(*target_pc < 0);
+                    *target_pc = to_offset;
+                }
+                Insn::IfNot { reg, target_pc } => {
+                    assert!(*target_pc < 0);
+                    *target_pc = to_offset;
+                }
+                Insn::RewindAwait {
+                    cursor_id,
+                    pc_if_empty,
+                } => {
+                    assert!(*pc_if_empty < 0);
+                    *pc_if_empty = to_offset;
+                }
+                Insn::Goto { target_pc } => {
+                    assert!(*target_pc < 0);
+                    *target_pc = to_offset;
+                }
+                Insn::DecrJumpZero { reg, target_pc } => {
+                    assert!(*target_pc < 0);
+                    *target_pc = to_offset;
+                }
+                Insn::SorterNext {
+                    cursor_id,
+                    pc_if_next,
+                } => {
+                    assert!(*pc_if_next < 0);
+                    *pc_if_next = to_offset;
+                }
+                _ => {
+                    todo!("missing resolve_label for {:?}", insn);
+                }
+            }
+        }
     }
 
     pub fn build(self) -> Program {
@@ -316,7 +436,7 @@ impl Program {
         let mut prev_insn: Option<&Insn> = None;
         for (addr, insn) in self.insns.iter().enumerate() {
             indent_count = get_indent_count(indent_count, insn, prev_insn);
-            print_insn(addr, insn, indent.repeat(indent_count));
+            print_insn(addr as BranchOffset, insn, indent.repeat(indent_count));
             prev_insn = Some(insn);
         }
     }
@@ -327,7 +447,7 @@ impl Program {
         pager: Rc<Pager>,
     ) -> Result<StepResult<'a>> {
         loop {
-            let insn = &self.insns[state.pc];
+            let insn = &self.insns[state.pc as usize];
             trace_insn(state.pc, insn);
             let mut cursors = state.cursors.borrow_mut();
             match insn {


### PR DESCRIPTION
This PR includes two things: labels and limit refactor. Let's start with the meat of the issue.

## Labels
* Labels are allocated the same way you would allocate a new register, but instead of incrementing, you decrement.
* Insn that depend on a label are appended to the list of that label (`unresolved_insns`).
* The list of dependent insn are accesed through `label.abs - 1` (`label_to_index` helper). 
* List of dependents is cleared once resolved to ensure we don't resolve more than once.
* O(1)
* Added some extra type definitions to help distinguish parts like `BranchOffset` which can be negative and `InsnReference` which is a index to the list of `insns`.
### Api
the api is quite simple
```rust
allocate_label() -> creates a new label with empty list of dependents
add_labe(label, InsnReference) -> add insn dependent on label
resolve_label(label, BranchOffset) -> switch labels to the input offset
```

 ## Limit refactor

Now limit information is gathered on a centralized struct (`LimitInfo`)instead of sparse variables that confused the flow. If this is LimitInfo, do stuff with it.