### PR TITLE
Handle count(*)

### DIFF
--- a/testing/agg-functions.test
+++ b/testing/agg-functions.test
@@ -35,6 +35,10 @@ do_execsql_test select-count {
   SELECT count(id) FROM users;
 } {10000}
 
+do_execsql_test select-count {
+  SELECT count(*) FROM users;
+} {10000}
+
 do_execsql_test select-max {
   SELECT max(age) FROM users;
 } {100}


### PR DESCRIPTION
This PR adds support for `count(*)`. I did not find any other functions than `count` which expect a `*` argument yet, but I'm sure there are some?

Surprisingly (to me) I did not need to make any changes to `translate_expr`, only to `analyze_expr`.

```
limbo> SELECT count(id) FROM users;
2
limbo> SELECT count(*) FROM users;
2
limbo> SELECT count(*) FROM users where id = 1;
1
limbo> SELECT count(id) FROM users where id = 1;
1
```

Other aggregation functions such as sum fail, since they expect a specific column:
```
limbo> select sum(*) from users;
Parse error: sum bad number of arguments
```