### PR TITLE
Kill anyhow usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,6 @@ dependencies = [
 name = "limbo-wasm"
 version = "0.0.2"
 dependencies = [
- "anyhow",
  "limbo_core",
  "wasm-bindgen",
 ]
@@ -1033,7 +1032,6 @@ dependencies = [
 name = "limbo_core"
 version = "0.0.2"
 dependencies = [
- "anyhow",
  "cfg_block",
  "chrono",
  "criterion",
@@ -1061,7 +1059,6 @@ dependencies = [
 name = "limbo_sim"
 version = "0.0.2"
 dependencies = [
- "anyhow",
  "limbo_core",
  "rand",
  "rand_chacha",

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -11,6 +11,5 @@ crate-type = ["cdylib"]
 path = "lib.rs"
 
 [dependencies]
-anyhow = "1.0.75"
 limbo_core = { path = "../../core", default-features = false }
 wasm-bindgen = "0.2"

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use limbo_core::Result;
 use std::rc::Rc;
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,6 @@ rustix = "0.38.34"
 mimalloc = { version = "*", default-features = false }
 
 [dependencies]
-anyhow = "1.0.75"
 cfg_block = "0.1.1"
 fallible-iterator = "0.3.0"
 libc = "0.2.155"

--- a/core/btree.rs
+++ b/core/btree.rs
@@ -1,8 +1,7 @@
 use crate::pager::Pager;
 use crate::sqlite3_ondisk::{BTreeCell, TableInteriorCell, TableLeafCell};
 use crate::types::{Cursor, CursorResult, OwnedRecord};
-
-use anyhow::Result;
+use crate::Result;
 
 use std::cell::{Ref, RefCell};
 use std::rc::Rc;

--- a/core/datetime.rs
+++ b/core/datetime.rs
@@ -1,7 +1,7 @@
 use crate::types::OwnedValue;
-use anyhow;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
 use log::trace;
+use std::result::Result;
 use std::{error::Error, fmt::Display};
 
 #[derive(Debug)]
@@ -86,7 +86,7 @@ fn get_max_datetime_exclusive() -> NaiveDateTime {
     )
 }
 
-pub fn get_date_from_time_value(time_value: &OwnedValue) -> anyhow::Result<String> {
+pub fn get_date_from_time_value(time_value: &OwnedValue) -> crate::Result<String> {
     let dt = match time_value {
         OwnedValue::Text(s) => get_date_time_from_time_value_string(s),
         OwnedValue::Integer(i) => get_date_time_from_time_value_integer(*i),
@@ -106,7 +106,7 @@ pub fn get_date_from_time_value(time_value: &OwnedValue) -> anyhow::Result<Strin
             }
             DateTimeError::Other(s) => {
                 trace!("Other date time error: {}", s);
-                anyhow::bail!(s)
+                Err(crate::error::LimboError::InvalidDate(s))
             }
         }
     }

--- a/core/error.rs
+++ b/core/error.rs
@@ -1,0 +1,49 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum LimboError {
+    #[error("Corrupt database: {0}")]
+    Corrupt(String),
+    #[error("File is not a database")]
+    NotADB,
+    #[error("Internal error: {0}")]
+    InternalError(String),
+    #[error("Parse error: {0}")]
+    ParseError(String),
+    #[error("Parse error: {0}")]
+    LexerError(#[from] sqlite3_parser::lexer::sql::Error),
+    #[error("Conversion error: {0}")]
+    ConversionError(String),
+    #[error("Env variable error: {0}")]
+    EnvVarError(#[from] std::env::VarError),
+    #[error("I/O error: {0}")]
+    IOError(#[from] std::io::Error),
+    #[cfg(target_os = "linux")]
+    #[error("I/O error: {0}")]
+    LinuxIOError(String),
+    #[error("Locking error: {0}")]
+    LockingError(String),
+    #[cfg(target_os = "macos")]
+    #[error("I/O error: {0}")]
+    RustixIOError(#[from] rustix::io::Errno),
+    #[error("Parse error: {0}")]
+    ParseIntError(#[from] std::num::ParseIntError),
+    #[error("Parse error: {0}")]
+    ParseFloatError(#[from] std::num::ParseFloatError),
+    #[error("Parse error: {0}")]
+    InvalidDate(String),
+}
+
+#[macro_export]
+macro_rules! bail_parse_error {
+    ($($arg:tt)*) => {
+        return Err(crate::error::LimboError::ParseError(format!($($arg)*)))
+    };
+}
+
+#[macro_export]
+macro_rules! bail_corrupt_error {
+    ($($arg:tt)*) => {
+        return Err(crate::error::LimboError::Corrupt(format!($($arg)*)))
+    };
+}

--- a/core/io/common.rs
+++ b/core/io/common.rs
@@ -2,8 +2,7 @@ pub const ENV_DISABLE_FILE_LOCK: &str = "LIMBO_DISABLE_FILE_LOCK";
 
 #[cfg(test)]
 pub mod tests {
-    use crate::IO;
-    use anyhow::Result;
+    use crate::{Result, IO};
     use std::process::{Command, Stdio};
     use tempfile::NamedTempFile;
 

--- a/core/io/generic.rs
+++ b/core/io/generic.rs
@@ -1,5 +1,4 @@
-use super::{Completion, File, WriteCompletion, IO};
-use anyhow::{Ok, Result};
+use crate::{Completion, File, Result, WriteCompletion, IO};
 use log::trace;
 use std::cell::RefCell;
 use std::io::{Read, Seek, Write};

--- a/core/io/mod.rs
+++ b/core/io/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::Result;
 use cfg_block::cfg_block;
 use std::{
     cell::{Ref, RefCell, RefMut},

--- a/core/io/windows.rs
+++ b/core/io/windows.rs
@@ -1,5 +1,4 @@
-use super::{Completion, File, WriteCompletion, IO};
-use anyhow::{Ok, Result};
+use crate::{Completion, File, Result, WriteCompletion, IO};
 use log::trace;
 use std::cell::RefCell;
 use std::io::{Read, Seek, Write};

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1,6 +1,7 @@
 mod btree;
 mod buffer_pool;
 mod datetime;
+mod error;
 mod function;
 mod io;
 mod pager;
@@ -17,7 +18,6 @@ mod vdbe;
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use anyhow::Result;
 use fallible_iterator::FallibleIterator;
 use log::trace;
 use pager::Pager;
@@ -26,6 +26,9 @@ use sqlite3_ondisk::DatabaseHeader;
 use sqlite3_parser::{ast::Cmd, lexer::sql::Parser};
 use std::sync::Arc;
 use std::{cell::RefCell, rc::Rc};
+
+pub use error::LimboError;
+pub type Result<T> = std::result::Result<T, error::LimboError>;
 
 #[cfg(feature = "fs")]
 pub use io::PlatformIO;

--- a/core/pager.rs
+++ b/core/pager.rs
@@ -1,7 +1,7 @@
 use crate::buffer_pool::BufferPool;
 use crate::sqlite3_ondisk::BTreePage;
 use crate::sqlite3_ondisk::{self, DatabaseHeader};
-use crate::PageSource;
+use crate::{PageSource, Result};
 use log::trace;
 use sieve_cache::SieveCache;
 use std::cell::RefCell;
@@ -106,7 +106,7 @@ pub struct Pager {
 }
 
 impl Pager {
-    pub fn begin_open(page_source: &PageSource) -> anyhow::Result<Rc<RefCell<DatabaseHeader>>> {
+    pub fn begin_open(page_source: &PageSource) -> Result<Rc<RefCell<DatabaseHeader>>> {
         sqlite3_ondisk::begin_read_database_header(page_source)
     }
 
@@ -114,7 +114,7 @@ impl Pager {
         db_header: Rc<RefCell<DatabaseHeader>>,
         page_source: PageSource,
         io: Arc<dyn crate::io::IO>,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self> {
         let db_header = db_header.borrow();
         let page_size = db_header.page_size as usize;
         let buffer_pool = Rc::new(BufferPool::new(page_size));
@@ -127,7 +127,7 @@ impl Pager {
         })
     }
 
-    pub fn read_page(&self, page_idx: usize) -> anyhow::Result<Rc<Page>> {
+    pub fn read_page(&self, page_idx: usize) -> Result<Rc<Page>> {
         trace!("read_page(page_idx = {})", page_idx);
         let mut page_cache = self.page_cache.borrow_mut();
         if let Some(page) = page_cache.get(&page_idx) {

--- a/core/pseudo.rs
+++ b/core/pseudo.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::Result;
 use std::cell::{Ref, RefCell};
 
 use crate::types::{Cursor, CursorResult, OwnedRecord, OwnedValue};

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -1,5 +1,4 @@
-use crate::util::normalize_ident;
-use anyhow::Result;
+use crate::{util::normalize_ident, Result};
 use core::fmt;
 use fallible_iterator::FallibleIterator;
 use log::trace;
@@ -130,7 +129,7 @@ impl BTreeTable {
             Some(Cmd::Stmt(Stmt::CreateTable { tbl_name, body, .. })) => {
                 create_table(tbl_name, body, root_page)
             }
-            _ => anyhow::bail!("Expected CREATE TABLE statement"),
+            _ => todo!("Expected CREATE TABLE statement"),
         }
     }
 
@@ -213,9 +212,7 @@ fn create_table(
                                     value.trim_matches('\'').to_owned()
                                 }
                                 _ => {
-                                    return Err(anyhow::anyhow!(
-                                        "Unsupported primary key expression"
-                                    ))
+                                    todo!("Unsupported primary key expression");
                                 }
                             });
                         }

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::Result;
 use sqlite3_parser::ast::{self, Expr, UnaryOperator};
 
 use crate::{
@@ -132,22 +132,22 @@ pub fn translate_expr(
 
             match func_type {
                 Some(Func::Agg(_)) => {
-                    anyhow::bail!("Parse error: aggregation function in non-aggregation context")
+                    crate::bail_parse_error!("aggregation function in non-aggregation context")
                 }
                 Some(Func::Scalar(srf)) => {
                     match srf {
                         ScalarFunc::Coalesce => {
                             let args = if let Some(args) = args {
                                 if args.len() < 2 {
-                                    anyhow::bail!(
-                                        "Parse error: {} function with less than 2 arguments",
+                                    crate::bail_parse_error!(
+                                        "{} function with less than 2 arguments",
                                         srf.to_string()
                                     );
                                 }
                                 args
                             } else {
-                                anyhow::bail!(
-                                    "Parse error: {} function with no arguments",
+                                crate::bail_parse_error!(
+                                    "{} function with no arguments",
                                     srf.to_string()
                                 );
                             };
@@ -180,15 +180,15 @@ pub fn translate_expr(
                         ScalarFunc::Like => {
                             let args = if let Some(args) = args {
                                 if args.len() < 2 {
-                                    anyhow::bail!(
-                                        "Parse error: {} function with less than 2 arguments",
+                                    crate::bail_parse_error!(
+                                        "{} function with less than 2 arguments",
                                         srf.to_string()
                                     );
                                 }
                                 args
                             } else {
-                                anyhow::bail!(
-                                    "Parse error: {} function with no arguments",
+                                crate::bail_parse_error!(
+                                    "{} function with no arguments",
                                     srf.to_string()
                                 );
                             };
@@ -213,15 +213,15 @@ pub fn translate_expr(
                         | ScalarFunc::Length => {
                             let args = if let Some(args) = args {
                                 if args.len() != 1 {
-                                    anyhow::bail!(
-                                        "Parse error: {} function with not exactly 1 argument",
+                                    crate::bail_parse_error!(
+                                        "{} function with not exactly 1 argument",
                                         srf.to_string()
                                     );
                                 }
                                 args
                             } else {
-                                anyhow::bail!(
-                                    "Parse error: {} function with no arguments",
+                                crate::bail_parse_error!(
+                                    "{} function with no arguments",
                                     srf.to_string()
                                 );
                             };
@@ -237,8 +237,8 @@ pub fn translate_expr(
                         }
                         ScalarFunc::Random => {
                             if args.is_some() {
-                                anyhow::bail!(
-                                    "Parse error: {} function with arguments",
+                                crate::bail_parse_error!(
+                                    "{} function with arguments",
                                     srf.to_string()
                                 );
                             }
@@ -254,7 +254,7 @@ pub fn translate_expr(
                             let mut start_reg = 0;
                             if let Some(args) = args {
                                 if args.len() > 1 {
-                                    anyhow::bail!("Parse error: date function with > 1 arguments. Modifiers are not yet supported.");
+                                    crate::bail_parse_error!("date function with > 1 arguments. Modifiers are not yet supported.");
                                 } else if args.len() == 1 {
                                     let arg_reg = program.alloc_register();
                                     let _ = translate_expr(
@@ -277,15 +277,15 @@ pub fn translate_expr(
                         ScalarFunc::Trim | ScalarFunc::Round => {
                             let args = if let Some(args) = args {
                                 if args.len() > 2 {
-                                    anyhow::bail!(
-                                        "Parse error: {} function with more than 2 arguments",
+                                    crate::bail_parse_error!(
+                                        "{} function with more than 2 arguments",
                                         srf.to_string()
                                     );
                                 }
                                 args
                             } else {
-                                anyhow::bail!(
-                                    "Parse error: {} function with no arguments",
+                                crate::bail_parse_error!(
+                                    "{} function with no arguments",
                                     srf.to_string()
                                 );
                             };
@@ -307,13 +307,13 @@ pub fn translate_expr(
                         ScalarFunc::Min => {
                             let args = if let Some(args) = args {
                                 if args.len() < 1 {
-                                    anyhow::bail!(
-                                        "Parse error: min function with less than one argument"
+                                    crate::bail_parse_error!(
+                                        "min function with less than one argument"
                                     );
                                 }
                                 args
                             } else {
-                                anyhow::bail!("Parse error: min function with no arguments");
+                                crate::bail_parse_error!("min function with no arguments");
                             };
                             for arg in args {
                                 let reg = program.alloc_register();
@@ -334,13 +334,13 @@ pub fn translate_expr(
                         ScalarFunc::Max => {
                             let args = if let Some(args) = args {
                                 if args.len() < 1 {
-                                    anyhow::bail!(
-                                        "Parse error: max function with less than one argument"
+                                    crate::bail_parse_error!(
+                                        "max function with less than one argument"
                                     );
                                 }
                                 args
                             } else {
-                                anyhow::bail!("Parse error: max function with no arguments");
+                                crate::bail_parse_error!("max function with no arguments");
                             };
                             for arg in args {
                                 let reg = program.alloc_register();
@@ -361,7 +361,7 @@ pub fn translate_expr(
                     }
                 }
                 None => {
-                    anyhow::bail!("Parse error: unknown function {}", name.0);
+                    crate::bail_parse_error!("unknown function {}", name.0);
                 }
             }
         }
@@ -600,8 +600,8 @@ pub fn resolve_ident_qualified(
             Table::Pseudo(_) => todo!(),
         }
     }
-    anyhow::bail!(
-        "Parse error: column with qualified name {}.{} not found",
+    crate::bail_parse_error!(
+        "column with qualified name {}.{} not found",
         table_name,
         ident
     );
@@ -654,10 +654,10 @@ pub fn resolve_ident_table(
         return Ok(found[0]);
     }
     if found.is_empty() {
-        anyhow::bail!("Parse error: column with name {} not found", ident.as_str());
+        crate::bail_parse_error!("column with name {} not found", ident.as_str());
     }
 
-    anyhow::bail!("Parse error: ambiguous column name {}", ident.as_str());
+    crate::bail_parse_error!("ambiguous column name {}", ident.as_str());
 }
 
 pub fn maybe_apply_affinity(col_type: Type, target_register: usize, program: &mut ProgramBuilder) {

--- a/core/translate/mod.rs
+++ b/core/translate/mod.rs
@@ -10,7 +10,7 @@ use crate::schema::Schema;
 use crate::sqlite3_ondisk::{DatabaseHeader, MIN_PAGE_CACHE_SIZE};
 use crate::util::normalize_ident;
 use crate::vdbe::{builder::ProgramBuilder, BranchOffset, Insn, Program};
-use anyhow::Result;
+use crate::Result;
 use select::{build_select, translate_select};
 use sqlite3_parser::ast;
 

--- a/core/types.rs
+++ b/core/types.rs
@@ -1,7 +1,8 @@
 use std::fmt::Display;
 use std::{cell::Ref, rc::Rc};
 
-use anyhow::Result;
+use crate::error::LimboError;
+use crate::Result;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value<'a> {
@@ -257,7 +258,7 @@ impl<'a> FromValue<'a> for i64 {
     fn from_value(value: &Value<'a>) -> Result<Self> {
         match value {
             Value::Integer(i) => Ok(*i),
-            _ => anyhow::bail!("Expected integer value"),
+            _ => Err(LimboError::ConversionError("Expected integer value".into())),
         }
     }
 }
@@ -266,7 +267,7 @@ impl<'a> FromValue<'a> for String {
     fn from_value(value: &Value<'a>) -> Result<Self> {
         match value {
             Value::Text(s) => Ok(s.to_string()),
-            _ => anyhow::bail!("Expected text value"),
+            _ => Err(LimboError::ConversionError("Expected text value".into())),
         }
     }
 }
@@ -275,7 +276,7 @@ impl<'a> FromValue<'a> for &'a str {
     fn from_value(value: &Value<'a>) -> Result<&'a str> {
         match value {
             Value::Text(s) => Ok(s),
-            _ => anyhow::bail!("Expected text value"),
+            _ => Err(LimboError::ConversionError("Expected text value".into())),
         }
     }
 }

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -4,13 +4,14 @@ pub mod sorter;
 
 use crate::btree::BTreeCursor;
 use crate::datetime::get_date_from_time_value;
+use crate::error::LimboError;
 use crate::function::{AggFunc, ScalarFunc};
 use crate::pager::Pager;
 use crate::pseudo::PseudoCursor;
 use crate::schema::Table;
 use crate::types::{AggContext, Cursor, CursorResult, OwnedRecord, OwnedValue, Record};
+use crate::Result;
 
-use anyhow::Result;
 use regex::Regex;
 use std::borrow::BorrowMut;
 use std::cell::RefCell;
@@ -380,7 +381,9 @@ impl Program {
                             state.pc += 1;
                         }
                         _ => {
-                            anyhow::bail!("IfPos: the value in the register is not an integer");
+                            return Err(LimboError::InternalError(
+                                "IfPos: the value in the register is not an integer".into(),
+                            ));
                         }
                     }
                 }
@@ -1141,10 +1144,10 @@ impl Program {
                                     state.registers[*dest] = OwnedValue::Text(Rc::new(date))
                                 }
                                 Err(e) => {
-                                    anyhow::bail!(
+                                    return Err(LimboError::ParseError(format!(
                                         "Error encountered while parsing time value: {}",
                                         e
-                                    )
+                                    )));
                                 }
                             }
                         }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -1,5 +1,7 @@
-use crate::types::{Cursor, CursorResult, OwnedRecord};
-use anyhow::Result;
+use crate::{
+    types::{Cursor, CursorResult, OwnedRecord},
+    Result,
+};
 use std::{
     cell::{Ref, RefCell},
     collections::{BTreeMap, VecDeque},

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -15,7 +15,6 @@ name = "limbo_sim"
 path = "main.rs"
 
 [dependencies]
-anyhow = "1.0.86"
 limbo_core = { path = "../core" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -1,5 +1,4 @@
-use anyhow::Result;
-use limbo_core::{Database, File, PlatformIO, IO};
+use limbo_core::{Database, File, PlatformIO, Result, IO};
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use std::cell::RefCell;
@@ -100,7 +99,9 @@ impl IO for SimulatorIO {
 
     fn run_once(&self) -> Result<()> {
         if *self.fault.borrow() {
-            return Err(anyhow::anyhow!("Injected fault"));
+            return Err(limbo_core::LimboError::InternalError(
+                "Injected fault".into(),
+            ));
         }
         self.inner.run_once().unwrap();
         Ok(())
@@ -131,14 +132,18 @@ impl SimulatorFile {
 impl limbo_core::File for SimulatorFile {
     fn lock_file(&self, exclusive: bool) -> Result<()> {
         if *self.fault.borrow() {
-            return Err(anyhow::anyhow!("Injected fault"));
+            return Err(limbo_core::LimboError::InternalError(
+                "Injected fault".into(),
+            ));
         }
         self.inner.lock_file(exclusive)
     }
 
     fn unlock_file(&self) -> Result<()> {
         if *self.fault.borrow() {
-            return Err(anyhow::anyhow!("Injected fault"));
+            return Err(limbo_core::LimboError::InternalError(
+                "Injected fault".into(),
+            ));
         }
         self.inner.unlock_file()
     }
@@ -146,7 +151,9 @@ impl limbo_core::File for SimulatorFile {
     fn pread(&self, pos: usize, c: Rc<limbo_core::Completion>) -> Result<()> {
         if *self.fault.borrow() {
             *self.nr_pread_faults.borrow_mut() += 1;
-            return Err(anyhow::anyhow!("Injected fault"));
+            return Err(limbo_core::LimboError::InternalError(
+                "Injected fault".into(),
+            ));
         }
         self.inner.pread(pos, c)
     }
@@ -159,7 +166,9 @@ impl limbo_core::File for SimulatorFile {
     ) -> Result<()> {
         if *self.fault.borrow() {
             *self.nr_pwrite_faults.borrow_mut() += 1;
-            return Err(anyhow::anyhow!("Injected fault"));
+            return Err(limbo_core::LimboError::InternalError(
+                "Injected fault".into(),
+            ));
         }
         self.inner.pwrite(pos, buffer, c)
     }


### PR DESCRIPTION
Switch anyhow to explicit `LimboError` type using thiserror crate, which lets us make error handling more structured.