### PR TITLE
Pass FuncCtx to Insn::Function to keep track of arg count

### DIFF
--- a/core/function.rs
+++ b/core/function.rs
@@ -105,6 +105,22 @@ pub enum Func {
 }
 
 impl Func {
+    pub fn to_string(&self) -> String {
+        match self {
+            Func::Agg(agg_func) => agg_func.to_string().to_string(),
+            Func::Scalar(scalar_func) => scalar_func.to_string(),
+            Func::Json(json_func) => json_func.to_string(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FuncCtx {
+    pub func: Func,
+    pub arg_count: usize,
+}
+
+impl Func {
     pub fn resolve_function(name: &str, arg_count: usize) -> Result<Func, ()> {
         match name {
             "avg" => Ok(Func::Agg(AggFunc::Avg)),

--- a/core/vdbe/explain.rs
+++ b/core/vdbe/explain.rs
@@ -542,9 +542,14 @@ pub fn insn_to_str(
                 *constant_mask,
                 *start_reg as i32,
                 *dest as i32,
-                OwnedValue::Text(Rc::new(func.to_string())),
+                OwnedValue::Text(Rc::new(func.func.to_string())),
                 0,
-                format!("r[{}]=func(r[{}..])", dest, start_reg),
+                format!(
+                    "r[{}]=func(r[{}..{}])",
+                    dest,
+                    start_reg,
+                    start_reg + func.arg_count - 1
+                ),
             ),
             Insn::InitCoroutine {
                 yield_reg,

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -255,6 +255,10 @@ do_execsql_test length-empty-text {
   SELECT length('');
 } {0}
 
+do_execsql_test length-date-binary-expr {
+  select length(date('now')) = 10;
+} {1}
+
 do_execsql_test min-number {
   select min(-10,2,3)
 } {-10}


### PR DESCRIPTION
https://github.com/penberg/limbo/pull/321 recently fixed an error with register allocation order concerning binary expressions in `translate_condition_expr`. I noticed we had the same bug in `translate_expr` as well, and this led into noticing that our implementation of `Insn::Function` diverges from SQLite in that it doesn't provide a context object that keeps track of how many arguments the function call has.

Not having the arg count available at runtime means that e.g.:

```
do_execsql_test length-date-binary-expr {
  select length(date('now')) = 10;
} {1}
```

Returned 0 instead of 1, because at runtime another register was already allocated, and `date()` was implemented like this:

```
                    Func::Scalar(ScalarFunc::Date) => {
                        let result = exec_date(&state.registers[*start_reg..]); // all registers starting from start_reg
                        state.registers[*dest] = result;
                        state.pc += 1;
                    }
```

SQlite bytecode engine docs for Function say:

> Invoke a user function (P4 is a pointer to an sqlite3_context object that contains a pointer to the function to be run) with arguments taken from register P2 and successors. The number of arguments is in the sqlite3_context object that P4 points to.

Accordingly, this PR implements a `FuncCtx` struct that contains a `Func` and `arg_count` (usize).

