### PR TITLE
github: Add `cargo bench` to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,13 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: wasm-pack build --target nodejs bindings/wasm
 
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Bench
+      run: cargo bench
+
   test-limbo:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Let's run `cargo bench` just to make sure we don't keep breaking it all the time. As a follow up, it would be cool to upload the results to Nyrkiö, for example.