### PR TITLE
feat: add time() scalar function partial support without modifier #158

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -137,15 +137,15 @@ This document describes the SQLite compatibility status of Limbo:
 
 ### Date and time functions
 
-| Function                     | Status  | Comment |
-|------------------------------|---------|---------|
-| date()                       | Partial |     |
-| time()                       | No      |         |
-| datetime()                   | No      |         |
-| julianday()                  | No      |         |
-| unixepoch()                  | No      |         |
-| strftime()                   | No      |         |
-| timediff()                   | No      |         |
+| Function                     | Status  | Comment                |
+|------------------------------|---------|------------------------|
+| date()                       | Partial |                        |
+| time()                       | Partial | not supported modifier |
+| datetime()                   | No      |                        |
+| julianday()                  | No      |                        |
+| unixepoch()                  | No      |                        |
+| strftime()                   | No      |                        |
+| timediff()                   | No      |                        |
 
 ### JSON functions
 

--- a/core/error.rs
+++ b/core/error.rs
@@ -32,6 +32,8 @@ pub enum LimboError {
     ParseFloatError(#[from] std::num::ParseFloatError),
     #[error("Parse error: {0}")]
     InvalidDate(String),
+    #[error("Parse error: {0}")]
+    InvalidTime(String),
 }
 
 #[macro_export]

--- a/core/function.rs
+++ b/core/function.rs
@@ -41,6 +41,7 @@ pub enum ScalarFunc {
     Min,
     Max,
     Date,
+    Time,
     Unicode,
 }
 
@@ -61,6 +62,7 @@ impl ToString for ScalarFunc {
             ScalarFunc::Min => "min".to_string(),
             ScalarFunc::Max => "max".to_string(),
             ScalarFunc::Date => "date".to_string(),
+            ScalarFunc::Time => "time".to_string(),
             ScalarFunc::Unicode => "unicode".to_string(),
         }
     }
@@ -97,6 +99,7 @@ impl Func {
             "round" => Ok(Func::Scalar(ScalarFunc::Round)),
             "length" => Ok(Func::Scalar(ScalarFunc::Length)),
             "date" => Ok(Func::Scalar(ScalarFunc::Date)),
+            "time" => Ok(Func::Scalar(ScalarFunc::Time)),
             "unicode" => Ok(Func::Scalar(ScalarFunc::Unicode)),
             _ => Err(()),
         }

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -275,6 +275,30 @@ pub fn translate_expr(
                             });
                             Ok(target_register)
                         }
+                        ScalarFunc::Time => {
+                            let mut start_reg = 0;
+                            if let Some(args) = args {
+                                if args.len() > 1 {
+                                    crate::bail_parse_error!("date function with > 1 arguments. Modifiers are not yet supported.");
+                                } else if args.len() == 1 {
+                                    let arg_reg = program.alloc_register();
+                                    let _ = translate_expr(
+                                        program,
+                                        select,
+                                        &args[0],
+                                        arg_reg,
+                                        cursor_hint,
+                                    )?;
+                                    start_reg = arg_reg;
+                                }
+                            }
+                            program.emit_insn(Insn::Function {
+                                start_reg: start_reg,
+                                dest: target_register,
+                                func: ScalarFunc::Time,
+                            });
+                            Ok(target_register)
+                        }
                         ScalarFunc::Trim
                         | ScalarFunc::LTrim
                         | ScalarFunc::RTrim

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -22,7 +22,7 @@ pub mod explain;
 pub mod sorter;
 
 use crate::btree::BTreeCursor;
-use crate::datetime::get_date_from_time_value;
+use crate::datetime::{get_date_from_time_value, get_time_from_datetime_value};
 use crate::error::LimboError;
 use crate::function::{AggFunc, ScalarFunc};
 use crate::pager::Pager;
