### PR TITLE
implement min max scalar function

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AggFunc {
@@ -54,8 +53,8 @@ impl ToString for SingleRowFunc {
             SingleRowFunc::Trim => "trim".to_string(),
             SingleRowFunc::Round => "round".to_string(),
             SingleRowFunc::Length => "length".to_string(),
-            SingleRowFunc::Min => "min_arr".to_string(),
-            SingleRowFunc::Max => "max_arr".to_string(),
+            SingleRowFunc::Min => "min".to_string(),
+            SingleRowFunc::Max => "max".to_string(),
         }
     }
 }
@@ -66,16 +65,17 @@ pub enum Func {
     SingleRow(SingleRowFunc),
 }
 
-impl FromStr for Func {
-    type Err = ();
+impl Func{
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
+    pub fn resolve_function(name: &str, arg_count:usize) -> Result<Func, ()>{
+        match name {
             "avg" => Ok(Func::Agg(AggFunc::Avg)),
             "count" => Ok(Func::Agg(AggFunc::Count)),
             "group_concat" => Ok(Func::Agg(AggFunc::GroupConcat)),
-            "max" => Ok(Func::Agg(AggFunc::Max)),
-            "min" => Ok(Func::Agg(AggFunc::Min)),
+            "max"  if arg_count == 0 || arg_count == 1 => Ok(Func::Agg(AggFunc::Max)),
+            "max" if arg_count > 1 => Ok(Func::SingleRow(SingleRowFunc::Max)),
+            "min" if arg_count == 0 || arg_count == 1 => Ok(Func::Agg(AggFunc::Min)),
+            "min" if arg_count > 1 => Ok(Func::SingleRow(SingleRowFunc::Min)),
             "string_agg" => Ok(Func::Agg(AggFunc::StringAgg)),
             "sum" => Ok(Func::Agg(AggFunc::Sum)),
             "total" => Ok(Func::Agg(AggFunc::Total)),
@@ -88,8 +88,6 @@ impl FromStr for Func {
             "trim" => Ok(Func::SingleRow(SingleRowFunc::Trim)),
             "round" => Ok(Func::SingleRow(SingleRowFunc::Round)),
             "length" => Ok(Func::SingleRow(SingleRowFunc::Length)),
-            "min_arr" => Ok(Func::SingleRow(SingleRowFunc::Min)),
-            "max_arr" => Ok(Func::SingleRow(SingleRowFunc::Max)),
             _ => Err(()),
         }
     }

--- a/core/function.rs
+++ b/core/function.rs
@@ -38,6 +38,8 @@ pub enum SingleRowFunc {
     Trim,
     Round,
     Length,
+    Min,
+    Max,
 }
 
 impl ToString for SingleRowFunc {
@@ -52,6 +54,8 @@ impl ToString for SingleRowFunc {
             SingleRowFunc::Trim => "trim".to_string(),
             SingleRowFunc::Round => "round".to_string(),
             SingleRowFunc::Length => "length".to_string(),
+            SingleRowFunc::Min => "min_arr".to_string(),
+            SingleRowFunc::Max => "max_arr".to_string(),
         }
     }
 }
@@ -84,6 +88,8 @@ impl FromStr for Func {
             "trim" => Ok(Func::SingleRow(SingleRowFunc::Trim)),
             "round" => Ok(Func::SingleRow(SingleRowFunc::Round)),
             "length" => Ok(Func::SingleRow(SingleRowFunc::Length)),
+            "min_arr" => Ok(Func::SingleRow(SingleRowFunc::Min)),
+            "max_arr" => Ok(Func::SingleRow(SingleRowFunc::Max)),
             _ => Err(()),
         }
     }

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -390,7 +390,7 @@ pub fn translate_expr(
                             };
                             for arg in args {
                                 let reg = program.alloc_register();
-                                let _ = translate_expr(program, select, arg, reg)?;
+                                let _ = translate_expr(program, select, arg, reg, cursor_hint)?;
                                 match arg {
                                     ast::Expr::Literal(_) => program.mark_last_insn_constant(),
                                     _ => {}
@@ -417,7 +417,7 @@ pub fn translate_expr(
                             };
                             for arg in args {
                                 let reg = program.alloc_register();
-                                let _ = translate_expr(program, select, arg, reg)?;
+                                let _ = translate_expr(program, select, arg, reg, cursor_hint)?;
                                 match arg {
                                     ast::Expr::Literal(_) => program.mark_last_insn_constant(),
                                     _ => {}

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -225,7 +225,8 @@ pub fn translate_expr(
             args,
             filter_over: _,
         } => {
-            let func_type: Option<Func> = normalize_ident(name.0.as_str()).as_str().parse().ok();
+            let args_count = if let Some(args) = args { args.len() } else { 0 };
+            let func_type: Option<Func> = Func::resolve_function(normalize_ident(name.0.as_str()).as_str(),args_count).ok();
 
             match func_type {
                 Some(Func::Agg(_)) => {
@@ -585,7 +586,8 @@ pub fn analyze_expr<'a>(expr: &'a Expr, column_info_out: &mut ColumnInfo<'a>) {
             args,
             filter_over: _,
         } => {
-            let func_type = match normalize_ident(name.0.as_str()).as_str().parse() {
+            let args_count = if let Some(args) = args { args.len() } else { 0 };
+            let func_type = match Func::resolve_function(normalize_ident(name.0.as_str()).as_str(),args_count) {
                 Ok(func) => Some(func),
                 Err(_) => None,
             };

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -377,6 +377,60 @@ pub fn translate_expr(
                             });
                             Ok(target_register)
                         }
+                        SingleRowFunc::Min => {
+                            let args = if let Some(args) = args {
+                                if args.len() < 1 {
+                                    anyhow::bail!(
+                                        "Parse error: min function with less than one argument"
+                                    );
+                                }
+                                args
+                            } else {
+                                anyhow::bail!("Parse error: min function with no arguments");
+                            };
+                            for arg in args {
+                                let reg = program.alloc_register();
+                                let _ = translate_expr(program, select, arg, reg)?;
+                                match arg {
+                                    ast::Expr::Literal(_) => program.mark_last_insn_constant(),
+                                    _ => {}
+                                }
+                            }
+
+                            program.emit_insn(Insn::Function {
+                                start_reg: target_register + 1,
+                                dest: target_register,
+                                func: SingleRowFunc::Min,
+                            });
+                            Ok(target_register)
+                        }
+                        SingleRowFunc::Max => {
+                            let args = if let Some(args) = args {
+                                if args.len() < 1 {
+                                    anyhow::bail!(
+                                        "Parse error: max function with less than one argument"
+                                    );
+                                }
+                                args
+                            } else {
+                                anyhow::bail!("Parse error: max function with no arguments");
+                            };
+                            for arg in args {
+                                let reg = program.alloc_register();
+                                let _ = translate_expr(program, select, arg, reg)?;
+                                match arg {
+                                    ast::Expr::Literal(_) => program.mark_last_insn_constant(),
+                                    _ => {}
+                                }
+                            }
+
+                            program.emit_insn(Insn::Function {
+                                start_reg: target_register + 1,
+                                dest: target_register,
+                                func: SingleRowFunc::Max,
+                            });
+                            Ok(target_register)
+                        }
                     }
                 }
                 None => {

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -143,25 +143,25 @@ do_execsql_test length-empty-text {
   SELECT length('');
 } {0}
 do_execsql_test min-number {
-  select min_arr(-10,2,3)
+  select min(-10,2,3)
 } {-10}
 
 do_execsql_test min-str {
-  select min_arr('b','a','z')
+  select min('b','a','z')
 } {a}
 
 do_execsql_test min-null {
-  select min_arr(null,null)
+  select min(null,null)
 } {}
 
 do_execsql_test max-number {
-  select max_arr(-10,2,3)
+  select max(-10,2,3)
 } {3}
 
 do_execsql_test max-str {
-  select max_arr('b','a','z')
+  select max('b','a','z')
 } {z}
 
 do_execsql_test max-null {
-  select max_arr(null,null)
+  select max(null,null)
 } {}

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -142,3 +142,26 @@ do_execsql_test length-null {
 do_execsql_test length-empty-text {
   SELECT length('');
 } {0}
+do_execsql_test min-number {
+  select min_arr(-10,2,3)
+} {-10}
+
+do_execsql_test min-str {
+  select min_arr('b','a','z')
+} {a}
+
+do_execsql_test min-null {
+  select min_arr(null,null)
+} {}
+
+do_execsql_test max-number {
+  select max_arr(-10,2,3)
+} {3}
+
+do_execsql_test max-str {
+  select max_arr('b','a','z')
+} {z}
+
+do_execsql_test max-null {
+  select max_arr(null,null)
+} {}


### PR DESCRIPTION
This is related to issue #144.  Currently the name of the scalar functions min and max are conflicting with the aggregated functions min and max. I am using min_arr and max_arr instead and wanted to get your input on what we can do to keep both with the same name. What comes to my mind is adding conditional logic inside AggFunc::Min/Max. 