### PR TITLE
Don't output real affinity when translating conditions

### DIFF
--- a/core/vdbe.rs
+++ b/core/vdbe.rs
@@ -239,6 +239,7 @@ pub struct ProgramBuilder {
     next_insn_label: Option<BranchOffset>,
     // Cursors that are referenced by the program. Indexed by CursorID.
     cursor_ref: Vec<(String, Table)>,
+    pub is_translating_cond: bool,
 }
 
 impl ProgramBuilder {
@@ -252,6 +253,7 @@ impl ProgramBuilder {
             next_insn_label: None,
             cursor_ref: Vec::new(),
             constant_insns: Vec::new(),
+            is_translating_cond: false,
         }
     }
 


### PR DESCRIPTION
Related #122 

Main branch
```
> explain select * from products where price < 30;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     17    0                    0   Start at 17
1     OpenReadAsync      0     3     0                    0   root=3
2     OpenReadAwait      0     0     0                    0   
3     RewindAsync        0     0     0                    0   
4     RewindAwait        0     16    0                    0   
5       Column           0     2     1                    0   r[1]=products.price
6       RealAffinity     1     0     0                    0   
7       Integer          30    2     0                    0   r[2]=30
8       Ge               1     2     14                   0   if r[1]>=r[2] goto 14
9       RowId            0     3     0                    0   r[3]=products.rowid
10      Column           0     1     4                    0   r[4]=products.name
11      Column           0     2     5                    0   r[5]=products.price
12      RealAffinity     5     0     0                    0   
13      ResultRow        3     3     0                    0   output=r[3..5]
14    NextAsync          0     0     0                    0   
15    NextAwait          0     4     0                    0   
16    Halt               0     0     0                    0   
17    Transaction        0     0     0                    0   
18    Goto               0     1     0                    0   
```

This branch
```
> explain select * from products where price < 30;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     16    0                    0   Start at 16
1     OpenReadAsync      0     3     0                    0   root=3
2     OpenReadAwait      0     0     0                    0   
3     RewindAsync        0     0     0                    0   
4     RewindAwait        0     15    0                    0   
5       Column           0     2     1                    0   r[1]=products.price
6       Integer          30    2     0                    0   r[2]=30
7       Ge               1     2     13                   0   if r[1]>=r[2] goto 13
8       RowId            0     3     0                    0   r[3]=products.rowid
9       Column           0     1     4                    0   r[4]=products.name
10      Column           0     2     5                    0   r[5]=products.price
11      RealAffinity     5     0     0                    0   
12      ResultRow        3     3     0                    0   output=r[3..5]
13    NextAsync          0     0     0                    0   
14    NextAwait          0     4     0                    0   
15    Halt               0     0     0                    0   
16    Transaction        0     0     0                    0   
17    Goto               0     1     0                    0  
```