### PR TITLE
implementation of scalar functions `upper` and `lower`

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -81,7 +81,7 @@ This document describes the SQLite compatibility status of Limbo:
 | likely(X)                    | No     |         |
 | load_extension(X)            | No     |         |
 | load_extension(X,Y)          | No     |         |
-| lower(X)                     | No     |         |
+| lower(X)                     | Yes    |         |
 | ltrim(X)                     | No     |         |
 | ltrim(X,Y)                   | No     |         |
 | max(X,Y,...)                 | No     |         |
@@ -116,7 +116,7 @@ This document describes the SQLite compatibility status of Limbo:
 | unhex(X,Y)                   | No     |         |
 | unicode(X)                   | No     |         |
 | unlikely(X)                  | No     |         |
-| upper(X)                     | No     |         |
+| upper(X)                     | Yes    |         |
 | zeroblob(N)                  | No     |         |
 
 ### Aggregate functions

--- a/core/expr.rs
+++ b/core/expr.rs
@@ -311,6 +311,50 @@ pub fn translate_expr(
 
                             Ok(target_register)
                         }
+                        SingleRowFunc::Upper => {
+                            let args = if let Some(args) = args {
+                                if args.len() != 1 {
+                                    anyhow::bail!(
+                                        "Parse error: upper function with not exactly 1 argument"
+                                    );
+                                }
+                                args
+                            } else {
+                                anyhow::bail!("Parse error: upper function with no arguments");
+                            };
+
+                            let regs = program.alloc_register();
+                            let _ = translate_expr(program, select, &args[0], regs)?;
+                            program.emit_insn(Insn::Function {
+                                start_reg: regs,
+                                dest: target_register,
+                                func: SingleRowFunc::Upper,
+                            });
+
+                            Ok(target_register)
+                        }
+                        SingleRowFunc::Lower => {
+                            let args = if let Some(args) = args {
+                                if args.len() != 1 {
+                                    anyhow::bail!(
+                                        "Parse error: lower function with not exactly 1 argument"
+                                    );
+                                }
+                                args
+                            } else {
+                                anyhow::bail!("Parse error: lower function with no arguments");
+                            };
+
+                            let regs = program.alloc_register();
+                            let _ = translate_expr(program, select, &args[0], regs)?;
+                            program.emit_insn(Insn::Function {
+                                start_reg: regs,
+                                dest: target_register,
+                                func: SingleRowFunc::Lower,
+                            });
+
+                            Ok(target_register)
+                        }
                     }
                 }
                 None => {

--- a/core/function.rs
+++ b/core/function.rs
@@ -32,6 +32,8 @@ pub enum SingleRowFunc {
     Coalesce,
     Like,
     Abs,
+    Upper,
+    Lower,
 }
 
 impl ToString for SingleRowFunc {
@@ -40,6 +42,8 @@ impl ToString for SingleRowFunc {
             SingleRowFunc::Coalesce => "coalesce".to_string(),
             SingleRowFunc::Like => "like(2)".to_string(),
             SingleRowFunc::Abs => "abs".to_string(),
+            SingleRowFunc::Upper => "upper".to_string(),
+            SingleRowFunc::Lower => "lower".to_string(),
         }
     }
 }
@@ -65,6 +69,8 @@ impl FromStr for Func {
             "coalesce" => Ok(Func::SingleRow(SingleRowFunc::Coalesce)),
             "like" => Ok(Func::SingleRow(SingleRowFunc::Like)),
             "abs" => Ok(Func::SingleRow(SingleRowFunc::Abs)),
+            "upper" => Ok(Func::SingleRow(SingleRowFunc::Upper)),
+            "lower" => Ok(Func::SingleRow(SingleRowFunc::Lower)),
             _ => Err(()),
         }
     }

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -18,3 +18,35 @@ do_execsql_test abs-char {
 do_execsql_test abs-null {
     select abs(null);
 } {}
+
+do_execsql_test upper {
+  select upper('Limbo')
+} {LIMBO}
+
+do_execsql_test upper-number {
+  select upper(1)
+} {1}
+
+do_execsql_test upper-char {
+  select upper('a')
+} {A}
+
+do_execsql_test upper-null {
+  select upper(null)
+} {}
+
+do_execsql_test lower {
+  select lower('Limbo')
+} {limbo}
+
+do_execsql_test lower-number {
+  select lower(1)
+} {1}
+
+do_execsql_test lower-char {
+  select lower('A')
+} {a}
+
+do_execsql_test lower-null {
+  select lower(null)
+} {}


### PR DESCRIPTION
This is related to the issue #144. Here is the bytecode comparison from sqlite vs limbo

sqlite:
<img width="588" alt="image" src="https://github.com/user-attachments/assets/d7408def-9439-4703-9420-4f8aab458287">


limbo:
<img width="683" alt="image" src="https://github.com/user-attachments/assets/8a097668-e79a-4566-a9cd-14c390714f5e">
