### PR TITLE
Allocate the right-hand-side register for a binary expression after translating the left-hand-side

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -74,12 +74,12 @@ pub fn translate_condition_expr(
         }
         ast::Expr::Binary(lhs, op, rhs) => {
             let lhs_reg = program.alloc_register();
-            let rhs_reg = program.alloc_register();
             let _ = translate_expr(program, Some(referenced_tables), lhs, lhs_reg, cursor_hint);
             match lhs.as_ref() {
                 ast::Expr::Literal(_) => program.mark_last_insn_constant(),
                 _ => {}
             }
+            let rhs_reg = program.alloc_register();
             let _ = translate_expr(program, Some(referenced_tables), rhs, rhs_reg, cursor_hint);
             match rhs.as_ref() {
                 ast::Expr::Literal(_) => program.mark_last_insn_constant(),

--- a/testing/like.test
+++ b/testing/like.test
@@ -22,6 +22,11 @@ do_execsql_test where-like {
 } {4|sweater|25.0
 5|sweatshirt|74.0}
 
+do_execsql_test where-like-fn {
+    select * from products where like('sweat%', name)=1
+} {4|sweater|25.0
+5|sweatshirt|74.0}
+
 do_execsql_test where-not-like-and {
     select * from products where name not like 'sweat%' and price >= 70.0;
 } {1|hat|79.0


### PR DESCRIPTION
I found a bug in queries using a like function in the where clause, ex: `SELECT first_name, last_name FROM users WHERE like('Jas%', first_name) = 1`.  That panicked with the message:
```
thread 'main' panicked at core/vdbe/mod.rs:1226:33:
internal error: entered unreachable code: Like on non-text registers
```

This was caused by an off-by-one error in the vdbe code for executing a `ScalarFunc::Like`. However, this only happened in where-like-fn queries. Queries using the like operator (ex: `SELECT first_name, last_name FROM users WHERE first_name LIKE 'Jas%'`) did not have this problem.

I did some digging around, looked at the explains for these queries from both limbo and sqlite, and it turns out, for binary expressions, limbo positions the arguments in the register differently, which is the ultimate root cause of this problem.

For the where-like-fn query, before execution limbo's registers look like this:
```
[Null, Null, Integer(1), Text("Jas%"), Text("Jason"), Null, Null]
                  ^the rhs 1  ^pattern         ^haystack str
```
Sqlite's look look something like this:
```
[Null, Null, Text("Jas%"), Text("Jason"), Integer(1), Null, Null]
                   ^pattern        ^haystack str  ^the rhs 1
```

Ultimately limbo's execution of scalar like function was looking in positions 2 and 3 always, but because we stored the right-hand-side before the like-fn arguments, there was an off-by-one error, and the non-text register it was finding was the `Integer(1)`.

This PR changes the binary expression translation to allocate the right-hand-side register *after* translating the left-hand-side, fixing the off-by-one and matching sqlite's register layout.