### PR TITLE
GROUP BY support

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -45,7 +45,7 @@ This document describes the SQLite compatibility status of Limbo:
 | SELECT ... WHERE ... LIKE    | Yes     |         |
 | SELECT ... LIMIT             | Yes     |         |
 | SELECT ... ORDER BY          | Partial |         |
-| SELECT ... GROUP BY          | No      |         |
+| SELECT ... GROUP BY          | Partial |         |
 | SELECT ... JOIN              | Partial |         |
 | SELECT ... CROSS JOIN        | Partial |         |
 | SELECT ... INNER JOIN        | Partial |         |

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -198,7 +198,7 @@ impl Connection {
                     match stmt {
                         ast::Stmt::Select(select) => {
                             let plan = prepare_select_plan(&self.schema, select)?;
-                            let plan = optimize_plan(plan)?;
+                            let (plan, _) = optimize_plan(plan)?;
                             println!("{}", plan);
                         }
                         _ => todo!(),

--- a/core/pseudo.rs
+++ b/core/pseudo.rs
@@ -41,7 +41,9 @@ impl Cursor for PseudoCursor {
             .as_ref()
             .map(|record| match record.values[0] {
                 OwnedValue::Integer(rowid) => rowid as u64,
-                _ => panic!("Expected integer value"),
+                ref ov => {
+                    panic!("Expected integer value, got {:?}", ov);
+                }
             });
         Ok(x)
     }

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -95,6 +95,13 @@ impl Table {
         }
     }
 
+    pub fn get_column_at(&self, index: usize) -> &Column {
+        match self {
+            Table::BTree(table) => table.columns.get(index).unwrap(),
+            Table::Pseudo(table) => table.columns.get(index).unwrap(),
+        }
+    }
+
     pub fn columns(&self) -> &Vec<Column> {
         match self {
             Table::BTree(table) => &table.columns,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -93,6 +93,7 @@ pub fn translate_insert(
                                 expr,
                                 column_registers_start + col,
                                 None,
+                                None,
                             )?;
                         }
                         program.emit_insn(Insn::Yield {

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -14,6 +14,6 @@ pub fn translate_select(
     database_header: Rc<RefCell<DatabaseHeader>>,
 ) -> Result<Program> {
     let select_plan = prepare_select_plan(schema, select)?;
-    let optimized_plan = optimize_plan(select_plan)?;
-    emit_program(database_header, optimized_plan)
+    let (optimized_plan, expr_result_cache) = optimize_plan(select_plan)?;
+    emit_program(database_header, optimized_plan, expr_result_cache)
 }

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -288,6 +288,16 @@ impl ProgramBuilder {
                     assert!(*target_pc < 0);
                     *target_pc = to_offset;
                 }
+                Insn::Gosub { target_pc, .. } => {
+                    assert!(*target_pc < 0);
+                    *target_pc = to_offset;
+                }
+                Insn::Jump { target_pc_eq, .. } => {
+                    // FIXME: this current implementation doesnt scale for insns that
+                    // have potentially multiple label dependencies.
+                    assert!(*target_pc_eq < 0);
+                    *target_pc_eq = to_offset;
+                }
                 _ => {
                     todo!("missing resolve_label for {:?}", insn);
                 }
@@ -313,6 +323,10 @@ impl ProgramBuilder {
                     .is_some_and(|ident| ident == table_identifier)
             })
             .unwrap()
+    }
+
+    pub fn resolve_cursor_to_table(&self, cursor_id: CursorID) -> Option<Table> {
+        self.cursor_ref[cursor_id].1.clone()
     }
 
     pub fn resolve_deferred_labels(&mut self) {

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -70,9 +70,10 @@ pub enum Insn {
     Init {
         target_pc: BranchOffset,
     },
-    // Set NULL in the given register.
+    // Write a NULL into register dest. If dest_end is Some, then also write NULL into register dest_end and every register in between dest and dest_end. If dest_end is not set, then only register dest is set to NULL.
     Null {
         dest: usize,
+        dest_end: Option<usize>,
     },
     // Move the cursor P1 to a null row. Any Column operations that occur while the cursor is on the null row will always write a NULL.
     NullRow {
@@ -83,6 +84,30 @@ pub enum Insn {
         lhs: usize,
         rhs: usize,
         dest: usize,
+    },
+    // Multiply two registers and store the result in a third register.
+    Multiply {
+        lhs: usize,
+        rhs: usize,
+        dest: usize,
+    },
+    // Compare two vectors of registers in reg(P1)..reg(P1+P3-1) (call this vector "A") and in reg(P2)..reg(P2+P3-1) ("B"). Save the result of the comparison for use by the next Jump instruct.
+    Compare {
+        start_reg_a: usize,
+        start_reg_b: usize,
+        count: usize,
+    },
+    // Jump to the instruction at address P1, P2, or P3 depending on whether in the most recent Compare instruction the P1 vector was less than, equal to, or greater than the P2 vector, respectively.
+    Jump {
+        target_pc_lt: BranchOffset,
+        target_pc_eq: BranchOffset,
+        target_pc_gt: BranchOffset,
+    },
+    // Move the P3 values in register P1..P1+P3-1 over into registers P2..P2+P3-1. Registers P1..P1+P3-1 are left holding a NULL. It is an error for register ranges P1..P1+P3-1 and P2..P2+P3-1 to overlap. It is an error for P3 to be less than 1.
+    Move {
+        source_reg: usize,
+        dest_reg: usize,
+        count: usize,
     },
     // If the given register is a positive integer, decrement it by decrement_by and jump to the given PC.
     IfPos {
@@ -212,6 +237,17 @@ pub enum Insn {
     // Branch to the given PC.
     Goto {
         target_pc: BranchOffset,
+    },
+
+    // Stores the current program counter into register 'return_reg' then jumps to address target_pc.
+    Gosub {
+        target_pc: BranchOffset,
+        return_reg: usize,
+    },
+
+    // Returns to the program counter stored in register 'return_reg'.
+    Return {
+        return_reg: usize,
     },
 
     // Write an integer value into a register.
@@ -382,6 +418,7 @@ pub struct ProgramState {
     pub pc: BranchOffset,
     cursors: RefCell<BTreeMap<CursorID, Box<dyn Cursor>>>,
     registers: Vec<OwnedValue>,
+    last_compare: Option<std::cmp::Ordering>,
     ended_coroutine: bool, // flag to notify yield coroutine finished
     regex_cache: HashMap<String, Regex>,
 }
@@ -395,6 +432,7 @@ impl ProgramState {
             pc: 0,
             cursors,
             registers,
+            last_compare: None,
             ended_coroutine: false,
             regex_cache: HashMap::new(),
         }
@@ -464,19 +502,190 @@ impl Program {
                         (OwnedValue::Null, _) | (_, OwnedValue::Null) => {
                             state.registers[dest] = OwnedValue::Null;
                         }
+                        (OwnedValue::Agg(aggctx), other) | (other, OwnedValue::Agg(aggctx)) => {
+                            match other {
+                                OwnedValue::Null => {
+                                    state.registers[dest] = OwnedValue::Null;
+                                }
+                                OwnedValue::Integer(i) => match aggctx.final_value() {
+                                    OwnedValue::Float(acc) => {
+                                        state.registers[dest] = OwnedValue::Float(acc + *i as f64);
+                                    }
+                                    OwnedValue::Integer(acc) => {
+                                        state.registers[dest] = OwnedValue::Integer(acc + i);
+                                    }
+                                    _ => {
+                                        todo!("{:?}", aggctx);
+                                    }
+                                },
+                                OwnedValue::Float(f) => match aggctx.final_value() {
+                                    OwnedValue::Float(acc) => {
+                                        state.registers[dest] = OwnedValue::Float(acc + f);
+                                    }
+                                    OwnedValue::Integer(acc) => {
+                                        state.registers[dest] = OwnedValue::Float(*acc as f64 + f);
+                                    }
+                                    _ => {
+                                        todo!("{:?}", aggctx);
+                                    }
+                                },
+                                OwnedValue::Agg(aggctx2) => {
+                                    let acc = aggctx.final_value();
+                                    let acc2 = aggctx2.final_value();
+                                    match (acc, acc2) {
+                                        (OwnedValue::Integer(acc), OwnedValue::Integer(acc2)) => {
+                                            state.registers[dest] = OwnedValue::Integer(acc + acc2);
+                                        }
+                                        (OwnedValue::Float(acc), OwnedValue::Float(acc2)) => {
+                                            state.registers[dest] = OwnedValue::Float(acc + acc2);
+                                        }
+                                        (OwnedValue::Integer(acc), OwnedValue::Float(acc2)) => {
+                                            state.registers[dest] =
+                                                OwnedValue::Float(*acc as f64 + acc2);
+                                        }
+                                        (OwnedValue::Float(acc), OwnedValue::Integer(acc2)) => {
+                                            state.registers[dest] =
+                                                OwnedValue::Float(acc + *acc2 as f64);
+                                        }
+                                        _ => {
+                                            todo!("{:?} {:?}", acc, acc2);
+                                        }
+                                    }
+                                }
+                                rest => unimplemented!("{:?}", rest),
+                            }
+                        }
                         _ => {
                             todo!();
                         }
                     }
                     state.pc += 1;
                 }
-                Insn::Null { dest } => {
-                    state.registers[*dest] = OwnedValue::Null;
+                Insn::Multiply { lhs, rhs, dest } => {
+                    let lhs = *lhs;
+                    let rhs = *rhs;
+                    let dest = *dest;
+                    match (&state.registers[lhs], &state.registers[rhs]) {
+                        (OwnedValue::Integer(lhs), OwnedValue::Integer(rhs)) => {
+                            state.registers[dest] = OwnedValue::Integer(lhs * rhs);
+                        }
+                        (OwnedValue::Float(lhs), OwnedValue::Float(rhs)) => {
+                            state.registers[dest] = OwnedValue::Float(lhs * rhs);
+                        }
+                        (OwnedValue::Null, _) | (_, OwnedValue::Null) => {
+                            state.registers[dest] = OwnedValue::Null;
+                        }
+                        (OwnedValue::Agg(aggctx), other) | (other, OwnedValue::Agg(aggctx)) => {
+                            match other {
+                                OwnedValue::Null => {
+                                    state.registers[dest] = OwnedValue::Null;
+                                }
+                                OwnedValue::Integer(i) => match aggctx.final_value() {
+                                    OwnedValue::Float(acc) => {
+                                        state.registers[dest] = OwnedValue::Float(acc * *i as f64);
+                                    }
+                                    OwnedValue::Integer(acc) => {
+                                        state.registers[dest] = OwnedValue::Integer(acc * i);
+                                    }
+                                    _ => {
+                                        todo!("{:?}", aggctx);
+                                    }
+                                },
+                                OwnedValue::Float(f) => match aggctx.final_value() {
+                                    OwnedValue::Float(acc) => {
+                                        state.registers[dest] = OwnedValue::Float(acc * f);
+                                    }
+                                    OwnedValue::Integer(acc) => {
+                                        state.registers[dest] = OwnedValue::Float(*acc as f64 * f);
+                                    }
+                                    _ => {
+                                        todo!("{:?}", aggctx);
+                                    }
+                                },
+                                rest => unimplemented!("{:?}", rest),
+                            }
+                        }
+                        others => {
+                            todo!("{:?}", others);
+                        }
+                    }
+                    state.pc += 1;
+                }
+                Insn::Null { dest, dest_end } => {
+                    if let Some(dest_end) = dest_end {
+                        for i in *dest..=*dest_end {
+                            state.registers[i] = OwnedValue::Null;
+                        }
+                    } else {
+                        state.registers[*dest] = OwnedValue::Null;
+                    }
                     state.pc += 1;
                 }
                 Insn::NullRow { cursor_id } => {
                     let cursor = cursors.get_mut(cursor_id).unwrap();
                     cursor.set_null_flag(true);
+                    state.pc += 1;
+                }
+                Insn::Compare {
+                    start_reg_a,
+                    start_reg_b,
+                    count,
+                } => {
+                    let start_reg_a = *start_reg_a;
+                    let start_reg_b = *start_reg_b;
+                    let count = *count;
+
+                    if start_reg_a + count > start_reg_b {
+                        return Err(LimboError::InternalError(
+                            "Compare registers overlap".to_string(),
+                        ));
+                    }
+
+                    let mut cmp = None;
+                    for i in 0..count {
+                        let a = &state.registers[start_reg_a + i];
+                        let b = &state.registers[start_reg_b + i];
+                        cmp = Some(a.cmp(b));
+                        if cmp != Some(std::cmp::Ordering::Equal) {
+                            break;
+                        }
+                    }
+                    state.last_compare = cmp;
+                    state.pc += 1;
+                }
+                Insn::Jump {
+                    target_pc_lt,
+                    target_pc_eq,
+                    target_pc_gt,
+                } => {
+                    let cmp = state.last_compare.take();
+                    if cmp.is_none() {
+                        return Err(LimboError::InternalError(
+                            "Jump without compare".to_string(),
+                        ));
+                    }
+                    let target_pc = match cmp.unwrap() {
+                        std::cmp::Ordering::Less => *target_pc_lt,
+                        std::cmp::Ordering::Equal => *target_pc_eq,
+                        std::cmp::Ordering::Greater => *target_pc_gt,
+                    };
+                    assert!(target_pc >= 0);
+                    state.pc = target_pc;
+                }
+                Insn::Move {
+                    source_reg,
+                    dest_reg,
+                    count,
+                } => {
+                    let source_reg = *source_reg;
+                    let dest_reg = *dest_reg;
+                    let count = *count;
+                    for i in 0..count {
+                        state.registers[dest_reg + i] = std::mem::replace(
+                            &mut state.registers[source_reg + i],
+                            OwnedValue::Null,
+                        );
+                    }
                     state.pc += 1;
                 }
                 Insn::IfPos {
@@ -787,6 +996,28 @@ impl Program {
                 Insn::Goto { target_pc } => {
                     assert!(*target_pc >= 0);
                     state.pc = *target_pc;
+                }
+                Insn::Gosub {
+                    target_pc,
+                    return_reg,
+                } => {
+                    assert!(*target_pc >= 0);
+                    state.registers[*return_reg] = OwnedValue::Integer(state.pc as i64 + 1);
+                    state.pc = *target_pc;
+                }
+                Insn::Return { return_reg } => {
+                    if let OwnedValue::Integer(pc) = state.registers[*return_reg] {
+                        if pc < 0 {
+                            return Err(LimboError::InternalError(
+                                "Return register is negative".to_string(),
+                            ));
+                        }
+                        state.pc = pc;
+                    } else {
+                        return Err(LimboError::InternalError(
+                            "Return register is not an integer".to_string(),
+                        ));
+                    }
                 }
                 Insn::Integer { value, dest } => {
                     state.registers[*dest] = OwnedValue::Integer(*value);
@@ -1572,6 +1803,7 @@ fn exec_length(reg: &OwnedValue) -> OwnedValue {
             OwnedValue::Integer(reg.to_string().len() as i64)
         }
         OwnedValue::Blob(blob) => OwnedValue::Integer(blob.len() as i64),
+        OwnedValue::Agg(aggctx) => exec_length(&aggctx.final_value()),
         _ => reg.to_owned(),
     }
 }

--- a/core/vdbe/sorter.rs
+++ b/core/vdbe/sorter.rs
@@ -97,7 +97,7 @@ impl Cursor for Sorter {
         let _ = moved_before;
         let key_fields = self.order.len();
         let key = OwnedRecord::new(record.values[0..key_fields].to_vec());
-        self.insert(key, OwnedRecord::new(record.values[key_fields..].to_vec()));
+        self.insert(key, OwnedRecord::new(record.values.to_vec()));
         Ok(CursorResult::Ok(()))
     }
 

--- a/testing/all.test
+++ b/testing/all.test
@@ -11,6 +11,7 @@ source $testdir/join.test
 source $testdir/json.test
 source $testdir/like.test
 source $testdir/orderby.test
+source $testdir/groupby.test
 source $testdir/pragma.test
 source $testdir/scalar-functions.test
 source $testdir/scalar-functions-datetime.test

--- a/testing/groupby.test
+++ b/testing/groupby.test
@@ -1,0 +1,107 @@
+#!/usr/bin/env tclsh
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test group_by {
+  select u.first_name, sum(u.age) from users u group by u.first_name limit 10;
+} {Aaron|2271
+Abigail|890
+Adam|1642
+Adrian|439
+Adriana|83
+Adrienne|318
+Aimee|33
+Alan|551
+Albert|369
+Alec|247}
+
+do_execsql_test group_by_two_joined_columns {
+  select u.first_name, p.name, sum(u.age) from users u join products p on u.id = p.id group by u.first_name, p.name limit 10;
+} {Aimee|jeans|24
+Cindy|cap|37
+Daniel|coat|13
+Edward|sweatshirt|15
+Jamie|hat|94
+Jennifer|sweater|33
+Matthew|boots|77
+Nicholas|shorts|89
+Rachel|sneakers|63
+Tommy|shirt|18}
+
+do_execsql_test group_by_order_by {
+  select u.first_name, p.name, sum(u.age) from users u join products p on u.id = p.id group by u.first_name, p.name order by p.name limit 10;
+} {Travis|accessories|22
+Matthew|boots|77
+Cindy|cap|37
+Daniel|coat|13
+Jamie|hat|94
+Aimee|jeans|24
+Tommy|shirt|18
+Nicholas|shorts|89
+Rachel|sneakers|63
+Jennifer|sweater|33}
+
+do_execsql_test group_by_order_by_aggregate {
+  select u.first_name, p.name, sum(u.age) from users u join products p on u.id = p.id group by u.first_name, p.name order by sum(u.age) limit 10;
+} {Daniel|coat|13
+Edward|sweatshirt|15
+Tommy|shirt|18
+Travis|accessories|22
+Aimee|jeans|24
+Jennifer|sweater|33
+Cindy|cap|37
+Rachel|sneakers|63
+Matthew|boots|77
+Nicholas|shorts|89}
+
+do_execsql_test group_by_multiple_aggregates {
+  select u.first_name, sum(u.age), count(u.age) from users u group by u.first_name order by sum(u.age) limit 10;
+} {Jaclyn|1|1
+Mia|1|1
+Kirsten|7|1
+Kellie|8|1
+Makayla|8|1
+Yvette|9|1
+Mckenzie|12|1
+Grant|14|1
+Mackenzie|15|1
+Cesar|17|1}
+
+do_execsql_test group_by_multiple_aggregates_2 {
+  select u.first_name, sum(u.age), group_concat(u.age) from users u group by u.first_name order by u.first_name limit 10;
+} {Aaron|2271|52,46,17,69,71,91,34,30,97,81,47,98,45,69,97,18,38,26,98,60,33,97,42,43,43,22,18,75,56,67,83,58,82,28,22,72,5,58,96,32,55
+Abigail|890|17,82,62,57,55,5,9,83,93,22,23,57,56,100,74,95
+Adam|1642|34,23,10,11,46,40,2,57,51,80,65,24,15,84,59,6,34,100,32,79,57,5,77,34,30,19,54,74,89,98,72,91,90
+Adrian|439|37,28,94,76,69,60,34,41
+Adriana|83|83
+Adrienne|318|79,74,82,33,50
+Aimee|33|24,9
+Alan|551|18,52,30,62,96,13,85,97,98
+Albert|369|99,80,41,7,64,7,26,41,4
+Alec|247|55,48,53,91}
+
+do_execsql_test group_by_complex_order_by {
+  select u.first_name, group_concat(u.last_name) from users u group by u.first_name order by -1 * length(group_concat(u.last_name)) limit 1;
+} {Michael|Love,Finley,Hurst,Molina,Williams,Brown,King,Whitehead,Ochoa,Davis,Rhodes,Mcknight,Reyes,Johnston,Smith,Young,Lopez,Roberts,Green,Cole,Lane,Wagner,Allen,Simpson,Schultz,Perry,Mendez,Gibson,Hale,Williams,Bradford,Johnson,Weber,Nunez,Walls,Gonzalez,Park,Blake,Vazquez,Garcia,Mathews,Pacheco,Johnson,Perez,Gibson,Sparks,Chapman,Tate,Dudley,Miller,Alvarado,Ward,Nguyen,Rosales,Flynn,Ball,Jones,Hoffman,Clarke,Rivera,Moore,Hardin,Dillon,Montgomery,Rodgers,Payne,Williams,Mueller,Hernandez,Ware,Yates,Grimes,Gilmore,Johnson,Clark,Rodriguez,Walters,Powell,Colon,Mccoy,Allen,Quinn,Dunn,Wilson,Thompson,Bradford,Hunter,Gilmore,Woods,Bennett,Collier,Ali,Herrera,Lawson,Garner,Perez,Brown,Pena,Allen,Davis,Washington,Jackson,Khan,Martinez,Blackwell,Lee,Parker,Lynn,Johnson,Benton,Leonard,Munoz,Alvarado,Mathews,Salazar,Nelson,Jones,Carpenter,Walter,Young,Coleman,Berry,Clark,Powers,Meyer,Lewis,Barton,Guzman,Schneider,Hernandez,Mclaughlin,Allen,Atkinson,Woods,Rivera,Jones,Gordon,Dennis,Yoder,Hunt,Vance,Nelson,Park,Barnes,Lang,Williams,Cervantes,Tran,Anderson,Todd,Gonzalez,Lowery,Sanders,Mccullough,Haley,Rogers,Perez,Watson,Weaver,Wise,Walter,Summers,Long,Chan,Williams,Mccoy,Duncan,Roy,West,Christensen,Cuevas,Garcia,Williams,Butler,Anderson,Armstrong,Villarreal,Boyer,Johnson,Dyer,Hurst,Wilkins,Mercer,Taylor,Montes,Mccarty,Gill,Rodriguez,Williams,Copeland,Hansen,Palmer,Alexander,White,Taylor,Bowers,Hughes,Gibbs,Myers,Kennedy,Sanchez,Bell,Wilson,Berry,Spears,Patton,Rose,Smith,Bowen,Nicholson,Stewart,Quinn,Powell,Delgado,Mills,Duncan,Phillips,Grant,Hatfield,Russell,Anderson,Reed,Mahoney,Mcguire,Ortega,Logan,Schmitt,Walker}
+
+do_execsql_test group_by_complex_order_by_2 {
+  select u.first_name, sum(u.age) from users u group by u.first_name order by -1 * sum(u.age) limit 10;
+} {Michael|11204
+David|8758
+Robert|8109
+Jennifer|7700
+John|7299
+Christopher|6397
+James|5921
+Joseph|5711
+Brian|5059
+William|5047}
+
+do_execsql_test group_by_and_binary_expression_that_depends_on_two_aggregates {
+  select u.first_name, sum(u.age) + count(1) from users u group by u.first_name limit 5;
+} {Aaron|2312
+Abigail|906
+Adam|1675
+Adrian|447
+Adriana|84}


### PR DESCRIPTION
This PR implements GROUP BY (and also ordering by the groups or the aggregate expressions). See `groupby.test` for the kinds of things that are now supported.

This PR is a rabbit hole and insanely big, sorry.

---

I thought about how to explain how GROUP BY works in SQLite bytecode, and opted to go for just adding a bunch of Insn comments, so here's an example that uses both GROUP BY and ORDER BY:

**LIMBO**
```
limbo> explain select u.first_name, sum(u.age) from users u group by u.first_name order by sum(u.age);
addr  opcode             p1    p2    p3    p4             p5  comment
----  -----------------  ----  ----  ----  -------------  --  -------
0     Init               0     56    0                    0   Start at 56
1     SorterOpen         0     1     0     k(1,B)         0   cursor=0
2     SorterOpen         1     2     0     k(1,B)         0   cursor=1
3     Integer            0     2     0                    0   r[2]=0; clear group by abort flag
4     Null               0     4     0                    0   r[4]=NULL; initialize group by comparison registers to NULL
5     Gosub              8     45    0                    0   ; go to clear accumulator subroutine
6     OpenReadAsync      2     2     0                    0   table=u, root=2
7     OpenReadAwait      0     0     0                    0
8     RewindAsync        2     0     0                    0
9     RewindAwait        2     38    0                    0   Rewind table u
10      Column           2     1     10                   0   r[10]=u.first_name
11      Column           2     9     11                   0   r[11]=u.age
12      MakeRecord       10    2     7                    0   r[7]=mkrec(r[10..11])
13      SorterInsert     1     7     0     0              0   key=r[7]
14    NextAsync          2     0     0                    0
15    NextAwait          2     9     0                    0
16    OpenPseudo         3     7     2                    0   2 columns in r[7]
17    SorterSort         1     32    0                    0
18      SorterData       1     7     3                    0   r[7]=data
19      Column           3     0     12                   0   r[12]=cursor 3.u.first_name
20      Compare          4     12    1                    0   r[4..4]==r[12..12]
21      Jump             22    26    22                   0   ; start new group if comparison is not equal
22      Move             12    4     1                    0   r[4..4]=r[12..12]
23      Gosub            9     36    0                    0   ; check if ended group had data, and output if so
24      IfPos            2     55    0                    0   r[2]>0 -> r[2]-=0, goto 55; check abort flag
25      Gosub            8     45    0                    0   ; goto clear accumulator subroutine
26      Column           3     1     13                   0   r[13]=cursor 3.u.age
27      AggStep          0     13    6     sum            0   accum=r[6] step(r[13])
28      If               3     30    0                    0   if r[3] goto 30; don't emit group columns if continuing existing group
29      Column           3     0     5                    0   r[5]=cursor 3.u.first_name
30      Integer          1     3     0                    0   r[3]=1; indicate data in accumulator
31    SorterNext         1     18    0                    0
32    Gosub              9     36    0                    0   ; emit row for final group
33    Goto               0     48    0                    0   ; group by finished
34    Integer            1     2     0                    0   r[2]=1
35    Return             9     0     0                    0
36    IfPos              3     38    0                    0   r[3]>0 -> r[3]-=0, goto 38; output group by row subroutine start
37    Return             9     0     0                    0
38    AggFinal           0     6     0     sum            0   accum=r[6]
39    Copy               5     15    0                    0   r[15]=r[5]
40    Copy               6     16    0                    0   r[16]=r[6]
41    Copy               6     14    0                    0   r[14]=r[6]
42    MakeRecord         14    3     1                    0   r[1]=mkrec(r[14..16])
43    SorterInsert       0     1     0     0              0   key=r[1]
44    Return             9     0     0                    0
45    Null               0     5     6                    0   r[5..6]=NULL; clear accumulator subroutine start
46    Integer            0     3     0                    0   r[3]=0
47    Return             8     0     0                    0
48    OpenPseudo         4     1     3                    0   3 columns in r[1]
49    SorterSort         0     55    0                    0
50      SorterData       0     1     4                    0   r[1]=data
51      Column           4     1     17                   0   r[17]=cursor 4.sum
52      Column           4     2     18                   0   r[18]=cursor 4.u.first_name
53      ResultRow        17    2     0                    0   output=r[17..18]
54    SorterNext         0     50    0                    0
55    Halt               0     0     0                    0
56    Transaction        0     0     0                    0
57    Goto               0     1     0                    0
```

**SQLITE3**:
```
sqlite> explain select u.first_name, sum(u.age) from users u group by u.first_name order by sum(u.age);
addr  opcode         p1    p2    p3    p4             p5  comment
----  -------------  ----  ----  ----  -------------  --  -------------
0     Init           0     52    0                    0   Start at 52
1     SorterOpen     1     4     0     k(1,B)         0
2     SorterOpen     2     2     0     k(1,B)         0
3     Integer        0     2     0                    0   r[2]=0; clear abort flag
4     Null           0     5     5                    0   r[5..5]=NULL
5     Gosub          4     41    0                    0
6     OpenRead       0     2     0     10             0   root=2 iDb=0; users
7     Rewind         0     13    0                    0
8       Column         0     1     10                   0   r[10]= cursor 0 column 1
9       Column         0     9     11                   0   r[11]= cursor 0 column 9
10      MakeRecord     10    2     12                   0   r[12]=mkrec(r[10..11])
11      SorterInsert   2     12    0                    0   key=r[12]
12    Next           0     8     0                    1
13    OpenPseudo     3     12    2                    0   2 columns in r[12]
14    SorterSort     2     44    0                    0   GROUP BY sort
15      SorterData     2     12    3                    0   r[12]=data
16      Column         3     0     6                    0   r[6]= cursor 3 column 0
17      Compare        5     6     1     k(1,B)         0   r[5] <-> r[6]
18      Jump           19    23    19                   0
19      Move           6     5     1                    0   r[5]=r[6]
20      Gosub          3     33    0                    0   output one row
21      IfPos          2     44    0                    0   if r[2]>0 then r[2]-=0, goto 44; check abort flag
22      Gosub          4     41    0                    0   reset accumulator
23      Column         3     1     13                   0   r[13]=users.age
24      AggStep        0     13    9     sum(1)         1   accum=r[9] step(r[13])
25      If             1     27    0                    0
26      Column         3     0     7                    0   r[7]=users.first_name
27      Integer        1     1     0                    0   r[1]=1; indicate data in accumulator
28    SorterNext     2     15    0                    0
29    Gosub          3     33    0                    0   output final row
30    Goto           0     44    0                    0
31    Integer        1     2     0                    0   r[2]=1; set abort flag
32    Return         3     0     0                    0
33    IfPos          1     35    0                    0   if r[1]>0 then r[1]-=0, goto 35; Groupby result generator entry point
34    Return         3     0     0                    0
35    AggFinal       9     1     0     sum(1)         0   accum=r[9] N=1
36    Copy           7     15    0                    0   r[15]=r[7]
37    Copy           9     14    0                    0   r[14]=r[9]
38    MakeRecord     14    2     17                   0   r[17]=mkrec(r[14..15])
39    SorterInsert   1     17    14    2              0   key=r[17]
40    Return         3     0     0                    0   end groupby result generator
41    Null           0     7     9                    0   r[7..9]=NULL
42    Integer        0     1     0                    0   r[1]=0; indicate accumulator empty
43    Return         4     0     0                    0
44    OpenPseudo     4     18    4                    0   4 columns in r[18]
45    SorterSort     1     51    0                    0
46      SorterData     1     18    4                    0   r[18]=data
47      Column         4     0     16                   0   r[16]=sum(u.age)
48      Column         4     1     15                   0   r[15]=u.first_name
49      ResultRow      15    2     0                    0   output=r[15..16]
50    SorterNext     1     46    0                    0
51    Halt           0     0     0                    0
52    Transaction    0     0     2     0              1   usesStmtJournal=0
53    Goto           0     1     0                    0
```

As you can see the bytecodes are fairly close in this scenario.

SQLite opts to use an ephemeral index in certain cases (e.g. when you use `LIMIT` or have multiple grouping columns). Will not implement those branching strategies as part of this PR

---

Example operator tree:

```
limbo> explain query plan select u.first_name, p.name, sum(u.age) from users u join products p on u.id = p.id group by u.first_name, p.name order by p.name limit 10;

QUERY PLAN
`--TAKE 10
   `--SORT p.name ASC
   |  `--PROJECT u.first_name, p.name, sum (u.age)
   |  |  `--AGGREGATE Sum(u.age)
   |  |  |  `--JOIN
   |  |  |  |  |--SCAN users AS u
   |  |  |  |  `--SEEK products.rowid ON rowid=u.id
```