### PR TITLE
draft: Lazily load records

### DIFF
--- a/core/pseudo.rs
+++ b/core/pseudo.rs
@@ -50,6 +50,11 @@ impl Cursor for PseudoCursor {
         Ok(self.current.borrow())
     }
 
+    fn value_at(&self, col: usize) -> Result<Option<OwnedValue>> {
+        let record = self.current.borrow();
+        return Ok(record.as_ref().map(|r| r.values[col].clone()));
+    }
+
     fn insert(
         &mut self,
         key: &OwnedValue,

--- a/core/types.rs
+++ b/core/types.rs
@@ -370,6 +370,7 @@ pub trait Cursor {
     fn wait_for_completion(&mut self) -> Result<()>;
     fn rowid(&self) -> Result<Option<u64>>;
     fn record(&self) -> Result<Ref<Option<OwnedRecord>>>;
+    fn value_at(&self, col: usize) -> Result<Option<OwnedValue>>;
     fn insert(
         &mut self,
         key: &OwnedValue,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -690,13 +690,9 @@ impl Program {
                     dest,
                 } => {
                     let cursor = cursors.get_mut(cursor_id).unwrap();
-                    if let Some(ref record) = *cursor.record()? {
+                    if let Some(record) = cursor.value_at(*column)? {
                         let null_flag = cursor.get_null_flag();
-                        state.registers[*dest] = if null_flag {
-                            OwnedValue::Null
-                        } else {
-                            record.values[*column].clone()
-                        };
+                        state.registers[*dest] = if null_flag { OwnedValue::Null } else { record };
                     } else {
                         state.registers[*dest] = OwnedValue::Null;
                     }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -79,6 +79,11 @@ impl Cursor for Sorter {
         Ok(self.current.borrow())
     }
 
+    fn value_at(&self, col: usize) -> Result<Option<OwnedValue>> {
+        let record = self.current.borrow();
+        return Ok(record.as_ref().map(|r| r.values[col].clone()));
+    }
+
     fn insert(
         &mut self,
         key: &OwnedValue,


### PR DESCRIPTION
Fix #30

```
Benchmarking limbo/Execute prepared statement: 'SELECT age FROM users': Collecting 100 samples in estimated 5.0002 s (
limbo/Execute prepared statement: 'SELECT age FROM users'
                        time:   [342.40 ns 342.76 ns 343.18 ns]
                        thrpt:  [2.9140 Melem/s 2.9175 Melem/s 2.9205 Melem/s]
                 change:
                        time:   [-3.3983% -3.0095% -2.6818%] (p = 0.00 < 0.05)
                        thrpt:  [+2.7557% +3.1029% +3.5178%]
                        Performance has improved.
```

but causes a 100% slowdown on `SELECT * FROM USERS` 😅