### PR TITLE
Add implementations of sqlite3 error codes and messages for compatibility with CPython

### DIFF
--- a/sqlite3/include/sqlite3.h
+++ b/sqlite3/include/sqlite3.h
@@ -7,7 +7,11 @@
 
 #define SQLITE_ERROR 1
 
+#define SQLITE_ABORT 4
+
 #define SQLITE_BUSY 5
+
+#define SQLITE_NOMEM 7
 
 #define SQLITE_NOTFOUND 14
 
@@ -16,6 +20,14 @@
 #define SQLITE_ROW 100
 
 #define SQLITE_DONE 101
+
+#define SQLITE_ABORT_ROLLBACK (SQLITE_ABORT | (2 << 8))
+
+#define SQLITE_STATE_OPEN 118
+
+#define SQLITE_STATE_SICK 186
+
+#define SQLITE_STATE_BUSY 109
 
 typedef struct sqlite3 sqlite3;
 

--- a/sqlite3/src/util.rs
+++ b/sqlite3/src/util.rs
@@ -1,0 +1,13 @@
+use crate::sqlite3;
+
+pub fn sqlite3_safety_check_sick_or_ok(_db: &sqlite3) -> bool {
+    match _db.e_open_state {
+        crate::SQLITE_STATE_SICK | crate::SQLITE_STATE_OPEN | crate::SQLITE_STATE_BUSY => {
+            true
+        }
+        _ => {
+            eprintln!("Invalid database state: {}", _db.e_open_state);
+            false
+        }
+    }
+}


### PR DESCRIPTION
Did up an attempt at the first few implementations required for [this issue](https://github.com/penberg/limbo/issues/128). Let me know if there's anything I can improve on/rework to be cleaner!

Referenced [this file](https://github.com/sqlite/sqlite/blob/master/src/main.c) when doing up this attempt, not entirely sure if `sqlite3_mutex_enter` and `sqlite3_mutex_leave` should be included at this point.


The error faced currently when backtrace is switched on should now be attributed to `sqlite3_busy_timeout` not being implemented, rather than `sqlite3_errcode`:
<img width="819" alt="image" src="https://github.com/user-attachments/assets/cffbe091-7a88-49d6-af91-f3ceb66e8c3d">

Thanks!