### PR TITLE
Left join initial nested loop implementation

### DIFF
--- a/core/btree.rs
+++ b/core/btree.rs
@@ -38,6 +38,7 @@ pub struct BTreeCursor {
     page: RefCell<Option<Rc<MemPage>>>,
     rowid: RefCell<Option<u64>>,
     record: RefCell<Option<OwnedRecord>>,
+    null_flag: bool,
 }
 
 impl BTreeCursor {
@@ -48,6 +49,7 @@ impl BTreeCursor {
             page: RefCell::new(None),
             rowid: RefCell::new(None),
             record: RefCell::new(None),
+            null_flag: false,
         }
     }
 
@@ -160,5 +162,13 @@ impl Cursor for BTreeCursor {
 
     fn insert(&mut self, _record: &OwnedRecord) -> Result<()> {
         unimplemented!()
+    }
+
+    fn set_null_flag(&mut self, flag: bool) {
+        self.null_flag = flag;
+    }
+
+    fn get_null_flag(&self) -> bool {
+        self.null_flag
     }
 }

--- a/core/sorter.rs
+++ b/core/sorter.rs
@@ -75,4 +75,12 @@ impl Cursor for Sorter {
         self.insert(key, record.clone());
         Ok(())
     }
+
+    fn set_null_flag(&mut self, _flag: bool) {
+        todo!();
+    }
+
+    fn get_null_flag(&self) -> bool {
+        todo!();
+    }
 }

--- a/core/types.rs
+++ b/core/types.rs
@@ -291,4 +291,6 @@ pub trait Cursor {
     fn rowid(&self) -> Result<Ref<Option<u64>>>;
     fn record(&self) -> Result<Ref<Option<OwnedRecord>>>;
     fn insert(&mut self, record: &OwnedRecord) -> Result<()>;
+    fn set_null_flag(&mut self, flag: bool);
+    fn get_null_flag(&self) -> bool;
 }

--- a/testing/join.test
+++ b/testing/join.test
@@ -11,6 +11,16 @@ do_execsql_test cross-join-specific-columns {
     select first_name, price from users, products limit 1;
 } {Jamie|79.0}
 
