### PR TITLE
Use SeekRowId to avoid nested scans

### DIFF
--- a/core/pseudo.rs
+++ b/core/pseudo.rs
@@ -46,6 +46,10 @@ impl Cursor for PseudoCursor {
         Ok(x)
     }
 
+    fn seek_rowid(&mut self, _: u64) -> Result<CursorResult<bool>> {
+        unimplemented!();
+    }
+
     fn record(&self) -> Result<Ref<Option<OwnedRecord>>> {
         Ok(self.current.borrow())
     }

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -193,7 +193,7 @@ impl BTreeCursor {
                         first_overflow_page: _,
                     }) => {
                         if *cell_rowid == rowid {
-                            let record = crate::sqlite3_ondisk::read_record(&p)?;
+                            let record = crate::storage::sqlite3_ondisk::read_record(p)?;
                             return Ok(CursorResult::Ok((Some(*cell_rowid), Some(record))));
                         }
                     }

--- a/core/translate/where_clause.rs
+++ b/core/translate/where_clause.rs
@@ -251,7 +251,7 @@ pub fn translate_processed_where<'a>(
                 let computed_rowid_reg = program.alloc_register();
                 let _ = translate_expr(
                     program,
-                    select,
+                    Some(select),
                     s.rowid_expr,
                     computed_rowid_reg,
                     cursor_hint,

--- a/core/translate/where_clause.rs
+++ b/core/translate/where_clause.rs
@@ -223,9 +223,10 @@ pub fn translate_processed_where<'a>(
     loops: &[LoopInfo],
     current_loop: &'a LoopInfo,
     where_c: &'a ProcessedWhereClause,
-    skip_entire_table_label: BranchOffset,
+    skip_entire_loop_label: BranchOffset,
     cursor_hint: Option<usize>,
 ) -> Result<()> {
+    // If any of the terms are always false, we can skip the entire loop.
     for t in where_c.terms.iter().filter(|t| {
         select.src_tables[t.evaluate_at_loop(select)].identifier == current_loop.identifier
     }) {
@@ -233,9 +234,9 @@ pub fn translate_processed_where<'a>(
             if e.is_always_false().unwrap_or(false) {
                 program.emit_insn_with_label_dependency(
                     Insn::Goto {
-                        target_pc: skip_entire_table_label,
+                        target_pc: skip_entire_loop_label,
                     },
-                    skip_entire_table_label,
+                    skip_entire_loop_label,
                 );
                 return Ok(());
             }

--- a/core/translate/where_clause.rs
+++ b/core/translate/where_clause.rs
@@ -277,6 +277,11 @@ pub fn translate_processed_where<'a>(
                     // and end up with a result where u.id = 3 and p.id = 5, which is incorrect.
                     // Instead we replace the second SeekRowid with a comparison against the row that was already fetched,
                     // i.e. we compare p.id == 5, which would not match (and is the correct result).
+                    //
+                    // It would probably be better to modify the AST in the WhereTerms directly, but that would require
+                    // refactoring to not use &'a Ast::Expr references in the WhereTerms, i.e. the WhereClause would own its data
+                    // and could mutate it to change the query as needed. We probably need to do this anyway if we want to have some
+                    // kind of Query Plan construct that is not just a container for AST nodes.
                     let rowid_reg = program.alloc_register();
                     program.emit_insn(Insn::RowId {
                         cursor_id,

--- a/core/types.rs
+++ b/core/types.rs
@@ -369,6 +369,7 @@ pub trait Cursor {
     fn next(&mut self) -> Result<CursorResult<()>>;
     fn wait_for_completion(&mut self) -> Result<()>;
     fn rowid(&self) -> Result<Option<u64>>;
+    fn seek_rowid(&mut self, rowid: u64) -> Result<CursorResult<bool>>;
     fn record(&self) -> Result<Ref<Option<OwnedRecord>>>;
     fn insert(
         &mut self,

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -270,6 +270,10 @@ impl ProgramBuilder {
                 } => {
                     *end_offset = to_offset;
                 }
+                Insn::SeekRowid { target_pc, .. } => {
+                    assert!(*target_pc < 0);
+                    *target_pc = to_offset;
+                }
                 _ => {
                     todo!("missing resolve_label for {:?}", insn);
                 }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -71,10 +71,13 @@ impl ProgramBuilder {
         (self.seekrowid_emitted_bitmask & (1 << cursor_id)) != 0
     }
 
+    fn set_cursor_emitted_seekrowid(&mut self, cursor_id: CursorID) {
+        self.seekrowid_emitted_bitmask |= 1 << cursor_id;
+    }
+
     fn _emit_insn(&mut self, insn: Insn) {
         if let Insn::SeekRowid { cursor_id, .. } = insn {
-            // set the nth bit to 1, where n is the cursor_id, and the first bit is 0
-            self.seekrowid_emitted_bitmask |= 1 << cursor_id;
+            self.set_cursor_emitted_seekrowid(cursor_id);
         }
         self.insns.push(insn);
     }

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -179,7 +179,14 @@ pub fn insn_to_str(program: &Program, addr: InsnReference, insn: &Insn, indent: 
                 0,
                 OwnedValue::Text(Rc::new("".to_string())),
                 0,
-                format!("root={}", root_page),
+                format!(
+                    "table={}, root={}",
+                    program.cursor_ref[*cursor_id]
+                        .0
+                        .as_ref()
+                        .unwrap_or(&format!("cursor {}", cursor_id)),
+                    root_page
+                ),
             ),
             Insn::OpenReadAwait => (
                 "OpenReadAwait",
@@ -222,14 +229,20 @@ pub fn insn_to_str(program: &Program, addr: InsnReference, insn: &Insn, indent: 
                 0,
                 OwnedValue::Text(Rc::new("".to_string())),
                 0,
-                "".to_string(),
+                format!(
+                    "Rewind table {}",
+                    program.cursor_ref[*cursor_id]
+                        .0
+                        .as_ref()
+                        .unwrap_or(&format!("cursor {}", cursor_id))
+                ),
             ),
             Insn::Column {
                 cursor_id,
                 column,
                 dest,
             } => {
-                let (_, table) = &program.cursor_ref[*cursor_id];
+                let (table_identifier, table) = &program.cursor_ref[*cursor_id];
                 (
                     "Column",
                     *cursor_id as i32,
@@ -240,10 +253,9 @@ pub fn insn_to_str(program: &Program, addr: InsnReference, insn: &Insn, indent: 
                     format!(
                         "r[{}]={}.{}",
                         dest,
-                        table
+                        table_identifier
                             .as_ref()
-                            .map(|x| x.get_name())
-                            .unwrap_or(format!("cursor {}", cursor_id).as_str()),
+                            .unwrap_or(&format!("cursor {}", cursor_id)),
                         table
                             .as_ref()
                             .and_then(|x| x.column_index_to_name(*column))
@@ -377,10 +389,9 @@ pub fn insn_to_str(program: &Program, addr: InsnReference, insn: &Insn, indent: 
                     "r[{}]={}.rowid",
                     dest,
                     &program.cursor_ref[*cursor_id]
-                        .1
+                        .0
                         .as_ref()
-                        .map(|x| x.get_name())
-                        .unwrap_or(format!("cursor {}", cursor_id).as_str())
+                        .unwrap_or(&format!("cursor {}", cursor_id))
                 ),
             ),
             Insn::SeekRowid {
@@ -398,10 +409,9 @@ pub fn insn_to_str(program: &Program, addr: InsnReference, insn: &Insn, indent: 
                     "if (r[{}]!={}.rowid) goto {}",
                     src_reg,
                     &program.cursor_ref[*cursor_id]
-                        .1
+                        .0
                         .as_ref()
-                        .map(|x| x.get_name())
-                        .unwrap_or(format!("cursor {}", cursor_id).as_str()),
+                        .unwrap_or(&format!("cursor {}", cursor_id)),
                     target_pc
                 ),
             ),

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -383,6 +383,28 @@ pub fn insn_to_str(program: &Program, addr: InsnReference, insn: &Insn, indent: 
                         .unwrap_or(format!("cursor {}", cursor_id).as_str())
                 ),
             ),
+            Insn::SeekRowid {
+                cursor_id,
+                src_reg,
+                target_pc,
+            } => (
+                "SeekRowid",
+                *cursor_id as i32,
+                *src_reg as i32,
+                *target_pc as i32,
+                OwnedValue::Text(Rc::new("".to_string())),
+                0,
+                format!(
+                    "if (r[{}]!={}.rowid) goto {}",
+                    src_reg,
+                    &program.cursor_ref[*cursor_id]
+                        .1
+                        .as_ref()
+                        .map(|x| x.get_name())
+                        .unwrap_or(format!("cursor {}", cursor_id).as_str()),
+                    target_pc
+                ),
+            ),
             Insn::DecrJumpZero { reg, target_pc } => (
                 "DecrJumpZero",
                 *reg as i32,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -435,6 +435,9 @@ impl Program {
                         (OwnedValue::Float(lhs), OwnedValue::Float(rhs)) => {
                             state.registers[dest] = OwnedValue::Float(lhs + rhs);
                         }
+                        ((OwnedValue::Null, _) | (_, OwnedValue::Null)) => {
+                            state.registers[dest] = OwnedValue::Null;
+                        }
                         _ => {
                             todo!();
                         }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -75,6 +75,10 @@ impl Cursor for Sorter {
         todo!();
     }
 
+    fn seek_rowid(&mut self, _: u64) -> Result<CursorResult<bool>> {
+        unimplemented!();
+    }
+
     fn record(&self) -> Result<Ref<Option<OwnedRecord>>> {
         Ok(self.current.borrow())
     }

--- a/testing/join.test
+++ b/testing/join.test
@@ -117,6 +117,11 @@ do_execsql_test left-join-self {
 } {Jamie|
 Cindy|Jamie}
 
+do_execsql_test left-join-self-2 {
+    select u1.first_name as user_name, u2.first_name as neighbor_name from users u1 left join users as u2 on u2.id = u1.id + 1 limit 2;
+} {Jamie|Cindy
+Cindy|Tommy}
+
 do_execsql_test left-join-self-with-where {
     select u1.first_name as user_name, u2.first_name as neighbor_name from users u1 left join users as u2 on u1.id = u2.id + 1 where u1.id = 5 limit 2;
 } {Edward|Jennifer}

--- a/testing/where.test
+++ b/testing/where.test
@@ -245,3 +245,11 @@ do_execsql_test where_name_not_in_list_or_name_eq_shirt {
 8|sneakers|82.0
 10|coat|33.0
 11|accessories|81.0}
+
+do_execsql_test where_multiple {
+    select id, first_name, age from users where id = 5 and age < 50;
+} {5|Edward|15}
+
+do_execsql_test where_multiple_flipped {
+    select id, first_name, age from users where age < 50 and id = 5;
+} {5|Edward|15}


### PR DESCRIPTION
The SQLite `SeekRowid` instruction tries to find a record in a B-tree table with a particular `rowid`  (or INTEGER PRIMARY KEY, if defined), and jumps if it is not found. In this PR, constraints like `tbl.id = 5` or `tbl.id = tbl2.id` are transformed into special `SeekRowid` expressions that emit `SeekRowid` VM instructions. This avoids a table scan and instead completes in `log N` time (for a table of `N` rows), because of how B-Trees work.


`LoopInfo` now contains a `Plan` which is either `Scan` or `SeekRowid` -- in the case of `SeekRowid` no `Rewind`/`Next` instructions are emitted - i.e. no looping is done.

`BTreeCursor` now implements a `btree_seek_rowid()` method that tries to find a row by `rowid`.

Our loop order is currently static, i.e. `SELECT * from a join b join c` always results in "loop a, loop b, loop c", so `SeekRowId` is only supported for equality expressions where the non-PK side of the expression only refers to outer loops or constants. Examples:

**Because `u.id` refers to an outer loop compared to the primary key `p.id`, `p` is selected for SeekRowid optimization:**
```
limbo> explain SELECT u.age FROM users u JOIN products p ON u.id = p.id

addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     14    0                    0   Start at 14
1     OpenReadAsync      0     2     0                    0   table=u, root=2
2     OpenReadAwait      0     0     0                    0   
3     OpenReadAsync      1     3     0                    0   table=p, root=3
4     OpenReadAwait      0     0     0                    0   
5     RewindAsync        0     0     0                    0   
6     RewindAwait        0     -5    0                    0   Rewind table u
7       RowId            0     1     0                    0   r[1]=u.rowid
8       SeekRowid        1     1     11                   0   if (r[1]!=p.rowid) goto 11
9       Column           0     9     2                    0   r[2]=u.age
10      ResultRow        2     1     0                    0   output=r[2]
11    NextAsync          0     0     0                    0   
12    NextAwait          0     6     0                    0   
13    Halt               0     0     0                    0   
14    Transaction        0     0     0                    0   
15    Goto               0     1     0                    0

limbo> SELECT u.age FROM users u JOIN products p ON u.id = p.id
94
37
18
33
15
89
24
63
77
13
22
```

**Because `5` refers to a constant and `u.id` is a primary key, `u` is selected for SeekRowid optimization:**
```
limbo> explain SELECT u.first_name, p.name FROM users u JOIN products p ON u.id = 5;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     15    0                    0   Start at 15
1     OpenReadAsync      0     2     0                    0   table=u, root=2
2     OpenReadAwait      0     0     0                    0   
3     OpenReadAsync      1     3     0                    0   table=p, root=3
4     OpenReadAwait      0     0     0                    0   
5     Integer            5     1     0                    0   r[1]=5
6     SeekRowid          0     1     14                   0   if (r[1]!=u.rowid) goto 14
7     RewindAsync        1     0     0                    0   
8     RewindAwait        1     -8    0                    0   Rewind table p
9       Column           0     1     2                    0   r[2]=u.first_name
10      Column           1     1     3                    0   r[3]=p.name
11      ResultRow        2     2     0                    0   output=r[2..3]
12    NextAsync          1     0     0                    0   
13    NextAwait          1     8     0                    0   
14    Halt               0     0     0                    0   
15    Transaction        0     0     0                    0   
16    Goto               0     1     0                    0   
limbo> SELECT u.first_name, p.name FROM users u JOIN products p ON u.id = 5;
Edward|hat
Edward|cap
Edward|shirt
Edward|sweater
Edward|sweatshirt
Edward|shorts
Edward|jeans
Edward|sneakers
Edward|boots
Edward|coat
Edward|accessories
```

**Same, but LEFT JOIN:**
```
limbo> EXPLAIN SELECT u.first_name, p.name FROM users u LEFT JOIN products p ON u.id = 5;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     20    0                    0   Start at 20
1     OpenReadAsync      0     2     0                    0   table=u, root=2
2     OpenReadAwait      0     0     0                    0   
3     OpenReadAsync      1     3     0                    0   table=p, root=3
4     OpenReadAwait      0     0     0                    0   
5     Integer            0     1     0                    0   r[1]=0
6     RewindAsync        1     0     0                    0   
7     RewindAwait        1     -11   0                    0   Rewind table p
8       Integer          5     2     0                    0   r[2]=5
9       SeekRowid        0     2     14                   0   if (r[2]!=u.rowid) goto 14
10      Integer          1     1     0                    0   r[1]=1
11      Column           0     1     3                    0   r[3]=u.first_name
12      Column           1     1     4                    0   r[4]=p.name
13      ResultRow        3     2     0                    0   output=r[3..4]
14    NextAsync          1     0     0                    0   
15    NextAwait          1     7     0                    0   
16    IfPos              1     19    0                    0   r[1]>0 -> r[1]-=0, goto 19
17    NullRow            1     0     0                    0   Set cursor 1 to a (pseudo) NULL row
18    Goto               0     10    0                    0   
19    Halt               0     0     0                    0   
20    Transaction        0     0     0                    0   
21    Goto               0     1     0                    0   
limbo> SELECT u.first_name, p.name FROM users u LEFT JOIN products p ON u.id = 5;
Edward|hat
Edward|cap
Edward|shirt
Edward|sweater
Edward|sweatshirt
Edward|shorts
Edward|jeans
Edward|sneakers
Edward|boots
Edward|coat
Edward|accessories
```

**Both `p` and `u` selected for optimization:**
```
limbo> EXPLAIN SELECT u.first_name, p.name FROM users u JOIN products p ON u.id = p.id and u.id = 5;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     13    0                    0   Start at 13
1     OpenReadAsync      0     2     0                    0   table=u, root=2
2     OpenReadAwait      0     0     0                    0   
3     OpenReadAsync      1     3     0                    0   table=p, root=3
4     OpenReadAwait      0     0     0                    0   
5     Integer            5     1     0                    0   r[1]=5
6     SeekRowid          0     1     12                   0   if (r[1]!=u.rowid) goto 12
7     RowId              0     2     0                    0   r[2]=u.rowid
8     SeekRowid          1     2     12                   0   if (r[2]!=p.rowid) goto 12
9     Column             0     1     3                    0   r[3]=u.first_name
10    Column             1     1     4                    0   r[4]=p.name
11    ResultRow          3     2     0                    0   output=r[3..4]
12    Halt               0     0     0                    0   
13    Transaction        0     0     0                    0   
14    Goto               0     1     0                    0   

limbo> SELECT u.first_name, p.name FROM users u JOIN products p ON u.id = p.id and u.id = 5;
Edward|sweatshirt
```

**`p.id + 1` refers to an INNER loop compared to the primary key `u.id`, so optimization is skipped:**
```
limbo> EXPLAIN SELECT u.age FROM users u JOIN products p ON u.id = p.id + 1;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     21    0                    0   Start at 21
1     OpenReadAsync      0     2     0                    0   table=u, root=2
2     OpenReadAwait      0     0     0                    0   
3     OpenReadAsync      1     3     0                    0   table=p, root=3
4     OpenReadAwait      0     0     0                    0   
5     RewindAsync        0     0     0                    0   
6     RewindAwait        0     -5    0                    0   Rewind table u
7       RewindAsync      1     0     0                    0   
8       RewindAwait      1     -8    0                    0   Rewind table p
9         RowId          0     1     0                    0   r[1]=u.rowid
10        RowId          1     3     0                    0   r[3]=p.rowid
11        Integer        1     4     0                    0   r[4]=1
12        Add            3     4     2                    0   r[2]=r[3]+r[4]
13        Ne             1     2     16                   0   if r[1]!=r[2] goto 16
14        Column         0     9     5                    0   r[5]=u.age
15        ResultRow      5     1     0                    0   output=r[5]
16      NextAsync        1     0     0                    0   
17      NextAwait        1     8     0                    0   
18    NextAsync          0     0     0                    0   
19    NextAwait          0     6     0                    0   
20    Halt               0     0     0                    0   
21    Transaction        0     0     0                    0   
22    Goto               0     1     0                    0   
limbo> SELECT u.age FROM users u JOIN products p ON u.id = p.id + 1;
37
18
33
15
89
24
63
77
13
22
18
```

This whole thing is a bit ad-hoc / "something that works" kind of thing, probably me and @benclmnt need to put our noses down into some books and start to actually build some sort of graph-based query planner after this...