### PR TITLE
implementation of scalar function `length(X)`

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -37,6 +37,7 @@ pub enum SingleRowFunc {
     Random,
     Trim,
     Round,
+    Length,
 }
 
 impl ToString for SingleRowFunc {
@@ -50,6 +51,7 @@ impl ToString for SingleRowFunc {
             SingleRowFunc::Random => "random".to_string(),
             SingleRowFunc::Trim => "trim".to_string(),
             SingleRowFunc::Round => "round".to_string(),
+            SingleRowFunc::Length => "length".to_string(),
         }
     }
 }
@@ -80,6 +82,7 @@ impl FromStr for Func {
             "random" => Ok(Func::SingleRow(SingleRowFunc::Random)),
             "trim" => Ok(Func::SingleRow(SingleRowFunc::Trim)),
             "round" => Ok(Func::SingleRow(SingleRowFunc::Round)),
+            "length" => Ok(Func::SingleRow(SingleRowFunc::Length)),
             _ => Err(()),
         }
     }

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -122,3 +122,23 @@ do_execsql_test round-float-zero-precision {
 do_execsql_test round-null-precision {
   SELECT round(123.456, null);
 } {}
+
+do_execsql_test length-text {
+  SELECT length('limbo');
+} {5}
+
+do_execsql_test length-integer {
+  SELECT length(12345);
+} {5}
+
+do_execsql_test length-float {
+  SELECT length(123.456);
+} {7}
+
+do_execsql_test length-null {
+  SELECT length(NULL);
+} {}
+
+do_execsql_test length-empty-text {
+  SELECT length('');
+} {0}


### PR DESCRIPTION
Refactor the match `SingleRowFunc ` and add the scalar function `length(X)` (related to the issue https://github.com/penberg/limbo/issues/144)