### PR TITLE
Clean up compat tests

### DIFF
--- a/testing/agg-functions.test
+++ b/testing/agg-functions.test
@@ -1,0 +1,53 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test select-avg {
+  SELECT avg(age) FROM users;
+} {50.396}
+
+do_execsql_test select-sum {
+  SELECT sum(age) FROM users;
+} {503960}
+
+do_execsql_test select-total {
+  SELECT sum(age) FROM users;
+} {503960}
+
+do_execsql_test select-limit {
+  SELECT id FROM users LIMIT 1;
+} {1}
+
+do_execsql_test select-count {
+  SELECT count(id) FROM users;
+} {10000}
+
+do_execsql_test select-max {
+  SELECT max(age) FROM users;
+} {100}
+
+do_execsql_test select-min {
+  SELECT min(age) FROM users;
+} {1}
+
+do_execsql_test select-group-concat {
+  SELECT group_concat(name) FROM products;
+} {hat,cap,shirt,sweater,sweatshirt,shorts,jeans,sneakers,boots,coat,accessories}
+
+do_execsql_test select-group-concat-with-delimiter {
+  SELECT group_concat(name, ';') FROM products;
+} {hat;cap;shirt;sweater;sweatshirt;shorts;jeans;sneakers;boots;coat;accessories}
+
+do_execsql_test select-group-concat-with-column-delimiter {
+  SELECT group_concat(name, id) FROM products;
+} {hat2cap3shirt4sweater5sweatshirt6shorts7jeans8sneakers9boots10coat11accessories}
+
+do_execsql_test select-string-agg-with-delimiter {
+  SELECT string_agg(name, ',') FROM products;
+} {hat,cap,shirt,sweater,sweatshirt,shorts,jeans,sneakers,boots,coat,accessories}
+
+do_execsql_test select-string-agg-with-column-delimiter {
+  SELECT string_agg(name, id) FROM products;
+} {hat2cap3shirt4sweater5sweatshirt6shorts7jeans8sneakers9boots10coat11accessories}
+

--- a/testing/all.test
+++ b/testing/all.test
@@ -6,6 +6,7 @@ source $testdir/tester.tcl
 source $testdir/agg-functions.test
 source $testdir/coalesce.test
 source $testdir/join.test
