### PR TITLE
github: Cache Rust build dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Check formatting
       run: cargo fmt --check
+
   build-native:
     strategy:
       matrix:
@@ -24,6 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    - uses: Swatinem/rust-cache@v2
     - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose


### PR DESCRIPTION
Let's use a Github action to cache build dependencies in hopes to reduce
disk utilization.