### PR TITLE
fix: double quoted string in function

### DIFF
--- a/core/translate/where_clause.rs
+++ b/core/translate/where_clause.rs
@@ -523,8 +523,12 @@ fn introspect_expression_for_cursors(
             )?);
         }
         ast::Expr::Id(ident) => {
-            let (_, _, cursor_id, _) = resolve_ident_table(program, &ident.0, select, cursor_hint)?;
-            cursors.push(cursor_id);
+            match resolve_ident_table(program, &ident.0, select, cursor_hint)? {
+                Some((_, _, cursor_id, _)) => {
+                    cursors.push(cursor_id);
+                }
+                None => anyhow::bail!("Parse error: ambiguous column name {}", ident.0.as_str()),
+            }
         }
         ast::Expr::Qualified(tbl, ident) => {
             let (_, _, cursor_id, _) =

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -243,3 +243,26 @@ do_execsql_test date-with-invalid-timezone {
   SELECT date('2023-05-18 15:30:45+25:00');
 } {{}}
 
+do_execsql_test length-double-quoted-text-non-column {
+  SELECT length("limbo") from users LIMIT 1;
+} {5}
+
+do_execsql_test upper-double-quoted-text-non-column {
+  SELECT upper("limbo") from users LIMIT 1;
+} {LIMBO}
+
+do_execsql_test lower-double-quoted-text-non-column {
+  SELECT lower("LIMBO") from users LIMIT 1;
+} {limbo}
+
+do_execsql_test length-double-quoted-text-existing-column {
+  SELECT length("first_name") from users LIMIT 1;
+} {5}
+
+do_execsql_test upper-double-quoted-text-existing-column {
+  SELECT upper("first_name") from users LIMIT 1;
+} {JAMIE}
+
+do_execsql_test lower-double-quoted-text-existing-column {
+  SELECT lower("first_name") from users LIMIT 1;
+} {jamie}


### PR DESCRIPTION
Closes #196 

This PR addresses an issue with the SQL function that accepts double-quoted strings. The function works correctly when the string is an existing column but fails otherwise.

Examples:

- Supported: `SELECT length("username") FROM users;`
- Not supported: `SELECT length("foobar") FROM users;`