### PR TITLE
Optimize constant conditions

### DIFF
--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -526,7 +526,8 @@ fn translate_tables_begin(
     for loop_info in &select.loops {
         // early_terminate_label decides where to jump _IF_ there exists a condition on this loop that is always false.
         // this is part of a constant folding optimization where we can skip the loop entirely if we know it will never produce any rows.
-        let early_terminate_label = if let Some(left_join) = &loop_info.left_join_maybe {
+        let current_loop_early_terminate_label = if let Some(left_join) = &loop_info.left_join_maybe
+        {
             // If there exists a condition on the LEFT JOIN that is always false, e.g.:
             // 'SELECT * FROM x LEFT JOIN y ON false'
             // then we can't jump to e.g. Halt, but instead we need to still emit all rows from the 'x' table, with NULLs for the 'y' table.
@@ -544,7 +545,7 @@ fn translate_tables_begin(
             select,
             loop_info,
             &processed_where,
-            early_terminate_label,
+            current_loop_early_terminate_label,
         )?;
     }
 

--- a/testing/join.test
+++ b/testing/join.test
@@ -56,6 +56,18 @@ do_execsql_test inner-join-self-with-where {
 #    select u.first_name from users u join products as p on u.first_name != p.name where u.last_name = 'Williams' limit 1;
 #} {Laura} <-- sqlite3 returns 'Aaron'
 
+do_execsql_test inner-join-constant-condition-true {
+    select u.first_name, p.name from users u join products as p where 1 limit 5;
+} {Jamie|hat
+Jamie|cap
+Jamie|shirt
+Jamie|sweater
+Jamie|sweatshirt}
+
+do_execsql_test inner-join-constant-condition-false {
+    select u.first_name from users u join products as p where 0 limit 5;
+} {}
+
 do_execsql_test left-join-pk {
     select users.first_name as user_name, products.name as product_name from users left join products on users.id = products.id limit 12;
 } {Jamie|hat
@@ -133,6 +145,22 @@ do_execsql_test left-join-order-by-qualified-nullable-sorting-col {
     select users.first_name, products.name from users left join products on users.id = products.id order by products.name limit 1;
 } {Alan|}
 
+do_execsql_test left-join-constant-condition-true {
+    select u.first_name, p.name from users u left join products as p on 1 limit 5;
+} {Jamie|hat
+Jamie|cap
+Jamie|shirt
+Jamie|sweater
+Jamie|sweatshirt}
+
+do_execsql_test left-join-constant-condition-false {
+    select u.first_name, p.name from users u left join products as p on 0 limit 5;
+} {Jamie|
+Cindy|
+Tommy|
+Jennifer|
+Edward|}
+
 do_execsql_test four-way-inner-join {
   select u1.first_name, u2.first_name, u3.first_name, u4.first_name from users u1 join users u2 on u1.id = u2.id join users u3 on u2.id = u3.id + 1 join users u4 on u3.id = u4.id + 1 limit 1;
 } {Tommy|Tommy|Cindy|Jamie}
@@ -155,3 +183,15 @@ do_execsql_test innerjoin-leftjoin-with-or-terms {
   select u.first_name, u2.first_name, p.name from users u join users u2 on u.id = u2.id + 1 left join products p on p.name = u.first_name or p.name like 'sweat%' where u.first_name = 'Franklin';
 } {Franklin|Cynthia|sweater
 Franklin|Cynthia|sweatshirt}
+
+do_execsql_test left-join-constant-condition-false-inner-join-constant-condition-true {
+    select u.first_name, p.name, u2.first_name from users u left join products as p on 0 join users u2 on 1 limit 5;
+} {Jamie||Jamie
+Jamie||Cindy
+Jamie||Tommy
+Jamie||Jennifer
+Jamie||Edward}
+
+do_execsql_test left-join-constant-condition-true-inner-join-constant-condition-false {
+    select u.first_name, p.name, u2.first_name from users u left join products as p on 1 join users u2 on 0 limit 5;
+} {}

--- a/testing/where.test
+++ b/testing/where.test
@@ -40,12 +40,56 @@ do_execsql_test where-clause-unary-false {
     select count(1) from users where 0;
 } {0}
 
-do_execsql_test where-clause-no-table-unary-true {
+do_execsql_test where-clause-no-table-constant-condition-true {
     select 1 where 1;
 } {1}
 
-do_execsql_test where-clause-no-table-unary-false {
+do_execsql_test where-clause-no-table-constant-condition-true-2 {
+    select 1 where '1';
+} {1}
+
+do_execsql_test where-clause-no-table-constant-condition-true-3 {
+    select 1 where 6.66;
+} {1}
+
+do_execsql_test where-clause-no-table-constant-condition-true-4 {
+    select 1 where '6.66';
+} {1}
+
+do_execsql_test where-clause-no-table-constant-condition-true-5 {
+    select 1 where -1;
+} {1}
+
+do_execsql_test where-clause-no-table-constant-condition-true-6 {
+    select 1 where '-1';
+} {1}
+
+do_execsql_test where-clause-no-table-constant-condition-false {
     select 1 where 0;
+} {}
+
+do_execsql_test where-clause-no-table-constant-condition-false-2 {
+    select 1 where '0';
+} {}
+
+do_execsql_test where-clause-no-table-constant-condition-false-3 {
+    select 1 where 0.0;
+} {}
+
+do_execsql_test where-clause-no-table-constant-condition-false-4 {
+    select 1 where '0.0';
+} {}
+
+do_execsql_test where-clause-no-table-constant-condition-false-5 {
+    select 1 where -0.0;
+} {}
+
+do_execsql_test where-clause-no-table-constant-condition-false-6 {
+    select 1 where '-0.0';
+} {}
+
+do_execsql_test where-clause-no-table-constant-condition-false-7 {
+    select 1 where 'hamburger';
 } {}
 
 do_execsql_test select-where-and {


### PR DESCRIPTION
Example 1: jump immediately to halt when WHERE is always false

```
limbo> explain select first_name from users where 1 and 0;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     11    0                    0   Start at 11
1     OpenReadAsync      0     2     0                    0   root=2
2     OpenReadAwait      0     0     0                    0   
3     RewindAsync        0     0     0                    0   
4     RewindAwait        0     -5    0                    0   
5       Goto             0     10    0                    0   
6       Column           0     1     1                    0   r[1]=users.first_name
7       ResultRow        1     1     0                    0   output=r[1]
8     NextAsync          0     0     0                    0   
9     NextAwait          0     4     0                    0   
10    Halt               0     0     0                    0   
11    Transaction        0     0     0                    0   
12    Goto               0     1     0                    0
```

Example 2: don't emit a conditional when WHERE is always true

```
limbo> explain select first_name from users where 1 or 0;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     10    0                    0   Start at 10
1     OpenReadAsync      0     2     0                    0   root=2
2     OpenReadAwait      0     0     0                    0   
3     RewindAsync        0     0     0                    0   
4     RewindAwait        0     -5    0                    0   
5       Column           0     1     1                    0   r[1]=users.first_name
6       ResultRow        1     1     0                    0   output=r[1]
7     NextAsync          0     0     0                    0   
8     NextAwait          0     4     0                    0   
9     Halt               0     0     0                    0   
10    Transaction        0     0     0                    0   
11    Goto               0     1     0                    0
```

Example 3: in LEFT JOIN inner loop, jump immediately to setting the right cursor to null when the join condition is always false

```
limbo> explain select u.first_name, p.name from users u left join products p on 0;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     23    0                    0   Start at 23
1     OpenReadAsync      0     2     0                    0   root=2
2     OpenReadAwait      0     0     0                    0   
3     OpenReadAsync      1     3     0                    0   root=3
4     OpenReadAwait      0     0     0                    0   
5     RewindAsync        0     0     0                    0   
6     RewindAwait        0     -5    0                    0   
7       Integer          0     1     0                    0   r[1]=0
8       RewindAsync      1     0     0                    0   
9       RewindAwait      1     -11   0                    0   
10        Goto           0     17    0                    0   
11        Integer        1     1     0                    0   r[1]=1
12        Column         0     1     2                    0   r[2]=users.first_name
13        Column         1     1     3                    0   r[3]=products.name
14        ResultRow      2     2     0                    0   output=r[2..3]
15      NextAsync        1     0     0                    0   
16      NextAwait        1     9     0                    0   
17      IfPos            1     20    0                    0   r[1]>0 -> r[1]-=0, goto 20
18      NullRow          1     0     0                    0   Set cursor 1 to a (pseudo) NULL row
19      Goto             0     11    0                    0   
20    NextAsync          0     0     0                    0   
21    NextAwait          0     6     0                    0   
22    Halt               0     0     0                    0   
23    Transaction        0     0     0                    0   
24    Goto               0     1     0                    0   
limbo> explain select u.first_name, p.name from users u left join products p on 0 limit 5;
```

Example 4: three-way-join (a LEFT JOIN b ON TRUE JOIN c on FALSE), the left join condition is completely erased, but the code still jump immediately to halt because of the always-false inner join condition:

```
limbo> explain select u.first_name, p.name from users u left join products p on 1 join users u2 on 0;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     29    0                    0   Start at 29
1     OpenReadAsync      0     2     0                    0   root=2
2     OpenReadAwait      0     0     0                    0   
3     OpenReadAsync      1     3     0                    0   root=3
4     OpenReadAwait      0     0     0                    0   
5     OpenReadAsync      2     2     0                    0   root=2
6     OpenReadAwait      0     0     0                    0   
7     RewindAsync        0     0     0                    0   
8     RewindAwait        0     -5    0                    0   
9       Goto             0     28    0                    0   
10      Integer          0     1     0                    0   r[1]=0
11      RewindAsync      1     0     0                    0   
12      RewindAwait      1     -11   0                    0   
13        Integer        1     1     0                    0   r[1]=1
14        RewindAsync    2     0     0                    0   
15        RewindAwait    2     -14   0                    0   
16          Column       0     1     2                    0   r[2]=users.first_name
17          Column       1     1     3                    0   r[3]=products.name
18          ResultRow    2     2     0                    0   output=r[2..3]
19        NextAsync      2     0     0                    0   
20        NextAwait      2     15    0                    0   
21      NextAsync        1     0     0                    0   
22      NextAwait        1     12    0                    0   
23      IfPos            1     26    0                    0   r[1]>0 -> r[1]-=0, goto 26
24      NullRow          1     0     0                    0   Set cursor 1 to a (pseudo) NULL row
25      Goto             0     13    0                    0   
26    NextAsync          0     0     0                    0   
27    NextAwait          0     8     0                    0   
28    Halt               0     0     0                    0   
29    Transaction        0     0     0                    0   
30    Goto               0     1     0                    0 
```

This is OK I guess, but I noticed that SQLite immediately jumps to `Halt` even before `OpenRead` if it can, maybe we should also write it that way... the only consideration that you can only do that on constant-false conditions that are in a WHERE or an INNER JOIN.