### PR TITLE
implementation of scalar function `round(X)` and `round(X,Y)`

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -93,8 +93,8 @@ This document describes the SQLite compatibility status of Limbo:
 | random()                     | Yes     |         |
 | randomblob(N)                | No     |         |
 | replace(X,Y,Z)               | No     |         |
-| round(X)                     | No     |         |
-| round(X,Y)                   | No     |         |
+| round(X)                     | Yes     |         |
+| round(X,Y)                   | Yes     |         |
 | rtrim(X)                     | No     |         |
 | rtrim(X,Y)                   | No     |         |
 | sign(X)                      | No     |         |

--- a/core/expr.rs
+++ b/core/expr.rs
@@ -405,6 +405,43 @@ pub fn translate_expr(
                             }
                             Ok(target_register)
                         }
+                        SingleRowFunc::Round => {
+                            let args = if let Some(args) = args {
+                                if args.len() > 2 {
+                                    anyhow::bail!(
+                                        "Parse error: round function with more than 2 arguments"
+                                    );
+                                }
+                                args
+                            } else {
+                                anyhow::bail!("Parse error: round function with no arguments");
+                            };
+
+                            if args.len() == 1 {
+                                let regs = program.alloc_register();
+                                let _ = translate_expr(program, select, &args[0], regs)?;
+                                program.emit_insn(Insn::Function {
+                                    start_reg: regs,
+                                    dest: target_register,
+                                    func: SingleRowFunc::Round,
+                                });
+                            } else {
+                                for arg in args {
+                                    let reg = program.alloc_register();
+                                    let _ = translate_expr(program, select, arg, reg)?;
+                                    match arg {
+                                        ast::Expr::Literal(_) => program.mark_last_insn_constant(),
+                                        _ => {}
+                                    }
+                                }
+                                program.emit_insn(Insn::Function {
+                                    start_reg: target_register + 1,
+                                    dest: target_register,
+                                    func: SingleRowFunc::Round,
+                                });
+                            }
+                            Ok(target_register)
+                        }
                     }
                 }
                 None => {

--- a/core/function.rs
+++ b/core/function.rs
@@ -36,6 +36,7 @@ pub enum SingleRowFunc {
     Lower,
     Random,
     Trim,
+    Round,
 }
 
 impl ToString for SingleRowFunc {
@@ -48,6 +49,7 @@ impl ToString for SingleRowFunc {
             SingleRowFunc::Lower => "lower".to_string(),
             SingleRowFunc::Random => "random".to_string(),
             SingleRowFunc::Trim => "trim".to_string(),
+            SingleRowFunc::Round => "round".to_string(),
         }
     }
 }
@@ -77,6 +79,7 @@ impl FromStr for Func {
             "lower" => Ok(Func::SingleRow(SingleRowFunc::Lower)),
             "random" => Ok(Func::SingleRow(SingleRowFunc::Random)),
             "trim" => Ok(Func::SingleRow(SingleRowFunc::Trim)),
+            "round" => Ok(Func::SingleRow(SingleRowFunc::Round)),
             _ => Err(()),
         }
     }

--- a/sqlite3/tests/Makefile
+++ b/sqlite3/tests/Makefile
@@ -13,6 +13,7 @@ PROGRAM = sqlite3-tests
 CFLAGS = -g -Wall -std=c17 -MMD -MP
 
 LIBS ?= -lsqlite3
+LIBS += -lm
 
 OBJS += main.o
 OBJS += test-aux.o

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -86,3 +86,39 @@ do_execsql_test trim-pattern-null {
 do_execsql_test trim-no-match-pattern {
   SELECT trim('Limbo', 'xyz');
 } {Limbo}
+
+do_execsql_test round-float-no-precision {
+  SELECT round(123.456);
+} {123.0}
+
+do_execsql_test round-float-with-precision {
+  SELECT round(123.456, 2);
+} {123.46}
+
+do_execsql_test round-float-with-text-precision {
+  SELECT round(123.5, '1');
+} {123.5}
+
+do_execsql_test round-text-parsable {
+  SELECT round('123.456', 2);
+} {123.46}
+
+do_execsql_test round-text-non-parsable {
+  SELECT round('abc', 1);
+} {0.0}
+
+do_execsql_test round-integer-with-precision {
+  SELECT round(123, 1);
+} {123.0}
+
+do_execsql_test round-float-negative-precision {
+  SELECT round(123.456, -1);
+} {123.0}
+
+do_execsql_test round-float-zero-precision {
+  SELECT round(123.456, 0);
+} {123.0}
+
+do_execsql_test round-null-precision {
+  SELECT round(123.456, null);
+} {}


### PR DESCRIPTION
This is related to the issue https://github.com/penberg/limbo/issues/144. Add the scalar function `round(X)` and `round(X,Y)`