### PR TITLE
implement `unicode` scalar function + rename `SingleRowFunc` -> `ScalarFunc`

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -114,7 +114,7 @@ This document describes the SQLite compatibility status of Limbo:
 | typeof(X)                    | No      |         |
 | unhex(X)                     | No      |         |
 | unhex(X,Y)                   | No      |         |
-| unicode(X)                   | No      |         |
+| unicode(X)                   | Yes     |         |
 | unlikely(X)                  | No      |         |
 | upper(X)                     | No      |         |
 | zeroblob(N)                  | No      |         |

--- a/core/function.rs
+++ b/core/function.rs
@@ -28,25 +28,25 @@ impl AggFunc {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum SingleRowFunc {
+pub enum ScalarFunc {
     Coalesce,
     Like,
     Unicode,
 }
 
-impl ToString for SingleRowFunc {
+impl ToString for ScalarFunc {
     fn to_string(&self) -> String {
         match self {
-            SingleRowFunc::Coalesce => "coalesce".to_string(),
-            SingleRowFunc::Like => "like(2)".to_string(),
-            SingleRowFunc::Unicode => "unicode".to_string(),
+            ScalarFunc::Coalesce => "coalesce".to_string(),
+            ScalarFunc::Like => "like(2)".to_string(),
+            ScalarFunc::Unicode => "unicode".to_string(),
         }
     }
 }
 
 pub enum Func {
     Agg(AggFunc),
-    SingleRow(SingleRowFunc),
+    SingleRow(ScalarFunc),
 }
 
 impl FromStr for Func {
@@ -62,9 +62,9 @@ impl FromStr for Func {
             "string_agg" => Ok(Func::Agg(AggFunc::StringAgg)),
             "sum" => Ok(Func::Agg(AggFunc::Sum)),
             "total" => Ok(Func::Agg(AggFunc::Total)),
-            "coalesce" => Ok(Func::SingleRow(SingleRowFunc::Coalesce)),
-            "like" => Ok(Func::SingleRow(SingleRowFunc::Like)),
-            "unicode" => Ok(Func::SingleRow(SingleRowFunc::Unicode)),
+            "coalesce" => Ok(Func::SingleRow(ScalarFunc::Coalesce)),
+            "like" => Ok(Func::SingleRow(ScalarFunc::Like)),
+            "unicode" => Ok(Func::SingleRow(ScalarFunc::Unicode)),
             _ => Err(()),
         }
     }

--- a/core/function.rs
+++ b/core/function.rs
@@ -31,6 +31,7 @@ impl AggFunc {
 pub enum SingleRowFunc {
     Coalesce,
     Like,
+    Unicode,
 }
 
 impl ToString for SingleRowFunc {
@@ -38,6 +39,7 @@ impl ToString for SingleRowFunc {
         match self {
             SingleRowFunc::Coalesce => "coalesce".to_string(),
             SingleRowFunc::Like => "like(2)".to_string(),
+            SingleRowFunc::Unicode => "unicode".to_string(),
         }
     }
 }
@@ -62,6 +64,7 @@ impl FromStr for Func {
             "total" => Ok(Func::Agg(AggFunc::Total)),
             "coalesce" => Ok(Func::SingleRow(SingleRowFunc::Coalesce)),
             "like" => Ok(Func::SingleRow(SingleRowFunc::Like)),
+            "unicode" => Ok(Func::SingleRow(SingleRowFunc::Unicode)),
             _ => Err(()),
         }
     }

--- a/core/function.rs
+++ b/core/function.rs
@@ -46,7 +46,7 @@ impl ToString for ScalarFunc {
 
 pub enum Func {
     Agg(AggFunc),
-    SingleRow(ScalarFunc),
+    Scalar(ScalarFunc),
 }
 
 impl FromStr for Func {

--- a/core/translate.rs
+++ b/core/translate.rs
@@ -1024,6 +1024,26 @@ fn translate_expr(
                             });
                             Ok(target_register)
                         }
+                        SingleRowFunc::Unicode => {
+                            // Inside the SingleRowFunc::Unicode block
+                            let args = if let Some(args) = args {
+                                if args.len() != 1 {
+                                    anyhow::bail!("Parse error: unicode function requires exactly one argument");
+                                }
+                                args
+                            } else {
+                                anyhow::bail!("Parse error: unicode function requires arguments");
+                            };
+
+                            let arg_reg = program.alloc_register();
+                            translate_expr(program, select, &args[0], arg_reg)?;
+                            program.emit_insn(Insn::Function {
+                                func: SingleRowFunc::Unicode,
+                                start_reg: arg_reg,
+                                dest: target_register,
+                            });
+                            Ok(target_register)
+                        }
                     }
                 }
                 None => {

--- a/core/translate.rs
+++ b/core/translate.rs
@@ -1025,7 +1025,6 @@ fn translate_expr(
                             Ok(target_register)
                         }
                         ScalarFunc::Unicode => {
-                            // Inside the ScalarFunc::Unicode block
                             let args = if let Some(args) = args {
                                 if args.len() != 1 {
                                     anyhow::bail!("Parse error: unicode function requires exactly one argument");

--- a/core/types.rs
+++ b/core/types.rs
@@ -24,6 +24,18 @@ impl<'a> Display for Value<'a> {
     }
 }
 
+impl Value {
+    pub fn try_as_string(&self) -> Value {
+        match self {
+            Value::Text(s) => Value::Text(s),
+            Value::Blob(b) => Value::Text(&String::from_utf8_lossy(b).to_string()),
+            Value::Integer(i) => Value::Text(&i.to_string()),
+            Value::Float(f) => Value::Text(&f.to_string()),
+            Value::Null => Value::Null,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum OwnedValue {
     Null,

--- a/core/vdbe.rs
+++ b/core/vdbe.rs
@@ -1197,12 +1197,10 @@ impl Program {
                     }
                     SingleRowFunc::Unicode => {
                         let reg_value = state.registers[*start_reg].borrow_mut();
-                        if let OwnedValue::Text(text) = &*reg_value {
-                            if let Some(unicode_point) = exec_unicode(text) {
-                                state.registers[*dest] = OwnedValue::Integer(unicode_point as i64);
-                            } else {
-                                state.registers[*dest] = OwnedValue::Null;
-                            }
+                        if let Some(unicode_point) = exec_unicode(reg_value) {
+                            state.registers[*dest] = OwnedValue::Integer(unicode_point as i64);
+                        } else {
+                            state.registers[*dest] = OwnedValue::Null;
                         }
                         state.pc += 1;
                     }

--- a/core/vdbe.rs
+++ b/core/vdbe.rs
@@ -1755,6 +1755,23 @@ mod tests {
             exec_unicode(&OwnedValue::Text(Rc::new("a".to_string()))),
             Some(97)
         );
+        assert_eq!(
+            exec_unicode(&OwnedValue::Text(Rc::new("😊".to_string()))),
+            Some(128522)
+        );
+        assert_eq!(
+            exec_unicode(&OwnedValue::Text(Rc::new("".to_string()))),
+            None
+        );
+        assert_eq!(exec_unicode(&OwnedValue::Integer(23)), Some(50));
+        assert_eq!(exec_unicode(&OwnedValue::Integer(0)), None);
+        assert_eq!(exec_unicode(&OwnedValue::Float(0.0)), None);
+        assert_eq!(exec_unicode(&OwnedValue::Float(23.45)), None);
+        assert_eq!(exec_unicode(&OwnedValue::Null), None);
+        assert_eq!(
+            exec_unicode(&OwnedValue::Blob(Rc::new("apple".as_bytes().to_vec()))),
+            Some(97)
+        );
     }
 
     #[test]

--- a/core/vdbe.rs
+++ b/core/vdbe.rs
@@ -1198,9 +1198,11 @@ impl Program {
                     SingleRowFunc::Unicode => {
                         let reg_value = state.registers[*start_reg].borrow_mut();
                         if let OwnedValue::Text(text) = &*reg_value {
-                            let first_char = text.chars().next().unwrap_or('\0');
-                            let unicode_point = first_char as u32;
-                            state.registers[*dest] = OwnedValue::Integer(unicode_point as i64);
+                            if let Some(unicode_point) = exec_unicode(text) {
+                                state.registers[*dest] = OwnedValue::Integer(unicode_point as i64);
+                            } else {
+                                state.registers[*dest] = OwnedValue::Null;
+                            }
                         }
                         state.pc += 1;
                     }

--- a/core/vdbe.rs
+++ b/core/vdbe.rs
@@ -1,5 +1,5 @@
 use crate::btree::BTreeCursor;
-use crate::function::{AggFunc, SingleRowFunc};
+use crate::function::{AggFunc, ScalarFunc};
 use crate::pager::Pager;
 use crate::schema::Table;
 use crate::types::{AggContext, Cursor, CursorResult, OwnedRecord, OwnedValue, Record};
@@ -235,9 +235,9 @@ pub enum Insn {
     // Function
     Function {
         // constant_mask: i32, // P1, not used for now
-        start_reg: usize,    // P2, start of argument registers
-        dest: usize,         // P3
-        func: SingleRowFunc, // P4
+        start_reg: usize, // P2, start of argument registers
+        dest: usize,      // P3
+        func: ScalarFunc, // P4
     },
 }
 
@@ -1173,8 +1173,8 @@ impl Program {
                     start_reg,
                     dest,
                 } => match func {
-                    SingleRowFunc::Coalesce => {}
-                    SingleRowFunc::Like => {
+                    ScalarFunc::Coalesce => {}
+                    ScalarFunc::Like => {
                         let start_reg = *start_reg;
                         assert!(
                             start_reg + 2 <= state.registers.len(),
@@ -1195,7 +1195,7 @@ impl Program {
                         state.registers[*dest] = result;
                         state.pc += 1;
                     }
-                    SingleRowFunc::Unicode => {
+                    ScalarFunc::Unicode => {
                         let reg_value = state.registers[*start_reg].borrow_mut();
                         if let Some(unicode_point) = exec_unicode(reg_value) {
                             state.registers[*dest] = OwnedValue::Integer(unicode_point as i64);

--- a/testing/all.test
+++ b/testing/all.test
@@ -3,6 +3,7 @@
 set testdir [file dirname $argv0]
 
 source $testdir/agg-functions.test
+source $testdir/scalar-functions.test
 source $testdir/coalesce.test
 source $testdir/join.test
 source $testdir/pragma.test

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -1,0 +1,10 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test unicode {
+  SELECT unicode('a');
+} {97}
+
+

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -3,8 +3,19 @@
 set testdir [file dirname $argv0]
 source $testdir/tester.tcl
 
-do_execsql_test unicode {
+do_execsql_test unicode-a {
   SELECT unicode('a');
 } {97}
 
+do_execsql_test unicode-emoji {
+  SELECT unicode('😊');
+} {128522}
+
+do_execsql_test unicode-empty {
+  SELECT unicode('');
+} {NULL}
+
+do_execsql_test unicode-number {
+  SELECT unicode(23);
+} {50}
 


### PR DESCRIPTION
part of #144 

sqlite docs:
> The unicode(X) function returns the numeric unicode code point corresponding to the first character of the string X. If the argument to unicode(X) is not a string then the result is undefined.

sqlite implementation: https://github.com/sqlite/sqlite/blob/1ffd7ed54ff340039fbc0e809a784789048bdf8c/src/func.c#L1181

- [ ] add more tests
- [ ] handle other input types

I really do not know what i'm doing to be honest feedback is expected and appreciated thank you