+source $testdir/pragma.test
 source $testdir/where.test
 
 do_execsql_test select-const-1 {
@@ -19,10 +20,6 @@ do_execsql_test select-const-2 {
 do_execsql_test select-limit-0 {
   SELECT id FROM users LIMIT 0;
 } {}
-
-do_execsql_test pragma-cache-size {
-  PRAGMA cache_size
-} {-2000}
 
 do_execsql_test realify {
     select price from products limit 1;

--- a/testing/all.test
+++ b/testing/all.test
@@ -3,6 +3,7 @@
 set testdir [file dirname $argv0]
 source $testdir/tester.tcl
 
+source $testdir/agg-functions.test
 source $testdir/coalesce.test
 source $testdir/join.test
 source $testdir/where.test
@@ -14,54 +15,6 @@ do_execsql_test select-const-1 {
 do_execsql_test select-const-2 {
   SELECT 2
 } {2}
-
-do_execsql_test select-avg {
-  SELECT avg(age) FROM users;
-} {50.396}
-
-do_execsql_test select-sum {
-  SELECT sum(age) FROM users;
-} {503960}
-
-do_execsql_test select-total {
-  SELECT sum(age) FROM users;
-} {503960}
-
-do_execsql_test select-limit {
-  SELECT id FROM users LIMIT 1;
-} {1}
-
-do_execsql_test select-count {
-  SELECT count(id) FROM users;
-} {10000}
-
-do_execsql_test select-max {
-  SELECT max(age) FROM users;
-} {100}
-
-do_execsql_test select-min {
-  SELECT min(age) FROM users;
-} {1}
-
-do_execsql_test select-group-concat {
-  SELECT group_concat(name) FROM products;
-} {hat,cap,shirt,sweater,sweatshirt,shorts,jeans,sneakers,boots,coat,accessories}
-
-do_execsql_test select-group-concat-with-delimiter {
-  SELECT group_concat(name, ';') FROM products;
-} {hat;cap;shirt;sweater;sweatshirt;shorts;jeans;sneakers;boots;coat;accessories}
-
-do_execsql_test select-group-concat-with-column-delimiter {
-  SELECT group_concat(name, id) FROM products;
-} {hat2cap3shirt4sweater5sweatshirt6shorts7jeans8sneakers9boots10coat11accessories}
-
-do_execsql_test select-string-agg-with-delimiter {
-  SELECT string_agg(name, ',') FROM products;
-} {hat,cap,shirt,sweater,sweatshirt,shorts,jeans,sneakers,boots,coat,accessories}
-
-do_execsql_test select-string-agg-with-column-delimiter {
-  SELECT string_agg(name, id) FROM products;
-} {hat2cap3shirt4sweater5sweatshirt6shorts7jeans8sneakers9boots10coat11accessories}
 
 do_execsql_test select-limit-0 {
   SELECT id FROM users LIMIT 0;

--- a/testing/all.test
+++ b/testing/all.test
@@ -5,6 +5,7 @@ source $testdir/tester.tcl
 
 source $testdir/coalesce.test
 source $testdir/join.test
+source $testdir/where.test
 
 do_execsql_test select-const-1 {
   SELECT 1
@@ -74,100 +75,6 @@ do_execsql_test realify {
     select price from products limit 1;
 } {79.0}
 
-do_execsql_test where-clause-eq {
-    select last_name from users where id = 2000;
-} {Rodriguez}
-
-do_execsql_test where-clause-eq-string {
-    select count(1) from users where last_name = 'Rodriguez';
-} {61}
-
-do_execsql_test where-clause-ne {
-    select count(1) from users where id != 2000;
-} {9999}
-
-do_execsql_test where-clause-gt {
-    select count(1) from users where id > 2000;
-} {8000}
-
-do_execsql_test where-clause-gte {
-    select count(1) from users where id >= 2000;
-} {8001}
-
-do_execsql_test where-clause-lt {
-    select count(1) from users where id < 2000;
-} {1999}
-
-do_execsql_test where-clause-lte {
-    select count(1) from users where id <= 2000;
-} {2000}
-
-do_execsql_test where-clause-unary-true {
-    select count(1) from users where 1;
-} {10000}
-
-# not correct? should be 0?
-do_execsql_test where-clause-unary-false {
-    select count(1) from users where 0;
-} {0}
-
-do_execsql_test where-clause-no-table-unary-true {
-    select 1 where 1;
-} {1}
-
-do_execsql_test where-clause-no-table-unary-false {
-    select 1 where 0;
-} {}
-
 do_execsql_test select-add {
     select u.age + 1 from users u where u.age = 91 limit 1;
 } {92}
-
-do_execsql_test select-where-and {
-    select first_name, age from users where first_name = 'Jamie' and age > 80 
-} {Jamie|94
-Jamie|88
-Jamie|99
-Jamie|92
-Jamie|87
-Jamie|88
-}
-
-do_execsql_test select-where-or {
-    select first_name, age from users where first_name = 'Jamie' and age > 80 
-} {Jamie|94
-Jamie|88
-Jamie|99
-Jamie|92
-Jamie|87
-Jamie|88
-}
-
-do_execsql_test select-where-and-or {
-    select first_name, age from users where first_name = 'Jamie' or age = 1 and age = 2
-} {Jamie|94
-Jamie|88
-Jamie|31
-Jamie|26
-Jamie|71
-Jamie|50
-Jamie|28
-Jamie|46
-Jamie|17
-Jamie|64
-Jamie|76
-Jamie|99
-Jamie|92
-Jamie|47
-Jamie|27
-Jamie|54
-Jamie|47
-Jamie|15
-Jamie|12
-Jamie|71
-Jamie|87
-Jamie|34
-Jamie|88
-Jamie|41
-Jamie|73
-}

--- a/testing/all.test
+++ b/testing/all.test
@@ -3,6 +3,7 @@
 set testdir [file dirname $argv0]
 source $testdir/tester.tcl
 
+source $testdir/coalesce.test
 source $testdir/join.test
 
 do_execsql_test select-const-1 {
@@ -117,34 +118,6 @@ do_execsql_test where-clause-no-table-unary-true {
 do_execsql_test where-clause-no-table-unary-false {
     select 1 where 0;
 } {}
-
-do_execsql_test coalesce {
-    select coalesce(NULL, 1);
-} {1}
-
-do_execsql_test coalesce-2 {
-    select coalesce(NULL, NULL, 1);
-} {1}
-
-do_execsql_test coalesce-null {
-    select coalesce(NULL, NULL, NULL);
-} {}
-
-do_execsql_test coalesce-first {
-    select coalesce(1, 2, 3);
-} {1}
-
-do_execsql_test coalesce-from-table {
-    select coalesce(NULL, 1) from users limit 1;
-} {1}
-
-do_execsql_test coalesce-from-table-column {
-    select coalesce(NULL, age) from users where age = 94 limit 1;
-} {94}
-
-do_execsql_test coalesce-from-table-multiple-columns {
-    select coalesce(NULL, age), coalesce(NULL, id) from users where age = 94 limit 1;
-} {94|1}
 
 do_execsql_test select-add {
     select u.age + 1 from users u where u.age = 91 limit 1;

--- a/testing/all.test
+++ b/testing/all.test
@@ -3,6 +3,8 @@
 set testdir [file dirname $argv0]
 source $testdir/tester.tcl
 
+source $testdir/join.test
+
 do_execsql_test select-const-1 {
   SELECT 1
 } {1}
@@ -66,15 +68,6 @@ do_execsql_test select-limit-0 {
 do_execsql_test pragma-cache-size {
   PRAGMA cache_size
 } {-2000}
-
-
-do_execsql_test cross-join {
-    select * from users, products limit 1;
-} {1|Jamie|Foster|dylan00@example.com|496-522-9493|62375\ Johnson\ Rest\ Suite\ 322|West\ Lauriestad|IL|35865|94|1|hat|79.0}
-
-do_execsql_test cross-join-specific-columns {
-    select first_name, price from users, products limit 1;
-} {Jamie|79.0}
 
 do_execsql_test realify {
     select price from products limit 1;
@@ -152,41 +145,6 @@ do_execsql_test coalesce-from-table-column {
 do_execsql_test coalesce-from-table-multiple-columns {
     select coalesce(NULL, age), coalesce(NULL, id) from users where age = 94 limit 1;
 } {94|1}
-
-do_execsql_test inner-join-pk {
-    select users.first_name as user_name, products.name as product_name from users join products on users.id = products.id;
-} {Jamie|hat
-Cindy|cap
-Tommy|shirt
-Jennifer|sweater
-Edward|sweatshirt
-Nicholas|shorts
-Aimee|jeans
-Rachel|sneakers
-Matthew|boots
-Daniel|coat
-Travis|accessories}
-
-do_execsql_test inner-join-non-pk-unqualified {
-    select first_name, name from users join products on first_name != name limit 1;
-} {Jamie|hat}
-
-do_execsql_test inner-join-non-pk-qualified {
-    select users.first_name as user_name, products.name as product_name from users join products on users.first_name = products.name;
-} {}
-
-do_execsql_test inner-join-self {
-    select u1.first_name as user_name, u2.first_name as neighbor_name from users u1 join users as u2 on u1.id = u2.id + 1 limit 1;
-} {Cindy|Jamie}
-
-do_execsql_test inner-join-self-with-where {
-    select u1.first_name as user_name, u2.first_name as neighbor_name from users u1 join users as u2 on u1.id = u2.id + 1 where u1.id = 5 limit 1;
-} {Edward|Jennifer}
-
-# Uncomment this test when it works. Sqlite3 returns 'Aaron' due to the way it reorders tables in the join based on the where clause.
-#do_execsql_test inner-join-with-where-2 {
-#    select u.first_name from users u join products as p on u.first_name != p.name where u.last_name = 'Williams' limit 1;
-#} {Laura} <-- sqlite3 returns 'Aaron'
 
 do_execsql_test select-add {
     select u.age + 1 from users u where u.age = 91 limit 1;

--- a/testing/all.test
+++ b/testing/all.test
@@ -1,30 +1,10 @@
 #!/usr/bin/env tclsh
 
 set testdir [file dirname $argv0]
-source $testdir/tester.tcl
 
 source $testdir/agg-functions.test
 source $testdir/coalesce.test
 source $testdir/join.test
 source $testdir/pragma.test
+source $testdir/select.test
 source $testdir/where.test
-
-do_execsql_test select-const-1 {
-  SELECT 1
-} {1}
-
-do_execsql_test select-const-2 {
-  SELECT 2
-} {2}
-
-do_execsql_test select-limit-0 {
-  SELECT id FROM users LIMIT 0;
-} {}
-
-do_execsql_test realify {
-    select price from products limit 1;
-} {79.0}
-
-do_execsql_test select-add {
-    select u.age + 1 from users u where u.age = 91 limit 1;
-} {92}

--- a/testing/coalesce.test
+++ b/testing/coalesce.test
@@ -1,0 +1,32 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test coalesce {
+    select coalesce(NULL, 1);
+} {1}
+
+do_execsql_test coalesce-2 {
+    select coalesce(NULL, NULL, 1);
+} {1}
+
+do_execsql_test coalesce-null {
+    select coalesce(NULL, NULL, NULL);
+} {}
+
+do_execsql_test coalesce-first {
+    select coalesce(1, 2, 3);
+} {1}
+
+do_execsql_test coalesce-from-table {
+    select coalesce(NULL, 1) from users limit 1;
+} {1}
+
+do_execsql_test coalesce-from-table-column {
+    select coalesce(NULL, age) from users where age = 94 limit 1;
+} {94}
+
+do_execsql_test coalesce-from-table-multiple-columns {
+    select coalesce(NULL, age), coalesce(NULL, id) from users where age = 94 limit 1;
+} {94|1}

--- a/testing/join.test
+++ b/testing/join.test
@@ -1,0 +1,47 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test cross-join {
+    select * from users, products limit 1;
+} {1|Jamie|Foster|dylan00@example.com|496-522-9493|62375\ Johnson\ Rest\ Suite\ 322|West\ Lauriestad|IL|35865|94|1|hat|79.0}
+
+do_execsql_test cross-join-specific-columns {
+    select first_name, price from users, products limit 1;
+} {Jamie|79.0}
+
+do_execsql_test inner-join-pk {
+    select users.first_name as user_name, products.name as product_name from users join products on users.id = products.id;
+} {Jamie|hat
+Cindy|cap
+Tommy|shirt
+Jennifer|sweater
+Edward|sweatshirt
+Nicholas|shorts
+Aimee|jeans
+Rachel|sneakers
+Matthew|boots
+Daniel|coat
+Travis|accessories}
+
+do_execsql_test inner-join-non-pk-unqualified {
+    select first_name, name from users join products on first_name != name limit 1;
+} {Jamie|hat}
+
+do_execsql_test inner-join-non-pk-qualified {
+    select users.first_name as user_name, products.name as product_name from users join products on users.first_name = products.name;
+} {}
+
+do_execsql_test inner-join-self {
+    select u1.first_name as user_name, u2.first_name as neighbor_name from users u1 join users as u2 on u1.id = u2.id + 1 limit 1;
+} {Cindy|Jamie}
+
+do_execsql_test inner-join-self-with-where {
+    select u1.first_name as user_name, u2.first_name as neighbor_name from users u1 join users as u2 on u1.id = u2.id + 1 where u1.id = 5 limit 1;
+} {Edward|Jennifer}
+
+# Uncomment this test when it works. Sqlite3 returns 'Aaron' due to the way it reorders tables in the join based on the where clause.
+#do_execsql_test inner-join-with-where-2 {
+#    select u.first_name from users u join products as p on u.first_name != p.name where u.last_name = 'Williams' limit 1;
+#} {Laura} <-- sqlite3 returns 'Aaron'

--- a/testing/pragma.test
+++ b/testing/pragma.test
@@ -1,0 +1,8 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test pragma-cache-size {
+  PRAGMA cache_size
+} {-2000}

--- a/testing/select.test
+++ b/testing/select.test
@@ -1,0 +1,24 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test select-const-1 {
+  SELECT 1
+} {1}
+
+do_execsql_test select-const-2 {
+  SELECT 2
+} {2}
+
+do_execsql_test select-limit-0 {
+  SELECT id FROM users LIMIT 0;
+} {}
+
+do_execsql_test realify {
+    select price from products limit 1;
+} {79.0}
+
+do_execsql_test select-add {
+    select u.age + 1 from users u where u.age = 91 limit 1;
+} {92}

--- a/testing/where.test
+++ b/testing/where.test
@@ -1,0 +1,98 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test where-clause-eq {
+    select last_name from users where id = 2000;
+} {Rodriguez}
+
+do_execsql_test where-clause-eq-string {
+    select count(1) from users where last_name = 'Rodriguez';
+} {61}
+
+do_execsql_test where-clause-ne {
+    select count(1) from users where id != 2000;
+} {9999}
+
+do_execsql_test where-clause-gt {
+    select count(1) from users where id > 2000;
+} {8000}
+
+do_execsql_test where-clause-gte {
+    select count(1) from users where id >= 2000;
+} {8001}
+
+do_execsql_test where-clause-lt {
+    select count(1) from users where id < 2000;
+} {1999}
+
+do_execsql_test where-clause-lte {
+    select count(1) from users where id <= 2000;
+} {2000}
+
+do_execsql_test where-clause-unary-true {
+    select count(1) from users where 1;
+} {10000}
+
+# not correct? should be 0?
+do_execsql_test where-clause-unary-false {
+    select count(1) from users where 0;
+} {0}
+
+do_execsql_test where-clause-no-table-unary-true {
+    select 1 where 1;
+} {1}
+
+do_execsql_test where-clause-no-table-unary-false {
+    select 1 where 0;
+} {}
+
+do_execsql_test select-where-and {
+    select first_name, age from users where first_name = 'Jamie' and age > 80 
+} {Jamie|94
+Jamie|88
+Jamie|99
+Jamie|92
+Jamie|87
+Jamie|88
+}
+
+do_execsql_test select-where-or {
+    select first_name, age from users where first_name = 'Jamie' and age > 80 
+} {Jamie|94
+Jamie|88
+Jamie|99
+Jamie|92
+Jamie|87
+Jamie|88
+}
+
+do_execsql_test select-where-and-or {
+    select first_name, age from users where first_name = 'Jamie' or age = 1 and age = 2
+} {Jamie|94
+Jamie|88
+Jamie|31
+Jamie|26
+Jamie|71
+Jamie|50
+Jamie|28
+Jamie|46
+Jamie|17
+Jamie|64
+Jamie|76
+Jamie|99
+Jamie|92
+Jamie|47
+Jamie|27
+Jamie|54
+Jamie|47
+Jamie|15
+Jamie|12
+Jamie|71
+Jamie|87
+Jamie|34
+Jamie|88
+Jamie|41
+Jamie|73
+}


### PR DESCRIPTION
Split the compat tests into separate files, allowing developers to run subset of the tests too.