### PR TITLE
implementation of scalar function `trim(X)` and `trim(X,Y)`

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -109,8 +109,8 @@ This document describes the SQLite compatibility status of Limbo:
 | substring(X,Y,Z)             | No     |         |
 | substring(X,Y)               | No     |         |
 | total_changes()              | No     |         |
-| trim(X)                      | No     |         |
-| trim(X,Y)                    | No     |         |
+| trim(X)                      | Yes     |         |
+| trim(X,Y)                    | Yes     |         |
 | typeof(X)                    | No     |         |
 | unhex(X)                     | No     |         |
 | unhex(X,Y)                   | No     |         |

--- a/core/function.rs
+++ b/core/function.rs
@@ -35,6 +35,7 @@ pub enum SingleRowFunc {
     Upper,
     Lower,
     Random,
+    Trim,
 }
 
 impl ToString for SingleRowFunc {
@@ -46,6 +47,7 @@ impl ToString for SingleRowFunc {
             SingleRowFunc::Upper => "upper".to_string(),
             SingleRowFunc::Lower => "lower".to_string(),
             SingleRowFunc::Random => "random".to_string(),
+            SingleRowFunc::Trim => "trim".to_string(),
         }
     }
 }
@@ -74,6 +76,7 @@ impl FromStr for Func {
             "upper" => Ok(Func::SingleRow(SingleRowFunc::Upper)),
             "lower" => Ok(Func::SingleRow(SingleRowFunc::Lower)),
             "random" => Ok(Func::SingleRow(SingleRowFunc::Random)),
+            "trim" => Ok(Func::SingleRow(SingleRowFunc::Trim)),
             _ => Err(()),
         }
     }

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -50,3 +50,39 @@ do_execsql_test lower-char {
 do_execsql_test lower-null {
   select lower(null)
 } {}
+
+do_execsql_test trim {
+  SELECT trim('   Limbo    ');
+} {Limbo}
+
+do_execsql_test trim-number {
+  SELECT trim(1);
+} {1}
+
+do_execsql_test trim-null {
+  SELECT trim(null);
+} {}
+
+do_execsql_test trim-leading-whitespace {
+  SELECT trim('   Leading');
+} {Leading}
+
+do_execsql_test trim-trailing-whitespace {
+  SELECT trim('Trailing   ');
+} {Trailing}
+
+do_execsql_test trim-pattern {
+  SELECT trim('Limbo', 'Limbo');
+} {}
+
+do_execsql_test trim-pattern-number {
+  SELECT trim(1, '1');
+} {}
+
+do_execsql_test trim-pattern-null {
+  SELECT trim(null, 'null');
+} {}
+
+do_execsql_test trim-no-match-pattern {
+  SELECT trim('Limbo', 'xyz');
+} {Limbo}


### PR DESCRIPTION
This is related to the issue https://github.com/penberg/limbo/issues/144. Add the scalar function `trim(X)` and `trim(X,Y)`