### PR TITLE
Update changelog/compat re: joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Partial `LEFT JOIN` support.
+
 ### Fixed
 
 - Lock database file with POSIX filesystem advisory lock when database

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -46,10 +46,10 @@ This document describes the SQLite compatibility status of Limbo:
 | SELECT ... LIMIT             | Yes     |         |
 | SELECT ... ORDER BY          | No      |         |
 | SELECT ... GROUP BY          | No      |         |
-| SELECT ... JOIN              | Yes     |         |
-| SELECT ... CROSS JOIN        | Yes     |         |
-| SELECT ... INNER JOIN        | Yes     |         |
-| SELECT ... OUTER JOIN        | No      |         |
+| SELECT ... JOIN              | Partial |         |
+| SELECT ... CROSS JOIN        | Partial |         |
+| SELECT ... INNER JOIN        | Partial |         |
+| SELECT ... OUTER JOIN        | Partial |         |
 | UPDATE                       | No      |         |
 | UPSERT                       | No      |         |
 | VACUUM                       | No      |         |


### PR DESCRIPTION
Changed all JOIN compat entries to `Partial` because it's more accurate -- we don't support e.g. multiple joins and no guarantees that queries will yield correct results.

Which reminds me, should we have a separate compat test set with intentionally failing queries for unimplemented / incorrectly functioning features? I.e. run same test for both sqlite3 and limbo and expect the same result