### PR TITLE
Fix three issues with LIKE operator (#319)

### DIFF
--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -451,10 +451,6 @@ pub fn translate_condition_expr(
             escape: _,
         } => {
             let cur_reg = program.alloc_register();
-            assert!(match rhs.as_ref() {
-                ast::Expr::Literal(_) => true,
-                _ => false,
-            });
             match op {
                 ast::LikeOperator::Like => {
                     let pattern_reg = program.alloc_register();
@@ -468,7 +464,9 @@ pub fn translate_condition_expr(
                         cursor_hint,
                         None,
                     )?;
-                    program.mark_last_insn_constant();
+                    if let ast::Expr::Literal(_) = rhs.as_ref() {
+                        program.mark_last_insn_constant();
+                    }
                     let _ = translate_expr(
                         program,
                         Some(referenced_tables),

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1927,7 +1927,10 @@ fn exec_char(values: Vec<OwnedValue>) -> OwnedValue {
 }
 
 fn construct_like_regex(pattern: &str) -> Regex {
-    Regex::new(&pattern.replace('%', ".*").replace('_', ".").to_string()).unwrap()
+    let mut regex_pattern = String::from("^");
+    regex_pattern.push_str(&pattern.replace('%', ".*").replace('_', "."));
+    regex_pattern.push('$');
+    Regex::new(&regex_pattern).unwrap()
 }
 
 // Implements LIKE pattern matching. Caches the constructed regex if a cache is provided

--- a/testing/like.test
+++ b/testing/like.test
@@ -50,6 +50,17 @@ do_execsql_test where-like-another-column {
 Daniel|Daniel
 Taylor|Taylor}
 
+do_execsql_test where-like-another-column-prefix {
+    select first_name, last_name from users where last_name like concat(first_name, '%');
+} {James|James
+Daniel|Daniel
+William|Williams
+John|Johnson
+Taylor|Taylor
+John|Johnson
+Stephen|Stephens
+Robert|Roberts}
+
 do_execsql_test where-like-impossible {
     select * from products where 'foobar' like 'fooba';
 } {}

--- a/testing/like.test
+++ b/testing/like.test
@@ -43,3 +43,13 @@ do_execsql_test where-like-or {
 5|sweatshirt|74.0
 8|sneakers|82.0
 11|accessories|81.0}
+
+do_execsql_test where-like-another-column {
+    select first_name, last_name from users where last_name like first_name;
+} {James|James
+Daniel|Daniel
+Taylor|Taylor}
+
+do_execsql_test where-like-impossible {
+    select * from products where 'foobar' like 'fooba';
+} {}


### PR DESCRIPTION
Closes #319 

1. Allow using a column as the pattern
2. Construct LIKE regexes with `^` and `$` so that eg the string `'foobar'` does not match the pattern `'fooba'` unless the pattern specifically has a wildcard
3. Support function expressions as the LIKE pattern