### PR TITLE
Use `limbo` instead of `cargo run` in command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pipenv run ./testing/gen-database.py
 You can then start the Limbo shell with:
 
 ```console
-$ cargo run database.db
+$ limbo database.db
 Welcome to Limbo SQL shell!
 > SELECT * FROM users LIMIT 1;
 |1|Cody|Miller|mhurst@example.org|525.595.7319x21268|33667 Shaw Extension Suite 104|West Robert|VA|45161|`


### PR DESCRIPTION
Use `limbo` instead of `cargo run` in the example command in the README since we've already installed the program and have it on our path.