### PR TITLE
core: fix concat function wrong start_register

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -734,7 +734,7 @@ pub fn translate_expr(
                                 translate_expr(program, referenced_tables, arg, reg, cursor_hint)?;
                             }
                             program.emit_insn(Insn::Function {
-                                start_reg: target_register,
+                                start_reg: target_register + 1,
                                 dest: target_register,
                                 func: crate::vdbe::Func::Scalar(srf),
                             });


### PR DESCRIPTION
## What does PR do?
- fix concat function wrong start_register

## Current behavior
- addr 4 `r[1]=func(r[1..])`
- `r[1]` is target register to store the result, should not be the start reg of the function arguments
- it should be `r[1]=func(r[2..])` where 
  - `r[2]` is the start of arguments
  - `r[1]` is target register to store the result
  
```
limbo> explain SELECT concat('SQLite',' ','Concat') result;
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     7     0                    0   Start at 7
1     String8            0     2     0     SQLite         0   r[2]='SQLite'
2     String8            0     3     0                    0   r[3]=' '
3     String8            0     4     0     Concat         0   r[4]='Concat'
4     Function           1     1     1     concat         0   r[1]=func(r[1..])
5     ResultRow          1     1     0                    0   output=r[1]
6     Halt               0     0     0                    0
7     Transaction        0     0     0                    0
8     Goto               0     1     0                    0
```

## Expected behavior after the fix
- `r[1]=func(r[2..])` where `r[2]` is the start of arguments

```
limbo> explain SELECT concat('SQLite',' ','Concat') result;

addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     7     0                    0   Start at 7
1     String8            0     2     0     SQLite         0   r[2]='SQLite'
2     String8            0     3     0                    0   r[3]=' '
3     String8            0     4     0     Concat         0   r[4]='Concat'
4     Function           1     2     1     concat         0   r[1]=func(r[2..])
5     ResultRow          1     1     0                    0   output=r[1]
6     Halt               0     0     0                    0
7     Transaction        0     0     0                    0
8     Goto               0     1     0                    0
```



