### PR TITLE
bench: fix db lock on benchmark code by splitting the scopes

### DIFF
--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -15,7 +15,7 @@ fn bench(c: &mut Criterion) {
     rusqlite_bench(c)
 }
 
-fn limbo_bench(criterion: &mut Criterion){
+fn limbo_bench(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("limbo");
     group.throughput(Throughput::Elements(1));
     let io = Arc::new(PlatformIO::new().unwrap());
@@ -101,7 +101,7 @@ fn limbo_bench(criterion: &mut Criterion){
     );
 }
 
-fn rusqlite_bench(criterion: &mut Criterion){
+fn rusqlite_bench(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("rusqlite");
     group.throughput(Throughput::Elements(1));
 

--- a/core/benches/benchmark.rs
+++ b/core/benches/benchmark.rs
@@ -4,9 +4,20 @@ use pprof::criterion::{Output, PProfProfiler};
 use std::sync::Arc;
 
 fn bench(c: &mut Criterion) {
-    let mut group = c.benchmark_group("limbo");
-    group.throughput(Throughput::Elements(1));
+    limbo_bench(c);
 
+    // https://github.com/penberg/limbo/issues/174
+    // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
+    if std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_ok() {
+        return;
+    }
+
+    rusqlite_bench(c)
+}
+
+fn limbo_bench(criterion: &mut Criterion){
+    let mut group = criterion.benchmark_group("limbo");
+    group.throughput(Throughput::Elements(1));
     let io = Arc::new(PlatformIO::new().unwrap());
     let db = Database::open_file(io.clone(), "../testing/testing.db").unwrap();
     let conn = db.connect();
@@ -88,16 +99,10 @@ fn bench(c: &mut Criterion) {
             });
         },
     );
+}
 
-    drop(group);
-
-    // https://github.com/penberg/limbo/issues/174
-    // The rusqlite benchmark crashes on Mac M1 when using the flamegraph features
-    if std::env::var("DISABLE_RUSQLITE_BENCHMARK").is_ok() {
-        return;
-    }
-
-    let mut group = c.benchmark_group("rusqlite");
+fn rusqlite_bench(criterion: &mut Criterion){
+    let mut group = criterion.benchmark_group("rusqlite");
     group.throughput(Throughput::Elements(1));
 
     let conn = rusqlite::Connection::open("../testing/testing.db").unwrap();


### PR DESCRIPTION
closes issue #217. 

I separated the benchmark code into two functions one for limbo code and another for rusqlite. Now all the benchmark test are working. 

screenshot from the rusqlite tests:
<img width="683" alt="image" src="https://github.com/user-attachments/assets/71926bd1-c667-42a0-ae42-27feb8384935">
