### PR TITLE
Use the correct integer PK column idx as the row-id alias

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -393,9 +393,9 @@ pub fn translate_expr(
         ast::Expr::FunctionCallStar { .. } => todo!(),
         ast::Expr::Id(ident) => {
             // let (idx, col) = table.unwrap().get_column(&ident.0).unwrap();
-            let (idx, col_type, cursor_id, is_primary_key) =
+            let (idx, col_type, cursor_id, is_rowid_alias) =
                 resolve_ident_table(program, &ident.0, select, cursor_hint)?;
-            if is_primary_key {
+            if is_rowid_alias {
                 program.emit_insn(Insn::RowId {
                     cursor_id,
                     dest: target_register,
@@ -648,12 +648,12 @@ pub fn resolve_ident_table(
                     .iter()
                     .enumerate()
                     .find(|(_, col)| col.name == *ident)
-                    .map(|(idx, col)| (idx, col.ty, col.primary_key));
+                    .map(|(idx, col)| (idx, col.ty, table.column_is_rowid_alias(col)));
                 let mut idx;
                 let mut col_type;
-                let mut is_primary_key;
+                let mut is_rowid_alias;
                 if res.is_some() {
-                    (idx, col_type, is_primary_key) = res.unwrap();
+                    (idx, col_type, is_rowid_alias) = res.unwrap();
                     // overwrite if cursor hint is provided
                     if let Some(cursor_hint) = cursor_hint {
                         let cols = &program.cursor_ref[cursor_hint].1;
@@ -665,11 +665,11 @@ pub fn resolve_ident_table(
                         }) {
                             idx = res.0;
                             col_type = res.1.ty;
-                            is_primary_key = res.1.primary_key;
+                            is_rowid_alias = table.column_is_rowid_alias(res.1);
                         }
                     }
                     let cursor_id = program.resolve_cursor_id(&join.identifier, cursor_hint);
-                    found.push((idx, col_type, cursor_id, is_primary_key));
+                    found.push((idx, col_type, cursor_id, is_rowid_alias));
                 }
             }
             Table::Pseudo(_) => todo!(),

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -128,15 +128,17 @@ pub fn translate_insert(
     );
 
     if table.has_rowid() {
-        let key_reg = column_registers_start + 1;
         let row_id_reg = column_registers_start;
-        // copy key to rowid
-        program.emit_insn(Insn::Copy {
-            src_reg: key_reg,
-            dst_reg: row_id_reg,
-            amount: 0,
-        });
-        program.emit_insn(Insn::SoftNull { reg: key_reg });
+        if let Some(rowid_alias_column) = table.get_rowid_alias_column() {
+            let key_reg = column_registers_start + 1 + rowid_alias_column.0;
+            // copy key to rowid
+            program.emit_insn(Insn::Copy {
+                src_reg: key_reg,
+                dst_reg: row_id_reg,
+                amount: 0,
+            });
+            program.emit_insn(Insn::SoftNull { reg: key_reg });
+        }
 
         let notnull_label = program.allocate_label();
         program.emit_insn_with_label_dependency(


### PR DESCRIPTION
This pull request addresses [issue #256](https://github.com/penberg/limbo/issues/256). 

However, it currently breaks insertions into tables that lack a row-id alias due to the NewRowId not being implemented yet. I have created an [issue](https://github.com/penberg/limbo/issues/275) to track this problem and will submit a separate pull request to resolve it soon.