@@ -1247,6 +1247,29 @@ impl Program {
                             match date_str {
                                 Ok(date) => {
                                     state.registers[*dest] = OwnedValue::Text(Rc::new(date))
+                                }
+                                Err(e) => {
+                                    return Err(LimboError::ParseError(format!(
+                                        "Error encountered while parsing time value: {}",
+                                        e
+                                    )));
+                                }
+                            }
+                        }
+                        state.pc += 1;
+                    }
+                    ScalarFunc::Time => {
+                        if *start_reg == 0 {
+                            let time_str = get_time_from_datetime_value(&OwnedValue::Text(
+                                Rc::new("now".to_string()),
+                            ))?;
+                            state.registers[*dest] = OwnedValue::Text(Rc::new(time_str));
+                        } else {
+                            let datetime_value = &state.registers[*start_reg];
+                            let time_str = get_time_from_datetime_value(datetime_value);
+                            match time_str {
+                                Ok(time) => {
+                                    state.registers[*dest] = OwnedValue::Text(Rc::new(time))
                                 }
                                 Err(e) => {
                                     return Err(LimboError::ParseError(format!(

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -315,6 +315,86 @@ do_execsql_test date-with-invalid-timezone {
   SELECT date('2023-05-18 15:30:45+25:00');
 } {{}}
 
+do_execsql_test time-no-arg {
+  SELECT length(time()) = 8;
+} {1}
+
+do_execsql_test time-current-time {
+  SELECT length(time('now')) = 8;
+} {1}
+
+do_execsql_test time-specific-time {
+  SELECT time('04:02:00');
+} {04:02:00}
+
+do_execsql_test time-of-datetime {
+  SELECT time('2023-05-18 15:30:45');
+} {15:30:45}
+
+do_execsql_test time-iso8601 {
+  SELECT time('2023-05-18T15:30:45');
+} {15:30:45}
+
+do_execsql_test time-with-milliseconds {
+  SELECT time('2023-05-18 15:30:45.123');
+} {15:30:45}
+
+do_execsql_test time-julian-day-integer {
+  SELECT time(2460082);
+} {12:00:00}
+
+do_execsql_test time-julian-day-float {
+  SELECT time(2460082.2);
+} {16:48:00}
+
+do_execsql_test time-invalid-input {
+  SELECT time('not a time');
+} {{}}
+
+do_execsql_test time-null-input {
+  SELECT time(NULL);
+} {{}}
+
+do_execsql_test time-out-of-range {
+  SELECT time('25:05:01');
+} {{}}
+
+do_execsql_test time-date-only {
+  SELECT time('2024-02-02');
+} {00:00:00}
+
+do_execsql_test time-with-timezone-utc {
+  SELECT time('2023-05-18 15:30:45Z');
+} {15:30:45}
+
+do_execsql_test time-with-timezone-positive {
+  SELECT time('2023-05-18 23:30:45+07:00');
+} {16:30:45}
+
+do_execsql_test time-with-timezone-negative {
+  SELECT time('2023-05-19 01:30:45-05:00');
+} {06:30:45}
+
+do_execsql_test time-with-timezone-day-change-positive {
+  SELECT time('2023-05-18 23:30:45-03:00');
+} {02:30:45}
+
+do_execsql_test time-with-timezone-day-change-negative {
+  SELECT time('2023-05-19 01:30:45+03:00');
+} {22:30:45}
+
+do_execsql_test time-with-timezone-iso8601 {
+  SELECT time('2023-05-18T15:30:45+02:00');
+} {13:30:45}
+
+do_execsql_test time-with-timezone-and-milliseconds {
+  SELECT time('2023-05-18 15:30:45.123+02:00');
+} {13:30:45}
+
+do_execsql_test time-with-invalid-timezone {
+  SELECT time('2023-05-18 15:30:45+25:00');
+} {{}}
+
 do_execsql_test unicode-a {
   SELECT unicode('a');
 } {97}


### PR DESCRIPTION
Partially support time() scalar function tracked by #158 (not supported modifier yet).
ref: https://www.sqlite.org/lang_datefunc.html

Existing date() function support

```
limbo> explain select date();
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     4     0                    0   Start at 4
1     Function           1     0     1     date           0   r[1]=func(r[0..])
2     ResultRow          1     1     0                    0   output=r[1]
3     Halt               0     0     0                    0
4     Transaction        0     0     0                    0
5     Goto               0     1     0                    0
```

added time()
```
limbo> explain select time();
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     4     0                    0   Start at 4
1     Function           1     0     1     time           0   r[1]=func(r[0..])
2     ResultRow          1     1     0                    0   output=r[1]
3     Halt               0     0     0                    0
4     Transaction        0     0     0                    0
5     Goto               0     1     0                    0

limbo> select time();
06:14:08
limbo> select time('2023-05-18 23:30:45+07:00');
16:30:45
limbo> select time('invalid');

limbo> select time('now');
06:15:17
```