+do_execsql_test cross-join-where-right-tbl {
+    select users.first_name, products.name from users join products where products.id = 1 limit 2;
+} {Jamie|hat
+Cindy|hat}
+
+do_execsql_test cross-join-where-left-tbl {
+    select users.first_name, products.name from users join products where users.id = 1 limit 2;
+} {Jamie|hat
+Jamie|cap}
+
 do_execsql_test inner-join-pk {
     select users.first_name as user_name, products.name as product_name from users join products on users.id = products.id;
 } {Jamie|hat
@@ -45,3 +55,56 @@ do_execsql_test inner-join-self-with-where {
 #do_execsql_test inner-join-with-where-2 {
 #    select u.first_name from users u join products as p on u.first_name != p.name where u.last_name = 'Williams' limit 1;
 #} {Laura} <-- sqlite3 returns 'Aaron'
+
+do_execsql_test left-join-pk {
+    select users.first_name as user_name, products.name as product_name from users left join products on users.id = products.id limit 12;
+} {Jamie|hat
+Cindy|cap
+Tommy|shirt
+Jennifer|sweater
+Edward|sweatshirt
+Nicholas|shorts
+Aimee|jeans
+Rachel|sneakers
+Matthew|boots
+Daniel|coat
+Travis|accessories
+Alan|}
+
+do_execsql_test left-join-with-where {
+    select u.first_name, p.name from users u left join products as p on u.id = p.id where u.id >= 10 limit 5;
+} {Daniel|coat
+Travis|accessories
+Alan|
+Michael|
+Brianna|}
+
+do_execsql_test left-join-non-pk {
+    select users.first_name as user_name, products.name as product_name from users left join products on users.first_name = products.name limit 3;
+} {Jamie|
+Cindy|
+Tommy|}
+
+do_execsql_test left-join-self {
+    select u1.first_name as user_name, u2.first_name as neighbor_name from users u1 left join users as u2 on u1.id = u2.id + 1 limit 2;
+} {Jamie|
+Cindy|Jamie}
+
+do_execsql_test left-join-self-with-where {
+    select u1.first_name as user_name, u2.first_name as neighbor_name from users u1 left join users as u2 on u1.id = u2.id + 1 where u1.id = 5 limit 2;
+} {Edward|Jennifer}
+
+do_execsql_test left-join-multiple-cond-and {
+    select u.first_name, p.name from users u left join products as p on u.id = p.id and u.first_name = p.name limit 2;
+} {Jamie|
+Cindy|}
+
+do_execsql_test left-join-multiple-cond-or {
+    select u.first_name, p.name from users u left join products as p on u.id = p.id or u.first_name = p.name limit 2;
+} {Jamie|hat
+Cindy|cap}
+
+do_execsql_test left-join-no-join-conditions-but-multiple-where {
+    select u.first_name, p.name from users u left join products as p where u.id = p.id or u.first_name = p.name limit 2;
+} {Jamie|hat
+Cindy|cap}


### PR DESCRIPTION
Left join algorithm, always using a nested loop join (reverse engineered from `sqlite3` with `pragma automatic_index = 0;` - thanks @pereman2 for the tip):

```
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     25    0                    0   Start at 25
1     OpenReadAsync      0     2     0                    0   root=2
2     OpenReadAwait      0     0     0                    0   
3     OpenReadAsync      1     3     0                    0   root=3
4     OpenReadAwait      0     0     0                    0   
5     RewindAsync        0     0     0                    0   
6     RewindAwait        0     24    0                    0   
7       Integer          0     1     0                    0   r[1]=0 <-------- SET "left join match flag" TO FALSE
8       RewindAsync      1     0     0                    0   
9       RewindAwait      1     19    0                    0   
10        RowId          0     2     0                    0   r[2]=users.rowid
11        RowId          1     3     0                    0   r[3]=products.rowid
12        Ne             2     3     17                   0   if r[2]!=r[3] goto 17 <----- IF NO MATCH ON JOIN COL, JUMP TO 17 (NEXT RIGHT TABLE ROW)
13        Integer        1     1     0                    0   r[1]=1 <-- SET "left join match flag" TO TRUE
14        Column         0     1     4                    0   r[4]=users.first_name
15        Column         1     1     5                    0   r[5]=products.name
16        ResultRow      4     2     0                    0   output=r[4..5]
17      NextAsync        1     0     0                    0   
18      NextAwait        1     9     0                    0   
19      IfPos            1     22    0                    0   r[1]>0 -> r[1]-=0, goto 22 <-- IF MATCH FLAG IS TRUE, JUMP TO 22 (NEXT LEFT TABLE ROW)
20      NullRow          1     0     0                    0   Set cursor 1 to a (pseudo) NULL row <- IF MATCH FLAG IS FALSE, SET A "NULL FLAG" ON THE RIGHT TABLE CURSOR TO MAKE Insn::Column ALWAYS RETURN NULL
21      Goto             0     13    0                    0   JUMP BACK TO "Set flag to true", READ THE COLUMNS AGAIN, ALL RIGHT TABLE COLUMNS WILL BE NULLED
22    NextAsync          0     0     0                    0   
23    NextAwait          0     6     0                    0   
24    Halt               0     0     0                    0   
25    Transaction        0     0     0                    0   
26    Goto               0     1     0                    0 
```

Supports:

- foo LEFT JOIN bar on xxx
- foo LEFT JOIN bar WHERE xxx (no join condition)
- foo LEFT JOIN BAR on xxx WHERE yyy (both)

Architectural changes:

- Before instructions for handling WHERE/JOIN are emitted ('translated'), they are first introspected in `evaluate_conditions()`
- `evaluate_conditions()` returns a single `QueryConstraint`, which is an enum consisting of members `QueryConstraint::Left` and `QueryConstraint::Inner`. Both `QueryConstraint` variants can contain a `where_clause` property and a `join_clause` property. The reason I wrote it this way is that even without a join condition, you can still have a LEFT JOIN, e.g. `select * from foo left join bar WHERE foo.id = bar.id`. Even a WHERE clause without a join is a `QueryConstraint::Inner`, which is a bit confusing and should probably be renamed. 
- Adds pseudo `null_flag` to Cursors to facilitate nulling out columns in a left join with no match


Sorry, this PR got pretty massive but I wanted to cover quite a few test cases and new bugs kept popping up :D