### PR TITLE
update cargo-dist and enable PS installer/github attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@
 
 name: Release
 permissions:
+  "attestations": "write"
   "contents": "write"
+  "id-token": "write"
 
 # This task will run whenever you push a git tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
@@ -132,6 +134,10 @@ jobs:
           # Actually do builds and make zips and whatnot
           cargo dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "cargo dist ran successfully"
+      - name: Attest
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       - id: cargo-dist
         name: Post-build
         # We force bash here just because github makes it really hard to get values up

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ install-path = "~/.limbo"
 install-updater = true
 # Whether to consider the binaries in a package for distribution (defaults true)
 dist = false
+# Whether to enable GitHub Attestations
+github-attestations = true
 
 [profile.dist]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,23 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/penberg/limbo"
 
+# Config for 'cargo dist'
 [workspace.metadata.dist]
+# The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.19.1"
+# CI backends to support
 ci = "github"
-installers = ["shell"]
+# The installers to generate for each app
+installers = ["shell", "powershell"]
+# Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+# Publish jobs to run in CI
 pr-run-mode = "plan"
-install-path = "~/.limbo/"
+# Path that installers should place binaries in
+install-path = "~/.limbo"
+# Whether to install an updater program
 install-updater = true
+# Whether to consider the binaries in a package for distribution (defaults true)
 dist = false
 
 [profile.dist]


### PR DESCRIPTION
saw you were building a windows bin but not a ps installer and thought i would turn it off. also turned on github attestations because why not.


`cargo dist plan` is basically the same as before but now also produces the PS installer.
```
announcing v0.0.3
  limbo 0.0.3
    source.tar.gz
      [checksum] source.tar.gz.sha256
    limbo-installer.sh
    limbo-installer.ps1
    limbo-aarch64-apple-darwin-update
    limbo-aarch64-apple-darwin.tar.xz
      [bin] limbo
      [misc] CHANGELOG.md, LICENSE.md, README.md
      [checksum] limbo-aarch64-apple-darwin.tar.xz.sha256
    limbo-x86_64-apple-darwin-update
    limbo-x86_64-apple-darwin.tar.xz
      [bin] limbo
      [misc] CHANGELOG.md, LICENSE.md, README.md
      [checksum] limbo-x86_64-apple-darwin.tar.xz.sha256
    limbo-x86_64-pc-windows-msvc-update
    limbo-x86_64-pc-windows-msvc.zip
      [bin] limbo.exe
      [misc] CHANGELOG.md, LICENSE.md, README.md
      [checksum] limbo-x86_64-pc-windows-msvc.zip.sha256
    limbo-x86_64-unknown-linux-gnu-update
    limbo-x86_64-unknown-linux-gnu.tar.xz
      [bin] limbo
      [misc] CHANGELOG.md, LICENSE.md, README.md
      [checksum] limbo-x86_64-unknown-linux-gnu.tar.xz.sha256
  ```