### PR TITLE
perf-latency: Fixes to enable building perf/latency 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "core",
   "simulator",
 ]
+exclude = ["perf/latency/limbo"]
 
 [workspace.package]
 version = "0.0.1"

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use std::rc::Rc;
+use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -11,7 +12,7 @@ pub struct Database {
 impl Database {
     #[wasm_bindgen(constructor)]
     pub fn new(_path: &str) -> Database {
-        let io = Rc::new(IO {});
+        let io = Arc::new(IO {});
         let page_source = limbo_core::PageSource::from_io(Rc::new(PageIO {}));
         let inner = limbo_core::Database::open(io, page_source).unwrap();
         Database { _inner: inner }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -5,7 +5,9 @@ use cli_table::{Cell, Table};
 use limbo_core::{Database, RowResult, Value};
 use opcodes_dictionary::OPCODE_DESCRIPTIONS;
 use rustyline::{error::ReadlineError, DefaultEditor};
-use std::{path::PathBuf, rc::Rc};
+use std::path::PathBuf;
+use std::sync::Arc;
+
 
 #[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
 enum OutputMode {
@@ -35,7 +37,7 @@ fn main() -> anyhow::Result<()> {
     env_logger::init();
     let opts = Opts::parse();
     let path = opts.database.to_str().unwrap();
-    let io = Rc::new(limbo_core::PlatformIO::new()?);
+    let io = Arc::new(limbo_core::PlatformIO::new()?);
     let db = Database::open_file(io.clone(), path)?;
     let conn = db.connect();
     if let Some(sql) = opts.sql {
@@ -108,7 +110,7 @@ Note:
 }
 
 fn handle_dot_command(
-    io: Rc<dyn limbo_core::IO>,
+    io: Arc<dyn limbo_core::IO>,
     conn: &limbo_core::Connection,
     line: &str,
 ) -> anyhow::Result<()> {
@@ -153,7 +155,7 @@ fn handle_dot_command(
 }
 
 fn display_schema(
-    io: Rc<dyn limbo_core::IO>,
+    io: Arc<dyn limbo_core::IO>,
     conn: &limbo_core::Connection,
     table: Option<&str>,
 ) -> anyhow::Result<()> {
@@ -208,7 +210,7 @@ fn display_schema(
 }
 
 fn query(
-    io: Rc<dyn limbo_core::IO>,
+    io: Arc<dyn limbo_core::IO>,
     conn: &limbo_core::Connection,
     sql: &str,
     output_mode: &OutputMode,

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -8,7 +8,6 @@ use rustyline::{error::ReadlineError, DefaultEditor};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-
 #[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
 enum OutputMode {
     Raw,

--- a/core/btree.rs
+++ b/core/btree.rs
@@ -101,7 +101,7 @@ impl BTreeCursor {
                 BTreeCell::TableLeafCell(TableLeafCell {
                     _rowid,
                     _payload,
-                    first_overflow_page,
+                    first_overflow_page: _,
                 }) => {
                     mem_page.advance();
                     let record = crate::sqlite3_ondisk::read_record(_payload)?;

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -27,6 +27,7 @@ use schema::Schema;
 use sqlite3_ondisk::DatabaseHeader;
 use sqlite3_parser::{ast::Cmd, lexer::sql::Parser};
 use std::{cell::RefCell, rc::Rc};
+use std::sync::Arc;
 
 #[cfg(feature = "fs")]
 pub use io::PlatformIO;
@@ -42,13 +43,13 @@ pub struct Database {
 
 impl Database {
     #[cfg(feature = "fs")]
-    pub fn open_file(io: Rc<dyn crate::io::IO>, path: &str) -> Result<Database> {
+    pub fn open_file(io: Arc<dyn crate::io::IO>, path: &str) -> Result<Database> {
         let file = io.open_file(path)?;
         let storage = storage::PageSource::from_file(file);
         Self::open(io, storage)
     }
 
-    pub fn open(io: Rc<dyn crate::io::IO>, page_source: PageSource) -> Result<Database> {
+    pub fn open(io: Arc<dyn crate::io::IO>, page_source: PageSource) -> Result<Database> {
         let db_header = Pager::begin_open(&page_source)?;
         io.run_once()?;
         let pager = Rc::new(Pager::finish_open(

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -26,8 +26,8 @@ use pager::Pager;
 use schema::Schema;
 use sqlite3_ondisk::DatabaseHeader;
 use sqlite3_parser::{ast::Cmd, lexer::sql::Parser};
-use std::{cell::RefCell, rc::Rc};
 use std::sync::Arc;
+use std::{cell::RefCell, rc::Rc};
 
 #[cfg(feature = "fs")]
 pub use io::PlatformIO;

--- a/core/pager.rs
+++ b/core/pager.rs
@@ -8,7 +8,7 @@ use std::cell::RefCell;
 use std::hash::Hash;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 pub struct Page {
     flags: AtomicUsize,
@@ -102,7 +102,7 @@ pub struct Pager {
     pub page_source: PageSource,
     page_cache: RefCell<PageCache<usize, Rc<Page>>>,
     buffer_pool: Rc<BufferPool>,
-    pub io: Rc<dyn crate::io::IO>,
+    pub io: Arc<dyn crate::io::IO>,
 }
 
 impl Pager {
@@ -113,7 +113,7 @@ impl Pager {
     pub fn finish_open(
         db_header: Rc<RefCell<DatabaseHeader>>,
         page_source: PageSource,
-        io: Rc<dyn crate::io::IO>,
+        io: Arc<dyn crate::io::IO>,
     ) -> anyhow::Result<Self> {
         let db_header = db_header.borrow();
         let page_size = db_header.page_size as usize;

--- a/core/vdbe.rs
+++ b/core/vdbe.rs
@@ -439,7 +439,7 @@ impl ProgramBuilder {
                 Insn::If {
                     reg: _reg,
                     target_pc,
-                    null_reg,
+                    null_reg: _,
                 } => {
                     assert!(*target_pc < 0);
                     *target_pc = to_offset;
@@ -447,7 +447,7 @@ impl ProgramBuilder {
                 Insn::IfNot {
                     reg: _reg,
                     target_pc,
-                    null_reg,
+                    null_reg: _,
                 } => {
                     assert!(*target_pc < 0);
                     *target_pc = to_offset;

--- a/core/where_clause.rs
+++ b/core/where_clause.rs
@@ -416,13 +416,13 @@ fn translate_condition_expr(
             }
             _ => todo!(),
         },
-        ast::Expr::InList { lhs, not, rhs } => {}
+        ast::Expr::InList { lhs: _, not: _, rhs: _ } => {}
         ast::Expr::Like {
             lhs,
             not,
             op,
             rhs,
-            escape,
+            escape: _,
         } => {
             let cur_reg = program.alloc_register();
             assert!(match rhs.as_ref() {
@@ -494,10 +494,10 @@ fn introspect_expression_for_cursors(
         ast::Expr::Literal(_) => {}
         ast::Expr::Like {
             lhs,
-            not,
-            op,
+            not: _,
+            op: _,
             rhs,
-            escape,
+            escape: _,
         } => {
             cursors.extend(introspect_expression_for_cursors(program, select, lhs)?);
             cursors.extend(introspect_expression_for_cursors(program, select, rhs)?);

--- a/core/where_clause.rs
+++ b/core/where_clause.rs
@@ -416,7 +416,11 @@ fn translate_condition_expr(
             }
             _ => todo!(),
         },
-        ast::Expr::InList { lhs: _, not: _, rhs: _ } => {}
+        ast::Expr::InList {
+            lhs: _,
+            not: _,
+            rhs: _,
+        } => {}
         ast::Expr::Like {
             lhs,
             not,

--- a/perf/latency/limbo/Cargo.lock
+++ b/perf/latency/limbo/Cargo.lock
@@ -120,6 +120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +145,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cfg_block"
@@ -193,12 +205,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "concurrent_lru"
-version = "0.2.0"
+name = "concurrent-queue"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7feb5cb312f774e8a24540e27206db4e890f7d488563671d24a16389cf4c2e4e"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
  "once_cell",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -225,6 +257,21 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
 
 [[package]]
 name = "env_filter"
@@ -256,6 +303,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +326,19 @@ checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -298,6 +368,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,10 +400,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.152"
+name = "js-sys"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.155"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -351,17 +436,31 @@ dependencies = [
 
 [[package]]
 name = "limbo_core"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "cfg_block",
- "concurrent_lru",
  "fallible-iterator",
+ "getrandom",
  "io-uring",
+ "libc",
  "log",
  "mimalloc",
+ "nix",
+ "ordered-multimap",
+ "polling",
+ "regex",
+ "rustix",
+ "sieve-cache",
  "sqlite3-parser",
+ "thiserror",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
@@ -400,6 +499,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +534,16 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown",
+]
 
 [[package]]
 name = "phf"
@@ -464,6 +585,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "polling"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,9 +640,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -524,6 +666,25 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "sieve-cache"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bf3a9dccf2c079bf1465d449a485c85b36443caf765f2f127bfec28b180f75"
 
 [[package]]
 name = "siphasher"
@@ -574,6 +735,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +805,66 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "windows-sys"

--- a/perf/latency/limbo/Cargo.toml
+++ b/perf/latency/limbo/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 clap = { version = "4.4.2", features = ["derive"] }
 env_logger = "0.11.0"
 hdrhistogram = "7.5.2"
-limbo_core = { path = "../../../limbo/core" }
+limbo_core = { path = "../../../core" }
 
 [profile.release]
 debug = true

--- a/perf/latency/limbo/src/main.rs
+++ b/perf/latency/limbo/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
                     let mut rows = stmt.query().unwrap();
                     let mut count = 0;
                     loop {
-                        let row = rows.next().unwrap();
+                        let row = rows.next_row().unwrap();
                         match row {
                             limbo_core::RowResult::Row(_) => {
                                 count += 1;

--- a/perf/latency/limbo/src/main.rs
+++ b/perf/latency/limbo/src/main.rs
@@ -1,5 +1,6 @@
 #![feature(coroutines)]
 #![feature(coroutine_trait)]
+#![feature(stmt_expr_attributes)]
 
 use clap::Parser;
 use hdrhistogram::Histogram;
@@ -15,7 +16,7 @@ struct Opts {
 }
 
 fn main() {
-    env_logger::init();;
+    env_logger::init();
     let opts = Opts::parse();
     let mut hist = Histogram::<u64>::new(2).unwrap().into_sync();
     let io = Arc::new(PlatformIO::new().unwrap());
@@ -23,7 +24,7 @@ fn main() {
     for i in 0..opts.count {
         let mut recorder = hist.recorder();
         let io = io.clone();
-        let mut tenant = move || {
+        let tenant =  #[coroutine] move || {
             let database = format!("database{}.db", i);
             let db = Database::open_file(io.clone(), &database).unwrap();
             let conn = db.connect();

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -4,6 +4,7 @@ use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::Arc;
 
 fn main() {
     let seed = match std::env::var("SEED") {
@@ -12,7 +13,7 @@ fn main() {
     };
     println!("Seed: {}", seed);
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
-    let io = Rc::new(SimulatorIO::new().unwrap());
+    let io = Arc::new(SimulatorIO::new().unwrap());
     for _ in 0..100000 {
         let db = match Database::open_file(io.clone(), "./testing/testing.db") {
             Ok(db) => db,

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -43,14 +43,14 @@ pub struct sqlite3 {
 
 impl sqlite3 {
     pub fn new(db: limbo_core::Database, conn: limbo_core::Connection) -> Self {
-        Self { 
-            _db: db, 
-            conn,            
+        Self {
+            _db: db,
+            conn,
             err_code: SQLITE_OK,
             err_mask: 0xFFFFFFFFu32 as i32,
             malloc_failed: false,
             e_open_state: SQLITE_STATE_OPEN,
-            p_err: std::ptr::null_mut(), 
+            p_err: std::ptr::null_mut(),
         }
     }
 }
@@ -373,7 +373,7 @@ pub unsafe extern "C" fn sqlite3_errcode(_db: *mut sqlite3) -> ffi::c_int {
     if _db.is_null() || (*_db).malloc_failed {
         return SQLITE_NOMEM;
     }
-    
+
     (*_db).err_code & (*_db).err_mask
 }
 
@@ -833,7 +833,7 @@ pub unsafe extern "C" fn sqlite3_extended_errcode(_db: *mut sqlite3) -> ffi::c_i
     if _db.is_null() || (*_db).malloc_failed {
         return SQLITE_NOMEM;
     }
-    
+
     (*_db).err_code & (*_db).err_mask
 }
 
@@ -861,38 +861,38 @@ pub unsafe extern "C" fn sqlite3_libversion_number() -> ffi::c_int {
 
 fn sqlite3_errstr_impl(rc: i32) -> *const std::ffi::c_char {
     const ERROR_MESSAGES: [&str; 29] = [
-        "not an error", // SQLITE_OK
-        "SQL logic error", // SQLITE_ERROR
-        "", // SQLITE_INTERNAL
-        "access permission denied", // SQLITE_PERM
-        "query aborted", // SQLITE_ABORT
-        "database is locked", // SQLITE_BUSY
-        "database table is locked", // SQLITE_LOCKED
-        "out of memory", // SQLITE_NOMEM
+        "not an error",                         // SQLITE_OK
+        "SQL logic error",                      // SQLITE_ERROR
+        "",                                     // SQLITE_INTERNAL
+        "access permission denied",             // SQLITE_PERM
+        "query aborted",                        // SQLITE_ABORT
+        "database is locked",                   // SQLITE_BUSY
+        "database table is locked",             // SQLITE_LOCKED
+        "out of memory",                        // SQLITE_NOMEM
         "attempt to write a readonly database", // SQLITE_READONLY
-        "interrupted", // SQLITE_INTERRUPT
-        "disk I/O error", // SQLITE_IOERR
-        "database disk image is malformed", // SQLITE_CORRUPT
-        "unknown operation", // SQLITE_NOTFOUND
-        "database or disk is full", // SQLITE_FULL
-        "unable to open database file", // SQLITE_CANTOPEN
-        "locking protocol", // SQLITE_PROTOCOL
-        "", // SQLITE_EMPTY
-        "database schema has changed", // SQLITE_SCHEMA
-        "string or blob too big", // SQLITE_TOOBIG
-        "constraint failed", // SQLITE_CONSTRAINT
-        "datatype mismatch", // SQLITE_MISMATCH
-        "bad parameter or other API misuse", // SQLITE_MISUSE
+        "interrupted",                          // SQLITE_INTERRUPT
+        "disk I/O error",                       // SQLITE_IOERR
+        "database disk image is malformed",     // SQLITE_CORRUPT
+        "unknown operation",                    // SQLITE_NOTFOUND
+        "database or disk is full",             // SQLITE_FULL
+        "unable to open database file",         // SQLITE_CANTOPEN
+        "locking protocol",                     // SQLITE_PROTOCOL
+        "",                                     // SQLITE_EMPTY
+        "database schema has changed",          // SQLITE_SCHEMA
+        "string or blob too big",               // SQLITE_TOOBIG
+        "constraint failed",                    // SQLITE_CONSTRAINT
+        "datatype mismatch",                    // SQLITE_MISMATCH
+        "bad parameter or other API misuse",    // SQLITE_MISUSE
         #[cfg(not(feature = "SQLITE_DISABLE_LFS"))]
         "", // SQLITE_NOLFS
         #[cfg(feature = "SQLITE_DISABLE_LFS")]
         "large file support is disabled", // SQLITE_NOLFS
-        "authorization denied", // SQLITE_AUTH
-        "", // SQLITE_FORMAT
-        "column index out of range", // SQLITE_RANGE
-        "file is not a database", // SQLITE_NOTADB
-        "notification message", // SQLITE_NOTICE
-        "warning message", // SQLITE_WARNING
+        "authorization denied",                 // SQLITE_AUTH
+        "",                                     // SQLITE_FORMAT
+        "column index out of range",            // SQLITE_RANGE
+        "file is not a database",               // SQLITE_NOTADB
+        "notification message",                 // SQLITE_NOTICE
+        "warning message",                      // SQLITE_WARNING
     ];
 
     const UNKNOWN_ERROR: &str = "unknown error";
@@ -906,7 +906,10 @@ fn sqlite3_errstr_impl(rc: i32) -> *const std::ffi::c_char {
         SQLITE_DONE => NO_MORE_ROWS_AVAILABLE.as_ptr() as *const std::ffi::c_char,
         _ => {
             let rc = rc & 0xff;
-            if rc >= 0 && rc < ERROR_MESSAGES.len() as i32 && !ERROR_MESSAGES[rc as usize].is_empty() {
+            if rc >= 0
+                && rc < ERROR_MESSAGES.len() as i32
+                && !ERROR_MESSAGES[rc as usize].is_empty()
+            {
                 ERROR_MESSAGES[rc as usize].as_ptr() as *const std::ffi::c_char
             } else {
                 UNKNOWN_ERROR.as_ptr() as *const std::ffi::c_char

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -4,7 +4,8 @@
 use log::trace;
 use std::cell::RefCell;
 use std::ffi;
-use std::rc::Rc;
+
+use std::sync::Arc;
 
 macro_rules! stub {
     () => {
@@ -103,7 +104,7 @@ pub unsafe extern "C" fn sqlite3_open(
         Err(_) => return SQLITE_MISUSE,
     };
     let io = match limbo_core::PlatformIO::new() {
-        Ok(io) => Rc::new(io),
+        Ok(io) => Arc::new(io),
         Err(_) => return SQLITE_MISUSE,
     };
     match limbo_core::Database::open_file(io, filename) {

--- a/sqlite3/src/util.rs
+++ b/sqlite3/src/util.rs
@@ -2,9 +2,7 @@ use crate::sqlite3;
 
 pub fn sqlite3_safety_check_sick_or_ok(_db: &sqlite3) -> bool {
     match _db.e_open_state {
-        crate::SQLITE_STATE_SICK | crate::SQLITE_STATE_OPEN | crate::SQLITE_STATE_BUSY => {
-            true
-        }
+        crate::SQLITE_STATE_SICK | crate::SQLITE_STATE_OPEN | crate::SQLITE_STATE_BUSY => true,
         _ => {
             eprintln!("Invalid database state: {}", _db.e_open_state);
             false


### PR DESCRIPTION
In my aim to see how the `perf/latency` works,  I encountered some issues when compiling it, here I have a fix to allow compilation.

However, I miss the instructions to run it.

Is it expected for a user to `create N database files` names in a specific manner?