### PR TITLE
update flake and add darwin link flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,20 @@
 MINIMUM_RUST_VERSION := 1.73.0
 CURRENT_RUST_VERSION := $(shell rustc -V | sed -E 's/rustc ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 RUSTUP := $(shell command -v rustup 2> /dev/null)
+UNAME_S := $(shell uname -s)
 
 # Executable used to execute the compatibility tests.
 SQLITE_EXEC ?= ./target/debug/limbo
 
 # Static library to use for SQLite C API compatibility tests.
-SQLITE_LIB ?= ./target/debug/liblimbo_sqlite3.a
+BASE_SQLITE_LIB = ./target/debug/liblimbo_sqlite3.a
+
+# On darwin link core foundation
+ifeq ($(UNAME_S),Darwin)
+    SQLITE_LIB ?= ../../$(BASE_SQLITE_LIB) -framework CoreFoundation
+else
+    SQLITE_LIB ?= ../../$(BASE_SQLITE_LIB)
+endif
 
 all: check-rust-version check-wasm-target limbo limbo-wasm
 .PHONY: all
@@ -52,5 +60,5 @@ test-compat:
 .PHONY: test-compat
 
 test-sqlite3:
-	LIBS=../../$(SQLITE_LIB) make -C sqlite3/tests test
+	LIBS="$(SQLITE_LIB)" make -C sqlite3/tests test
 .PHONY: test-sqlite3

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,11 @@
     };
   };
 
-  outputs = { nixpkgs, fenix, ... }: let
+  outputs = {
+    nixpkgs,
+    fenix,
+    ...
+  }: let
     systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
     forAllSystems = nixpkgs.lib.genAttrs systems;
   in {
@@ -18,18 +22,25 @@
         pkgs = nixpkgs.legacyPackages.${system};
         rustStable = fenix.packages.${system}.stable.toolchain;
         wasmTarget = fenix.packages.${system}.targets.wasm32-wasi.latest.rust-std;
+        extraDarwinInputs =
+          if pkgs.stdenv.isDarwin
+          then [pkgs.darwin.apple_sdk.frameworks.CoreFoundation]
+          else [];
       in {
         default = with pkgs;
           mkShell {
-            buildInputs = [
-              clang
-              libiconv
-              sqlite
-              gnumake
-              rustup # not used to install the toolchain, but the makefile uses it
-              rustStable
-              wasmTarget
-            ];
+            buildInputs =
+              [
+                clang
+                libiconv
+                sqlite
+                gnumake
+                rustup # not used to install the toolchain, but the makefile uses it
+                rustStable
+                wasmTarget
+                tcl
+              ]
+              ++ extraDarwinInputs;
           };
       }
     );


### PR DESCRIPTION
this pr:
 - updates the nix flake to include tcl 8.6 addressing #243 
 - updates the nix flake to add the darwin "core foundation" lib
 - updates the make flake to link the core foundation lib on darwin

I was previously unable to run `make test-sqlite3` with this error: https://gist.github.com/ethanniser/5b96888637da6ea9e9d56dcc3af9b573

but now it is able to run

although I am aware this might be just a me issue I have to work around, rather than something that belongs proper in the makefile so open to thoughts there

thanks as always