### PR TITLE
Refactor join processing / support multiway joins

### DIFF
--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -10,15 +10,15 @@ use crate::pager::Pager;
 use crate::schema::{Column, PseudoTable, Schema, Table};
 use crate::sqlite3_ondisk::{DatabaseHeader, MIN_PAGE_CACHE_SIZE};
 use crate::translate::select::{ColumnInfo, LoopInfo, Select, SrcTable};
-use crate::translate::where_clause::{
-    evaluate_conditions, translate_conditions, translate_where, Inner, Left, QueryConstraint,
-};
+use crate::translate::where_clause::{translate_processed_where, translate_where};
 use crate::types::{OwnedRecord, OwnedValue};
 use crate::util::normalize_ident;
 use crate::vdbe::{BranchOffset, Insn, Program, builder::ProgramBuilder};
 use anyhow::Result;
 use expr::{build_select, maybe_apply_affinity, translate_expr};
+use select::LeftJoinBookkeeping;
 use sqlite3_parser::ast::{self, Literal};
+use where_clause::{process_where, ProcessedWhereClause};
 
 struct LimitInfo {
     limit_reg: usize,
@@ -114,7 +114,7 @@ fn translate_select(mut select: Select) -> Result<Program> {
     };
 
     if !select.src_tables.is_empty() {
-        let constraint = translate_tables_begin(&mut program, &mut select)?;
+        translate_tables_begin(&mut program, &mut select)?;
 
         let (register_start, column_count) = if let Some(sort_columns) = select.order_by {
             let start = program.next_free_register();
@@ -153,7 +153,7 @@ fn translate_select(mut select: Select) -> Result<Program> {
             }
         }
 
-        translate_tables_end(&mut program, &select, constraint);
+        translate_tables_end(&mut program, &select);
 
         if select.exist_aggregation {
             let mut target = register_start;
@@ -283,7 +283,7 @@ fn translate_sorter(
         start_reg: register_start,
         count,
     });
-    emit_limit_insn(&limit_info, program);
+    emit_limit_insn(limit_info, program);
     program.emit_insn(Insn::SorterNext {
         cursor_id: sort_info.sorter_cursor,
         pc_if_next: sorter_data_offset,
@@ -292,145 +292,44 @@ fn translate_sorter(
     Ok(())
 }
 
-fn translate_tables_begin(
-    program: &mut ProgramBuilder,
-    select: &mut Select,
-) -> Result<Option<QueryConstraint>> {
+fn translate_tables_begin(program: &mut ProgramBuilder, select: &mut Select) -> Result<()> {
     for join in &select.src_tables {
         let loop_info = translate_table_open_cursor(program, join);
         select.loops.push(loop_info);
     }
 
-    let conditions = evaluate_conditions(program, select, None)?;
+    let processed_where = process_where(program, select)?;
 
-    for loop_info in &mut select.loops {
-        let mut left_join_match_flag_maybe = None;
-        if let Some(QueryConstraint::Left(Left {
-            match_flag,
-            right_cursor,
-            ..
-        })) = conditions.as_ref()
-        {
-            if loop_info.open_cursor == *right_cursor {
-                left_join_match_flag_maybe = Some(*match_flag);
-            }
-        }
-        translate_table_open_loop(program, loop_info, left_join_match_flag_maybe);
+    for loop_info in &select.loops {
+        translate_table_open_loop(program, select, loop_info, &processed_where)?;
     }
 
-    translate_conditions(program, select, conditions, None)
+    Ok(())
 }
 
-fn handle_skip_row(
-    program: &mut ProgramBuilder,
-    cursor_id: usize,
-    next_row_instruction_offset: BranchOffset,
-    constraint: &Option<QueryConstraint>,
-) {
-    match constraint {
-        Some(QueryConstraint::Left(Left {
-            where_clause,
-            join_clause,
-            match_flag,
-            match_flag_hit_marker,
-            found_match_next_row_label,
-            left_cursor,
-            right_cursor,
-            ..
-        })) => {
-            if let Some(where_clause) = where_clause {
-                if where_clause.no_match_target_cursor == cursor_id {
-                    program.resolve_label(
-                        where_clause.no_match_jump_label,
-                        next_row_instruction_offset,
-                    );
-                }
-            }
-            if let Some(join_clause) = join_clause {
-                if join_clause.no_match_target_cursor == cursor_id {
-                    program.resolve_label(
-                        join_clause.no_match_jump_label,
-                        next_row_instruction_offset,
-                    );
-                }
-            }
-            if cursor_id == *right_cursor {
-                // If the left join match flag has been set to 1, we jump to the next row (result row has been emitted already)
-                program.emit_insn_with_label_dependency(
-                    Insn::IfPos {
-                        reg: *match_flag,
-                        target_pc: *found_match_next_row_label,
-                        decrement_by: 0,
-                    },
-                    *found_match_next_row_label,
-                );
-                // If not, we set the right table cursor's "pseudo null bit" on, which means any Insn::Column will return NULL
-                program.emit_insn(Insn::NullRow {
-                    cursor_id: *right_cursor,
-                });
-                // Jump to setting the left join match flag to 1 again, but this time the right table cursor will set everything to null
-                program.emit_insn_with_label_dependency(
-                    Insn::Goto {
-                        target_pc: *match_flag_hit_marker,
-                    },
-                    *match_flag_hit_marker,
-                );
-            }
-            if cursor_id == *left_cursor {
-                program.resolve_label(*found_match_next_row_label, next_row_instruction_offset);
-            }
-        }
-        Some(QueryConstraint::Inner(Inner {
-            where_clause,
-            join_clause,
-            ..
-        })) => {
-            if let Some(join_clause) = join_clause {
-                if cursor_id == join_clause.no_match_target_cursor {
-                    program.resolve_label(
-                        join_clause.no_match_jump_label,
-                        next_row_instruction_offset,
-                    );
-                }
-            }
-            if let Some(where_clause) = where_clause {
-                if cursor_id == where_clause.no_match_target_cursor {
-                    program.resolve_label(
-                        where_clause.no_match_jump_label,
-                        next_row_instruction_offset,
-                    );
-                }
-            }
-        }
-        None => {}
-    }
-}
-
-fn translate_tables_end(
-    program: &mut ProgramBuilder,
-    select: &Select,
-    constraint: Option<QueryConstraint>,
-) {
+fn translate_tables_end(program: &mut ProgramBuilder, select: &Select) {
     // iterate in reverse order as we open cursors in order
     for table_loop in select.loops.iter().rev() {
         let cursor_id = table_loop.open_cursor;
-        let next_row_instruction_offset = program.offset();
+        program.resolve_label(table_loop.next_row_label, program.offset());
         program.emit_insn(Insn::NextAsync { cursor_id });
-        program.emit_insn(Insn::NextAwait {
-            cursor_id,
-            pc_if_next: table_loop.rewind_offset as BranchOffset,
-        });
-        program.resolve_label(table_loop.rewind_label, program.offset());
-        handle_skip_row(program, cursor_id, next_row_instruction_offset, &constraint);
+        program.emit_insn_with_label_dependency(
+            Insn::NextAwait {
+                cursor_id,
+                pc_if_next: table_loop.rewind_label,
+            },
+            table_loop.rewind_label,
+        );
+
+        if let Some(ljbk) = &table_loop.left_join_bookkeeping {
+            left_join_match_flag_check(program, ljbk, cursor_id);
+        }
     }
 }
 
 fn translate_table_open_cursor(program: &mut ProgramBuilder, table: &SrcTable) -> LoopInfo {
-    let table_identifier = normalize_ident(match table.alias {
-        Some(alias) => alias,
-        None => &table.table.get_name(),
-    });
-    let cursor_id = program.alloc_cursor_id(Some(table_identifier), Some(table.table.clone()));
+    let cursor_id =
+        program.alloc_cursor_id(Some(table.identifier.clone()), Some(table.table.clone()));
     let root_page = match &table.table {
         Table::BTree(btree) => btree.root_page,
         Table::Pseudo(_) => todo!(),
@@ -441,37 +340,109 @@ fn translate_table_open_cursor(program: &mut ProgramBuilder, table: &SrcTable) -
     });
     program.emit_insn(Insn::OpenReadAwait);
     LoopInfo {
+        identifier: table.identifier.clone(),
+        left_join_bookkeeping: if table.is_outer_join() {
+            Some(LeftJoinBookkeeping {
+                match_flag_register: program.alloc_register(),
+                on_match_jump_to_label: program.allocate_label(),
+                set_match_flag_true_label: program.allocate_label(),
+            })
+        } else {
+            None
+        },
         open_cursor: cursor_id,
-        rewind_offset: 0,
-        rewind_label: 0,
+        next_row_label: program.allocate_label(),
+        rewind_label: program.allocate_label(),
+        rewind_on_empty_label: program.allocate_label(),
     }
+}
+
+/**
+* initialize left join match flag to false
+* if condition checks pass, it will eventually be set to true
+*/
+fn left_join_match_flag_initialize(program: &mut ProgramBuilder, ljbk: &LeftJoinBookkeeping) {
+    program.emit_insn(Insn::Integer {
+        value: 0,
+        dest: ljbk.match_flag_register,
+    });
+}
+
+/**
+* after the relevant conditional jumps have been emitted, set the left join match flag to true
+*/
+fn left_join_match_flag_set_true(program: &mut ProgramBuilder, ljbk: &LeftJoinBookkeeping) {
+    program.defer_label_resolution(ljbk.set_match_flag_true_label, program.offset() as usize);
+    program.emit_insn(Insn::Integer {
+        value: 1,
+        dest: ljbk.match_flag_register,
+    });
+}
+
+/**
+* check if the left join match flag is set to true
+* if it is, jump to the next row on the outer table
+* if not, set the right table cursor's "pseudo null bit" on
+* then jump to setting the left join match flag to true again,
+* which will effectively emit all nulls for the right table.
+*/
+fn left_join_match_flag_check(
+    program: &mut ProgramBuilder,
+    ljbk: &LeftJoinBookkeeping,
+    cursor_id: usize,
+) {
+    // If the left join match flag has been set to 1, we jump to the next row on the outer table (result row has been emitted already)
+    program.emit_insn_with_label_dependency(
+        Insn::IfPos {
+            reg: ljbk.match_flag_register,
+            target_pc: ljbk.on_match_jump_to_label,
+            decrement_by: 0,
+        },
+        ljbk.on_match_jump_to_label,
+    );
+    // If not, we set the right table cursor's "pseudo null bit" on, which means any Insn::Column will return NULL
+    program.emit_insn(Insn::NullRow { cursor_id });
+    // Jump to setting the left join match flag to 1 again, but this time the right table cursor will set everything to null
+    program.emit_insn_with_label_dependency(
+        Insn::Goto {
+            target_pc: ljbk.set_match_flag_true_label,
+        },
+        ljbk.set_match_flag_true_label,
+    );
+    // This points to the NextAsync instruction of the next table in the loop
+    // (i.e. the outer table, since we're iterating in reverse order)
+    program.resolve_label(ljbk.on_match_jump_to_label, program.offset());
 }
 
 fn translate_table_open_loop(
     program: &mut ProgramBuilder,
-    loop_info: &mut LoopInfo,
-    left_join_match_flag_maybe: Option<usize>,
-) {
-    if let Some(match_flag) = left_join_match_flag_maybe {
-        // Initialize left join as not matched
-        program.emit_insn(Insn::Integer {
-            value: 0,
-            dest: match_flag,
-        });
+    select: &Select,
+    loop_info: &LoopInfo,
+    w: &ProcessedWhereClause,
+) -> Result<()> {
+    if let Some(ljbk) = loop_info.left_join_bookkeeping.as_ref() {
+        left_join_match_flag_initialize(program, ljbk);
     }
+
     program.emit_insn(Insn::RewindAsync {
         cursor_id: loop_info.open_cursor,
     });
-    let rewind_await_label = program.allocate_label();
+    program.defer_label_resolution(loop_info.rewind_label, program.offset() as usize);
     program.emit_insn_with_label_dependency(
         Insn::RewindAwait {
             cursor_id: loop_info.open_cursor,
-            pc_if_empty: rewind_await_label,
+            pc_if_empty: loop_info.rewind_on_empty_label,
         },
-        rewind_await_label,
+        loop_info.rewind_on_empty_label,
     );
-    loop_info.rewind_label = rewind_await_label;
-    loop_info.rewind_offset = program.offset() - 1;
+
+    translate_processed_where(program, select, loop_info, w, None)?;
+
+    if let Some(ljbk) = loop_info.left_join_bookkeeping.as_ref() {
+        left_join_match_flag_set_true(program, ljbk);
+    }
+
+    Ok(())
 }
 
 fn translate_columns(
@@ -539,11 +510,7 @@ fn translate_table_star(
     target_register: usize,
     cursor_hint: Option<usize>,
 ) {
-    let table_identifier = normalize_ident(match table.alias {
-        Some(alias) => alias,
-        None => &table.table.get_name(),
-    });
-    let table_cursor = program.resolve_cursor_id(&table_identifier, cursor_hint);
+    let table_cursor = program.resolve_cursor_id(&table.identifier, cursor_hint);
     let table = &table.table;
     for (i, col) in table.columns().iter().enumerate() {
         let col_target_register = target_register + i;

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -1,11 +1,32 @@
-use sqlite3_parser::ast;
+use sqlite3_parser::ast::{self, JoinOperator, JoinType};
 
 use crate::{function::Func, schema::Table, vdbe::BranchOffset};
 
+#[derive(Debug)]
 pub struct SrcTable<'a> {
     pub table: Table,
-    pub alias: Option<&'a String>,
-    pub join_info: Option<&'a ast::JoinedSelectTable>, // FIXME: preferably this should be a reference with lifetime == Select ast expr
+    pub identifier: String,
+    pub join_info: Option<&'a ast::JoinedSelectTable>,
+}
+
+impl SrcTable<'_> {
+    pub fn is_outer_join(&self) -> bool {
+        matches!(
+            self.join_info,
+            Some(ast::JoinedSelectTable {
+                operator: JoinOperator::TypedJoin {
+                    natural: false,
+                    join_type: Some(
+                        JoinType::Left
+                            | JoinType::LeftOuter
+                            | JoinType::Right
+                            | JoinType::RightOuter
+                    )
+                },
+                ..
+            })
+        )
+    }
 }
 
 #[derive(Debug)]
@@ -29,9 +50,27 @@ impl<'a> ColumnInfo<'a> {
     }
 }
 
+pub struct LeftJoinBookkeeping {
+    // integer register that holds a flag that is set to true if the current row has a match for the left join
+    pub match_flag_register: usize,
+    // label for the instruction that sets the match flag to true
+    pub set_match_flag_true_label: BranchOffset,
+    // label for the instruction where the program jumps to if the current row has a match for the left join
+    pub on_match_jump_to_label: BranchOffset,
+}
+
 pub struct LoopInfo {
-    pub rewind_offset: BranchOffset,
+    // The table or table alias that we are looping over
+    pub identifier: String,
+    // Metadata about a left join, if any
+    pub left_join_bookkeeping: Option<LeftJoinBookkeeping>,
+    // The label for the instruction that reads the next row for this table
+    pub next_row_label: BranchOffset,
+    // The label for the instruction that rewinds the cursor for this table
     pub rewind_label: BranchOffset,
+    // The label for the instruction that is jumped to in the Rewind instruction if the table is empty
+    pub rewind_on_empty_label: BranchOffset,
+    // The ID of the cursor that is opened for this table
     pub open_cursor: usize,
 }
 

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -242,6 +242,10 @@ impl ProgramBuilder {
                     assert!(*target_pc < 0);
                     *target_pc = to_offset;
                 }
+                Insn::NextAwait { pc_if_next, .. } => {
+                    assert!(*pc_if_next < 0);
+                    *pc_if_next = to_offset;
+                }
                 _ => {
                     todo!("missing resolve_label for {:?}", insn);
                 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -686,7 +686,7 @@ impl Program {
                     if let Some(ref rowid) = cursor.rowid()? {
                         state.registers[*dest] = OwnedValue::Integer(*rowid as i64);
                     } else {
-                        todo!();
+                        state.registers[*dest] = OwnedValue::Null;
                     }
                     state.pc += 1;
                 }
@@ -1397,7 +1397,7 @@ mod tests {
             OwnedValue::Integer(value) => {
                 // Check that the value is within the range of i64
                 assert!(
-                    value >= i64::MIN && value <= i64::MAX,
+                    (i64::MIN..=i64::MAX).contains(&value),
                     "Random number out of range"
                 );
             }

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -808,8 +808,7 @@ pub unsafe extern "C" fn sqlite3_errmsg(_db: *mut sqlite3) -> *const std::ffi::c
 
     let err_msg = if (*_db).err_code != SQLITE_OK {
         if !(*_db).p_err.is_null() {
-            let cstr = (*_db).p_err as *const std::ffi::c_char;
-            cstr
+            (*_db).p_err as *const std::ffi::c_char
         } else {
             std::ptr::null()
         }

--- a/testing/join.test
+++ b/testing/join.test
@@ -79,6 +79,21 @@ Alan|
 Michael|
 Brianna|}
 
+do_execsql_test left-join-with-where-2 {
+   select users.first_name, products.name from users left join products on users.id < 2 where users.id < 3;
+} {Jamie|hat
+Jamie|cap
+Jamie|shirt
+Jamie|sweater
+Jamie|sweatshirt
+Jamie|shorts
+Jamie|jeans
+Jamie|sneakers
+Jamie|boots
+Jamie|coat
+Jamie|accessories
+Cindy|}
+
 do_execsql_test left-join-non-pk {
     select users.first_name as user_name, products.name as product_name from users left join products on users.first_name = products.name limit 3;
 } {Jamie|
@@ -108,3 +123,26 @@ do_execsql_test left-join-no-join-conditions-but-multiple-where {
     select u.first_name, p.name from users u left join products as p where u.id = p.id or u.first_name = p.name limit 2;
 } {Jamie|hat
 Cindy|cap}
+
+do_execsql_test four-way-inner-join {
+  select u1.first_name, u2.first_name, u3.first_name, u4.first_name from users u1 join users u2 on u1.id = u2.id join users u3 on u2.id = u3.id + 1 join users u4 on u3.id = u4.id + 1 limit 1;
+} {Tommy|Tommy|Cindy|Jamie}
+
+do_execsql_test leftjoin-innerjoin-where {
+  select u.first_name, p.name, p2.name from users u left join products p on p.name = u.first_name join products p2 on length(p2.name) > 8 where u.first_name = 'Franklin';
+} {Franklin||sweatshirt
+Franklin||accessories}
+
+do_execsql_test leftjoin-leftjoin-where {
+  select u.first_name, p.name, p2.name from users u left join products p on p.name = u.first_name join products p2 on length(p2.name) > 8 where u.first_name = 'Franklin';
+} {Franklin||sweatshirt
+Franklin||accessories}
+
+do_execsql_test innerjoin-leftjoin-where {
+  select u.first_name, u2.first_name, p.name from users u join users u2 on u.id = u2.id + 1 left join products p on p.name = u.first_name where u.first_name = 'Franklin';
+} {Franklin|Cynthia|}
+
+do_execsql_test innerjoin-leftjoin-with-or-terms {
+  select u.first_name, u2.first_name, p.name from users u join users u2 on u.id = u2.id + 1 left join products p on p.name = u.first_name or p.name like 'sweat%' where u.first_name = 'Franklin';
+} {Franklin|Cynthia|sweater
+Franklin|Cynthia|sweatshirt}


### PR DESCRIPTION
Features:

- Support multiple joins instead of just one

Architectural changes:

- Make all constraints a list of WhereTerms in a ProcessedWhereClause instead of separate `where_clause` and `join_clause`; gets rid of `QueryConstraint` in favor of just `ProcessedWhereClause` which is currently just a wrapper for `Vec<WhereTerm>`
- A `WhereTerm` contains an AST expression plus an indication during which loop in the join the condition should be evaluated
- Add more metadata to `LoopInfo` mainly to indicate whether that loop contains a left join and to add labels/metadata associated with that left join
- Emit condition instructions in `translate_table_open_loop` depending on which cursor it is
- In both `translate_table_open_loop` and `translate_tables_end`, emit instructions relevant to left joins if the LoopInfo in question has been marked as containing a left join


---
Example query:
`explain select u.first_name, p.name, p2.name from users u left join products p on p.name = u.first_name join products p2 on length(p2.name) > 8 where u.first_name = 'Franklin';`

Codegen (limbo):

```
> explain select u.first_name, p.name, p2.name from users u left join products p on p.name = u.first_name join products p2 on length(p2.name) > 8 where u.first_name = 'Franklin';
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     37    0                    0   Start at 37
1     OpenReadAsync      0     2     0                    0   root=2
2     OpenReadAwait      0     0     0                    0
3     OpenReadAsync      1     3     0                    0   root=3
4     OpenReadAwait      0     0     0                    0
5     OpenReadAsync      2     3     0                    0   root=3
6     OpenReadAwait      0     0     0                    0
7     RewindAsync        0     0     0                    0
8     RewindAwait        0     36    0                    0
9       Column           0     1     2                    0   r[2]=users.first_name
10      Ne               2     3     34                   0   if r[2]!=r[3] goto 34
11      Integer          0     1     0                    0   r[1]=0
12      RewindAsync      1     0     0                    0
13      RewindAwait      1     34    0                    0
14        Column         1     1     4                    0   r[4]=products.name
15        Column         0     1     5                    0   r[5]=users.first_name
16        Ne             4     5     29                   0   if r[4]!=r[5] goto 29
17        Integer        1     1     0                    0   r[1]=1
18        RewindAsync    2     0     0                    0
19        RewindAwait    2     29    0                    0
20          Column       2     1     8                    0   r[8]=products.name
21          Function     1     8     6     length         0   r[6]=func(r[8..])
22          Le           6     7     27                   0   if r[6]<=r[7] goto 27
23          Column       0     1     9                    0   r[9]=users.first_name
24          Column       1     1     10                   0   r[10]=products.name
25          Column       2     1     11                   0   r[11]=products.name
26          ResultRow    9     3     0                    0   output=r[9..11]
27        NextAsync      2     0     0                    0
28        NextAwait      2     19    0                    0
29      NextAsync        1     0     0                    0
30      NextAwait        1     13    0                    0
31      IfPos            1     34    0                    0   r[1]>0 -> r[1]-=0, goto 34
32      NullRow          1     0     0                    0   Set cursor 1 to a (pseudo) NULL row
33      Goto             0     17    0                    0
34    NextAsync          0     0     0                    0
35    NextAwait          0     8     0                    0
36    Halt               0     0     0                    0
37    Transaction        0     0     0                    0
38    String8            0     3     0     Franklin       0   r[3]='Franklin'
39    Integer            8     7     0                    0   r[7]=8
40    Goto               0     1     0                    0
```

Codegen (sqlite):

```
sqlite> pragma automatic_index = 0;
sqlite> explain select u.first_name, p.name, p2.name from users u left join products p on p.name = u.first_name join products p2 on length(p2.name) > 8 where u.first_name = 'Franklin';
addr  opcode         p1    p2    p3    p4             p5  comment
----  -------------  ----  ----  ----  -------------  --  -------------
0     Init           0     28    0                    0   Start at 28
1     OpenRead       0     2     0     2              0   root=2 iDb=0; users
2     OpenRead       1     3     0     2              0   root=3 iDb=0; products
3     OpenRead       2     3     0     2              0   root=3 iDb=0; products
4     Rewind         0     27    0                    0
5       Column         0     1     1                    0   r[1]= cursor 0 column 1
6       Ne             2     26    1     BINARY-8       82  if r[1]!=r[2] goto 26
7       Integer        0     3     0                    0   r[3]=0; init LEFT JOIN match flag
8       Rewind         1     23    0                    0
9         Column         1     1     1                    0   r[1]= cursor 1 column 1
10        Column         0     1     4                    0   r[4]= cursor 0 column 1
11        Ne             4     22    1     BINARY-8       81  if r[1]!=r[4] goto 22
12        Integer        1     3     0                    0   r[3]=1; record LEFT JOIN hit
13        Rewind         2     23    0                    0
14          Column         2     1     1                    64  r[1]= cursor 2 column 1
15          Function       0     1     4     length(1)      0   r[4]=func(r[1])
16          Le             5     21    4                    80  if r[4]<=r[5] goto 21
17          Column         0     1     6                    0   r[6]= cursor 0 column 1
18          Column         1     1     7                    0   r[7]= cursor 1 column 1
19          Column         2     1     8                    0   r[8]= cursor 2 column 1
20          ResultRow      6     3     0                    0   output=r[6..8]
21        Next           2     14    0                    1
22      Next           1     9     0                    1
23      IfPos          3     26    0                    0   if r[3]>0 then r[3]-=0, goto 26
24      NullRow        1     0     0                    0
25      Goto           0     12    0                    0
26    Next           0     5     0                    1
27    Halt           0     0     0                    0
28    Transaction    0     0     2     0              1   usesStmtJournal=0
29    String8        0     2     0     Franklin       0   r[2]='Franklin'
30    Integer        8     5     0                    0   r[5]=8
31    Goto           0     1     0                    0
```