### PR TITLE
core/translate: #154: implement WHERE IN (...)

### DIFF
--- a/core/translate/where_clause.rs
+++ b/core/translate/where_clause.rs
@@ -477,9 +477,6 @@ fn translate_condition_expr(
             // which is what SQLite also does for small lists of values.
             // TODO: Let's refactor this later to use a more efficient implementation conditionally based on the number of values.
 
-            let lhs_reg = program.alloc_register();
-            let _ = translate_expr(program, select, lhs, lhs_reg, cursor_hint)?;
-
             if rhs.is_none() {
                 // If rhs is None, IN expressions are always false and NOT IN expressions are always true.
                 if *not {
@@ -505,6 +502,10 @@ fn translate_condition_expr(
                 }
                 return Ok(());
             }
+
+            // The left hand side only needs to be evaluated once we have a list of values to compare against.
+            let lhs_reg = program.alloc_register();
+            let _ = translate_expr(program, select, lhs, lhs_reg, cursor_hint)?;
 
             let rhs = rhs.as_ref().unwrap();
 

--- a/testing/where.test
+++ b/testing/where.test
@@ -49,7 +49,7 @@ do_execsql_test where-clause-no-table-unary-false {
 } {}
 
 do_execsql_test select-where-and {
-    select first_name, age from users where first_name = 'Jamie' and age > 80 
+    select first_name, age from users where first_name = 'Jamie' and age > 80
 } {Jamie|94
 Jamie|88
 Jamie|99
@@ -59,7 +59,7 @@ Jamie|88
 }
 
 do_execsql_test select-where-or {
-    select first_name, age from users where first_name = 'Jamie' and age > 80 
+    select first_name, age from users where first_name = 'Jamie' and age > 80
 } {Jamie|94
 Jamie|88
 Jamie|99
@@ -109,3 +109,95 @@ do_execsql_test where-float-int {
 do_execsql_test where-multiple-and {
     select * from products where price > 50 and name != 'sweatshirt' and price < 75;
 } {6|shorts|70.0}
+
+do_execsql_test where-multiple-or {
+    select * from products where price > 75 or name = 'shirt' or name = 'coat';
+} {1|hat|79.0
+2|cap|82.0
+3|shirt|18.0
+7|jeans|78.0
+8|sneakers|82.0
+10|coat|33.0
+11|accessories|81.0}
+
+do_execsql_test where_in_list {
+    select * from products where name in ('hat', 'sweatshirt', 'shorts');
+} {1|hat|79.0
+5|sweatshirt|74.0
+6|shorts|70.0}
+
+do_execsql_test where_not_in_list {
+    select * from products where name not in ('hat', 'sweatshirt', 'shorts');
+} {2|cap|82.0
+3|shirt|18.0
+4|sweater|25.0
+7|jeans|78.0
+8|sneakers|82.0
+9|boots|1.0
+10|coat|33.0
+11|accessories|81.0}
+
+do_execsql_test where_in_list_or_another_list {
+    select * from products where name in ('hat', 'sweatshirt', 'shorts') or price in (81.0, 82.0);
+} {1|hat|79.0
+2|cap|82.0
+5|sweatshirt|74.0
+6|shorts|70.0
+8|sneakers|82.0
+11|accessories|81.0}
+
+do_execsql_test where_not_in_list_and_not_in_another_list {
+    select * from products where name not in ('hat', 'sweatshirt', 'shorts') and price not in (81.0, 82.0, 78.0, 1.0, 33.0);
+} {3|shirt|18.0
+4|sweater|25.0}
+
+do_execsql_test where_in_list_or_not_in_another_list {
+    select * from products where name in ('hat', 'sweatshirt', 'shorts') or price not in (82.0, 18.0, 78.0, 33.0, 81.0);
+} {1|hat|79.0
+4|sweater|25.0
+5|sweatshirt|74.0
+6|shorts|70.0
+9|boots|1.0}
+
+do_execsql_test where_in_empty_list {
+    select * from products where name in ();
+} {}
+
+do_execsql_test where_not_in_empty_list {
+    select * from products where name not in ();
+} {1|hat|79.0
+2|cap|82.0
+3|shirt|18.0
+4|sweater|25.0
+5|sweatshirt|74.0
+6|shorts|70.0
+7|jeans|78.0
+8|sneakers|82.0
+9|boots|1.0
+10|coat|33.0
+11|accessories|81.0}
+
+do_execsql_test where_name_in_list_and_price_gt_70_or_name_exactly_boots {
+    select * from products where name in ('hat', 'sweatshirt', 'shorts') and price > 70 or name = 'boots';
+} {1|hat|79.0
+5|sweatshirt|74.0
+9|boots|1.0}
+
+do_execsql_test where_name_in_list_or_price_gt_70_and_name_like_shirt {
+    select * from products where name in ('hat', 'shorts') or price > 70 and name like '%shirt%';
+} {1|hat|79.0
+5|sweatshirt|74.0
+6|shorts|70.0}
+
+do_execsql_test where_name_not_in_list_or_name_eq_shirt {
+    select * from products where name not in ('shirt', 'boots') or name = 'shirt';
+} {1|hat|79.0
+2|cap|82.0
+3|shirt|18.0
+4|sweater|25.0
+5|sweatshirt|74.0
+6|shorts|70.0
+7|jeans|78.0
+8|sneakers|82.0
+10|coat|33.0
+11|accessories|81.0}


### PR DESCRIPTION
Fixes #154 

Implemented for now using as a series of OR checks (`foo IN (...)`) or AND checks (`foo NOT IN (...)`). SQLite uses a similar approach for small lists of values and starts making ephemeral indexes for larger lists. For now we just always do SQLite's "small list" approach since we don't have all the plumbing for ephemeral indexes yet.

I also refactored `translate_condition_expr` to take a `ConditionMetadata` argument always containing explicit success/failure jump labels plus `jump_on_success: bool`, which at least to my dumb ass, made the code a bit clearer. Your mileage may vary.