### PR TITLE
fix: ctrl-c stop current query execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -488,6 +494,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345"
+dependencies = [
+ "nix 0.28.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1014,6 +1030,7 @@ dependencies = [
  "anyhow",
  "clap 4.5.8",
  "cli-table",
+ "ctrlc",
  "dirs",
  "env_logger 0.10.2",
  "limbo_core",
@@ -1151,13 +1168,25 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,7 @@ dist = true
 name = "limbo"
 path = "main.rs"
 
+
 [dependencies]
 anyhow = "1.0.75"
 clap = { version = "4.4.0", features = ["derive"] }
@@ -25,3 +26,4 @@ dirs = "5.0.1"
 env_logger = "0.10.1"
 limbo_core = { path = "../core" }
 rustyline = "12.0.0"
+ctrlc = "3.4.4"


### PR DESCRIPTION
Fix #260 by ensuring `Ctrl-C` interrupts the query without terminating the process. Implement the SQLite strategy where pressing `Ctrl-C` twice exits the shell