### PR TITLE
Extract btree split verification of `test_sequential_write` into another class 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,7 @@ dependencies = [
  "rstest",
  "rusqlite",
  "rustyline",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ dependencies = [
  "dirs",
  "env_logger 0.10.2",
  "limbo_core",
+ "log",
  "rstest",
  "rusqlite",
  "rustyline",

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -83,6 +83,7 @@ pub struct Cursor {
 // SAFETY: The limbo_core crate guarantees that `Cursor` is thread-safe.
 unsafe impl Send for Cursor {}
 
+#[allow(unused_variables, clippy::arc_with_non_send_sync)]
 #[pymethods]
 impl Cursor {
     #[pyo3(signature = (sql, parameters=None))]
@@ -229,6 +230,7 @@ impl Connection {
     }
 }
 
+#[allow(clippy::arc_with_non_send_sync)]
 #[pyfunction]
 pub fn connect(path: &str) -> Result<Connection> {
     let io = Arc::new(limbo_core::PlatformIO::new().map_err(|e| {

--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -8,6 +8,7 @@ pub struct Database {
     _inner: limbo_core::Database,
 }
 
+#[allow(clippy::arc_with_non_send_sync)]
 #[wasm_bindgen]
 impl Database {
     #[wasm_bindgen(constructor)]
@@ -29,6 +30,7 @@ pub struct File {
     fd: i32,
 }
 
+#[allow(dead_code)]
 impl File {
     fn new(vfs: VFS, fd: i32) -> Self {
         File { vfs, fd }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -33,6 +33,7 @@ struct Opts {
     output_mode: OutputMode,
 }
 
+#[allow(clippy::arc_with_non_send_sync)]
 fn main() -> anyhow::Result<()> {
     env_logger::init();
     let opts = Opts::parse();

--- a/core/function.rs
+++ b/core/function.rs
@@ -1,13 +1,20 @@
+use std::fmt;
+use std::fmt::Display;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum JsonFunc {
-    JSON,
+    Json,
 }
 
-impl ToString for JsonFunc {
-    fn to_string(&self) -> String {
-        match self {
-            JsonFunc::JSON => "json".to_string(),
-        }
+impl Display for JsonFunc {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                JsonFunc::Json => "json".to_string(),
+            }
+        )
     }
 }
 
@@ -67,9 +74,9 @@ pub enum ScalarFunc {
     UnixEpoch,
 }
 
-impl ToString for ScalarFunc {
-    fn to_string(&self) -> String {
-        match self {
+impl Display for ScalarFunc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
             ScalarFunc::Char => "char".to_string(),
             ScalarFunc::Coalesce => "coalesce".to_string(),
             ScalarFunc::Concat => "concat".to_string(),
@@ -95,7 +102,8 @@ impl ToString for ScalarFunc {
             ScalarFunc::Unicode => "unicode".to_string(),
             ScalarFunc::Quote => "quote".to_string(),
             ScalarFunc::UnixEpoch => "unixepoch".to_string(),
-        }
+        };
+        write!(f, "{}", str)
     }
 }
 
@@ -106,12 +114,12 @@ pub enum Func {
     Json(JsonFunc),
 }
 
-impl Func {
-    pub fn to_string(&self) -> String {
+impl Display for Func {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Func::Agg(agg_func) => agg_func.to_string().to_string(),
-            Func::Scalar(scalar_func) => scalar_func.to_string(),
-            Func::Json(json_func) => json_func.to_string(),
+            Func::Agg(agg_func) => write!(f, "{}", agg_func.to_string()),
+            Func::Scalar(scalar_func) => write!(f, "{}", scalar_func),
+            Func::Json(json_func) => write!(f, "{}", json_func),
         }
     }
 }
@@ -157,7 +165,7 @@ impl Func {
             "time" => Ok(Func::Scalar(ScalarFunc::Time)),
             "unicode" => Ok(Func::Scalar(ScalarFunc::Unicode)),
             "quote" => Ok(Func::Scalar(ScalarFunc::Quote)),
-            "json" => Ok(Func::Json(JsonFunc::JSON)),
+            "json" => Ok(Func::Json(JsonFunc::Json)),
             "unixepoch" => Ok(Func::Scalar(ScalarFunc::UnixEpoch)),
             _ => Err(()),
         }

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -50,7 +50,7 @@ pub struct Database {
 
 impl Database {
     #[cfg(feature = "fs")]
-    pub fn open_file(io: Arc<dyn crate::io::IO>, path: &str) -> Result<Database> {
+    pub fn open_file(io: Arc<dyn IO>, path: &str) -> Result<Database> {
         let file = io.open_file(path)?;
         let page_io = Rc::new(FileStorage::new(file));
         let wal_path = format!("{}-wal", path);

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -403,6 +403,7 @@ pub fn sqlite_schema_table() -> BTreeTable {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct Index {
     pub name: String,
@@ -412,6 +413,7 @@ pub struct Index {
     pub unique: bool,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct IndexColumn {
     pub name: String,

--- a/core/storage/btree.rs
+++ b/core/storage/btree.rs
@@ -536,11 +536,11 @@ impl BTreeCursor {
                 }
             }
 
-            trace!("Balancing leaf. leaf={}", mem_page.page_idx);
             if mem_page.parent.is_none() {
                 self.balance_root();
                 continue;
             }
+            trace!("Balancing leaf. leaf={}", mem_page.page_idx);
 
             let page_ref = self.read_page_sync(mem_page.page_idx);
             let page_rc = RefCell::borrow(&page_ref);

--- a/core/storage/pager.rs
+++ b/core/storage/pager.rs
@@ -92,6 +92,7 @@ impl Page {
     }
 }
 
+#[allow(dead_code)]
 struct PageCacheEntry {
     key: usize,
     page: Rc<RefCell<Page>>,
@@ -100,7 +101,7 @@ struct PageCacheEntry {
 }
 
 impl PageCacheEntry {
-    fn into_non_null(&mut self) -> NonNull<PageCacheEntry> {
+    fn as_non_null(&mut self) -> NonNull<PageCacheEntry> {
         NonNull::new(&mut *self).unwrap()
     }
 }
@@ -175,7 +176,7 @@ impl DumbLruPageCache {
     }
 
     fn detach(&mut self, entry: &mut PageCacheEntry) {
-        let mut current = entry.into_non_null();
+        let mut current = entry.as_non_null();
 
         let (next, prev) = unsafe {
             let c = current.as_mut();
@@ -203,7 +204,7 @@ impl DumbLruPageCache {
     }
 
     fn touch(&mut self, entry: &mut PageCacheEntry) {
-        let mut current = entry.into_non_null();
+        let mut current = entry.as_non_null();
         unsafe {
             let c = current.as_mut();
             c.next = *self.head.borrow();
@@ -231,10 +232,12 @@ impl DumbLruPageCache {
     }
 }
 
+#[allow(dead_code)]
 pub struct PageCache<K: Eq + Hash + Clone, V> {
     cache: SieveCache<K, V>,
 }
 
+#[allow(dead_code)]
 impl<K: Eq + Hash + Clone, V> PageCache<K, V> {
     pub fn new(cache: SieveCache<K, V>) -> Self {
         Self { cache }
@@ -372,6 +375,7 @@ impl Pager {
         Get's a new page that increasing the size of the page or uses a free page.
         Currently free list pages are not yet supported.
     */
+    #[allow(clippy::readonly_write_lock)]
     pub fn allocate_page(&self) -> Result<Rc<RefCell<Page>>> {
         let header = &self.db_header;
         let mut header = RefCell::borrow_mut(header);

--- a/core/storage/sqlite3_ondisk.rs
+++ b/core/storage/sqlite3_ondisk.rs
@@ -99,6 +99,7 @@ pub struct WalHeader {
     checksum_2: u32,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub struct WalFrameHeader {
     page_number: u32,
@@ -288,6 +289,7 @@ impl PageContent {
         self.read_u8(self.offset).try_into().unwrap()
     }
 
+    #[allow(clippy::mut_from_ref)]
     pub fn as_ptr(&self) -> &mut [u8] {
         unsafe {
             // unsafe trick to borrow twice
@@ -552,6 +554,7 @@ pub fn begin_write_btree_page(pager: &Pager, page: &Rc<RefCell<Page>>) -> Result
     Ok(())
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone)]
 pub enum BTreeCell {
     TableInteriorCell(TableInteriorCell),
@@ -667,6 +670,7 @@ pub fn read_btree_cell(
 
 /// read_payload takes in the unread bytearray with the payload size
 /// and returns the payload on the page, and optionally the first overflow page number.
+#[allow(clippy::readonly_write_lock)]
 fn read_payload(unread: &[u8], payload_size: usize, pager: Rc<Pager>) -> (Vec<u8>, Option<u32>) {
     let cell_len = unread.len();
     if payload_size <= cell_len {
@@ -924,8 +928,7 @@ pub fn write_varint(buf: &mut [u8], value: u64) -> usize {
 }
 
 pub fn write_varint_to_vec(value: u64, payload: &mut Vec<u8>) {
-    let mut varint: Vec<u8> = Vec::new();
-    varint.extend(std::iter::repeat(0).take(9));
+    let mut varint: Vec<u8> = vec![0; 9];
     let n = write_varint(&mut varint.as_mut_slice()[0..9], value);
     write_varint(&mut varint, value);
     varint.truncate(n);
@@ -961,8 +964,9 @@ fn finish_read_wal_header(buf: Rc<RefCell<Buffer>>, header: Rc<RefCell<WalHeader
     Ok(())
 }
 
+#[allow(dead_code)]
 pub fn begin_read_wal_frame_header(
-    io: &Box<dyn File>,
+    io: &dyn File,
     offset: usize,
 ) -> Result<Rc<RefCell<WalFrameHeader>>> {
     let drop_fn = Rc::new(|_buf| {});
@@ -978,6 +982,7 @@ pub fn begin_read_wal_frame_header(
     Ok(result)
 }
 
+#[allow(dead_code)]
 fn finish_read_wal_frame_header(
     buf: Rc<RefCell<Buffer>>,
     frame: Rc<RefCell<WalFrameHeader>>,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::usize;
 
 use sqlite3_parser::ast;
 
@@ -25,7 +24,7 @@ use super::plan::{Operator, ProjectionColumn};
  * The Emitter trait is used to emit bytecode instructions for a given operator in the query plan.
  *
  * - step: perform a single step of the operator, emitting bytecode instructions as needed,
-    and returning a result indicating whether the operator is ready to emit a result row
+     and returning a result indicating whether the operator is ready to emit a result row
 */
 pub trait Emitter {
     fn step(
@@ -143,9 +142,9 @@ pub struct Metadata {
 /// - Continue: the operator is not yet ready to emit a result row
 /// - ReadyToEmit: the operator is ready to emit a result row
 /// - Done: the operator has completed execution
-/// For example, a Scan operator will return Continue until it has opened a cursor, rewound it and applied any predicates.
-/// At that point, it will return ReadyToEmit.
-/// Finally, when the Scan operator has emitted a Next instruction, it will return Done.
+///   For example, a Scan operator will return Continue until it has opened a cursor, rewound it and applied any predicates.
+///   At that point, it will return ReadyToEmit.
+///   Finally, when the Scan operator has emitted a Next instruction, it will return Done.
 ///
 /// Parent operators are free to make decisions based on the result a child operator's step() method.
 ///
@@ -614,6 +613,7 @@ impl Emitter for Operator {
 
                             return Ok(OpStepResult::Continue);
                         }
+                        #[allow(clippy::never_loop)]
                         GROUP_BY_SORT_AND_COMPARE => {
                             loop {
                                 match source.step(program, m, referenced_tables)? {
@@ -1065,6 +1065,7 @@ impl Emitter for Operator {
 
                         Ok(OpStepResult::Continue)
                     }
+                    #[allow(clippy::never_loop)]
                     ORDER_SORT_AND_OPEN_LOOP => {
                         loop {
                             match source.step(program, m, referenced_tables)? {

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -451,10 +451,7 @@ pub fn translate_condition_expr(
             escape: _,
         } => {
             let cur_reg = program.alloc_register();
-            assert!(match rhs.as_ref() {
-                ast::Expr::Literal(_) => true,
-                _ => false,
-            });
+            assert!(matches!(rhs.as_ref(), ast::Expr::Literal(_)));
             match op {
                 ast::LikeOperator::Like => {
                     let pattern_reg = program.alloc_register();
@@ -732,7 +729,7 @@ pub fn translate_expr(
                     crate::bail_parse_error!("aggregation function in non-aggregation context")
                 }
                 Func::Json(j) => match j {
-                    JsonFunc::JSON => {
+                    JsonFunc::Json => {
                         let args = if let Some(args) = args {
                             if args.len() != 1 {
                                 crate::bail_parse_error!(
@@ -1115,10 +1112,11 @@ pub fn translate_expr(
                         }
                         ScalarFunc::UnixEpoch => {
                             let mut start_reg = 0;
-                            if let Some(args) = args {
-                                if args.len() > 1 {
+                            match args {
+                                Some(args) if args.len() > 1 => {
                                     crate::bail_parse_error!("epoch function with > 1 arguments. Modifiers are not yet supported.");
-                                } else if args.len() == 1 {
+                                }
+                                Some(args) if args.len() == 1 => {
                                     let arg_reg = program.alloc_register();
                                     let _ = translate_expr(
                                         program,
@@ -1130,6 +1128,7 @@ pub fn translate_expr(
                                     )?;
                                     start_reg = arg_reg;
                                 }
+                                _ => {}
                             }
                             program.emit_insn(Insn::Function {
                                 constant_mask: 0,
@@ -1446,8 +1445,8 @@ fn wrap_eval_jump_expr(
 
 pub fn resolve_ident_qualified(
     program: &ProgramBuilder,
-    table_name: &String,
-    ident: &String,
+    table_name: &str,
+    ident: &str,
     referenced_tables: &[(Rc<BTreeTable>, String)],
     cursor_hint: Option<usize>,
 ) -> Result<(usize, Type, usize, bool)> {
@@ -1494,7 +1493,7 @@ pub fn resolve_ident_qualified(
 
 pub fn resolve_ident_table(
     program: &ProgramBuilder,
-    ident: &String,
+    ident: &str,
     referenced_tables: Option<&[(Rc<BTreeTable>, String)]>,
     cursor_hint: Option<usize>,
 ) -> Result<(usize, Type, usize, bool)> {

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -12,6 +12,7 @@ use crate::{
     vdbe::{builder::ProgramBuilder, Insn, Program},
 };
 
+#[allow(clippy::too_many_arguments)]
 pub fn translate_insert(
     schema: &Schema,
     with: &Option<With>,

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -65,6 +65,7 @@ fn resolve_aggregates(expr: &ast::Expr, aggs: &mut Vec<Aggregate>) {
     }
 }
 
+#[allow(clippy::extra_unused_lifetimes)]
 pub fn prepare_select_plan<'a>(schema: &Schema, select: ast::Select) -> Result<Plan> {
     match select.body.select {
         ast::OneSelect::Select {
@@ -112,7 +113,7 @@ pub fn prepare_select_plan<'a>(schema: &Schema, select: ast::Select) -> Result<P
                             let name_normalized = normalize_ident(name.0.as_str());
                             let referenced_table = referenced_tables
                                 .iter()
-                                .find(|(t, t_id)| *t_id == name_normalized);
+                                .find(|(_t, t_id)| *t_id == name_normalized);
 
                             if referenced_table.is_none() {
                                 crate::bail_parse_error!("Table {} not found", name.0);
@@ -128,10 +129,10 @@ pub fn prepare_select_plan<'a>(schema: &Schema, select: ast::Select) -> Result<P
                             match expr.clone() {
                                 ast::Expr::FunctionCall {
                                     name,
-                                    distinctness,
+                                    distinctness: _,
                                     args,
-                                    filter_over,
-                                    order_by,
+                                    filter_over: _,
+                                    order_by: _,
                                 } => {
                                     let args_count = if let Some(args) = &args {
                                         args.len()
@@ -155,7 +156,10 @@ pub fn prepare_select_plan<'a>(schema: &Schema, select: ast::Select) -> Result<P
                                         _ => {}
                                     }
                                 }
-                                ast::Expr::FunctionCallStar { name, filter_over } => {
+                                ast::Expr::FunctionCallStar {
+                                    name,
+                                    filter_over: _,
+                                } => {
                                     if let Ok(Func::Agg(f)) = Func::resolve_function(
                                         normalize_ident(name.0.as_str()).as_str(),
                                         0,
@@ -176,7 +180,7 @@ pub fn prepare_select_plan<'a>(schema: &Schema, select: ast::Select) -> Result<P
                         }
                     }
                 }
-                if let Some(group_by) = group_by.as_ref() {
+                if let Some(_group_by) = group_by.as_ref() {
                     if aggregate_expressions.is_empty() {
                         crate::bail_parse_error!(
                             "GROUP BY clause without aggregate functions is not allowed"
@@ -283,6 +287,7 @@ pub fn prepare_select_plan<'a>(schema: &Schema, select: ast::Select) -> Result<P
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn parse_from(
     schema: &Schema,
     from: Option<FromClause>,

--- a/core/types.rs
+++ b/core/types.rs
@@ -84,7 +84,8 @@ impl AggContext {
     }
 }
 
-impl std::cmp::PartialOrd<OwnedValue> for OwnedValue {
+#[allow(clippy::non_canonical_partial_ord_impl)]
+impl PartialOrd<OwnedValue> for OwnedValue {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         match (self, other) {
             (OwnedValue::Integer(int_left), OwnedValue::Integer(int_right)) => {

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -4,6 +4,7 @@ use crate::storage::sqlite3_ondisk::DatabaseHeader;
 
 use super::{BranchOffset, CursorID, Insn, InsnReference, Program, Table};
 
+#[allow(dead_code)]
 pub struct ProgramBuilder {
     next_free_register: usize,
     next_free_label: BranchOffset,

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -41,6 +41,7 @@ use regex::Regex;
 use std::borrow::BorrowMut;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
+use std::fmt::Display;
 use std::rc::Rc;
 
 pub type BranchOffset = i64;
@@ -49,18 +50,20 @@ pub type CursorID = usize;
 
 pub type PageIdx = usize;
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum Func {
     Scalar(ScalarFunc),
     Json(JsonFunc),
 }
 
-impl ToString for Func {
-    fn to_string(&self) -> String {
-        match self {
+impl Display for Func {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
             Func::Scalar(scalar_func) => scalar_func.to_string(),
             Func::Json(json_func) => json_func.to_string(),
-        }
+        };
+        write!(f, "{}", str)
     }
 }
 
@@ -739,7 +742,7 @@ impl Program {
                             state.pc = target_pc;
                         }
                         _ => {
-                            if &state.registers[lhs] == &state.registers[rhs] {
+                            if state.registers[lhs] == state.registers[rhs] {
                                 state.pc = target_pc;
                             } else {
                                 state.pc += 1;
@@ -761,7 +764,7 @@ impl Program {
                             state.pc = target_pc;
                         }
                         _ => {
-                            if &state.registers[lhs] != &state.registers[rhs] {
+                            if state.registers[lhs] != state.registers[rhs] {
                                 state.pc = target_pc;
                             } else {
                                 state.pc += 1;
@@ -783,7 +786,7 @@ impl Program {
                             state.pc = target_pc;
                         }
                         _ => {
-                            if &state.registers[lhs] < &state.registers[rhs] {
+                            if state.registers[lhs] < state.registers[rhs] {
                                 state.pc = target_pc;
                             } else {
                                 state.pc += 1;
@@ -805,7 +808,7 @@ impl Program {
                             state.pc = target_pc;
                         }
                         _ => {
-                            if &state.registers[lhs] <= &state.registers[rhs] {
+                            if state.registers[lhs] <= state.registers[rhs] {
                                 state.pc = target_pc;
                             } else {
                                 state.pc += 1;
@@ -827,7 +830,7 @@ impl Program {
                             state.pc = target_pc;
                         }
                         _ => {
-                            if &state.registers[lhs] > &state.registers[rhs] {
+                            if state.registers[lhs] > state.registers[rhs] {
                                 state.pc = target_pc;
                             } else {
                                 state.pc += 1;
@@ -849,7 +852,7 @@ impl Program {
                             state.pc = target_pc;
                         }
                         _ => {
-                            if &state.registers[lhs] >= &state.registers[rhs] {
+                            if state.registers[lhs] >= state.registers[rhs] {
                                 state.pc = target_pc;
                             } else {
                                 state.pc += 1;
@@ -1413,7 +1416,7 @@ impl Program {
                 } => {
                     let arg_count = func.arg_count;
                     match &func.func {
-                        crate::function::Func::Json(JsonFunc::JSON) => {
+                        crate::function::Func::Json(JsonFunc::Json) => {
                             let json_value = &state.registers[*start_reg];
                             let json_str = get_json(json_value);
                             match json_str {
@@ -1714,8 +1717,8 @@ impl Program {
 fn get_new_rowid<R: Rng>(cursor: &mut Box<dyn Cursor>, mut rng: R) -> Result<CursorResult<i64>> {
     cursor.seek_to_last()?;
     let mut rowid = cursor.rowid()?.unwrap_or(0) + 1;
-    if rowid > std::i64::MAX.try_into().unwrap() {
-        let distribution = Uniform::from(1..=std::i64::MAX);
+    if rowid > i64::MAX.try_into().unwrap() {
+        let distribution = Uniform::from(1..=i64::MAX);
         let max_attempts = 100;
         for count in 0..max_attempts {
             rowid = distribution.sample(&mut rng).try_into().unwrap();

--- a/simulator/main.rs
+++ b/simulator/main.rs
@@ -5,6 +5,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
+#[allow(clippy::arc_with_non_send_sync)]
 fn main() {
     let seed = match std::env::var("SEED") {
         Ok(seed) => seed.parse::<u64>().unwrap(),

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -83,6 +83,7 @@ pub unsafe extern "C" fn sqlite3_shutdown() -> ffi::c_int {
 }
 
 #[no_mangle]
+#[allow(clippy::arc_with_non_send_sync)]
 pub unsafe extern "C" fn sqlite3_open(
     filename: *const ffi::c_char,
     db_out: *mut *mut sqlite3,
@@ -883,7 +884,7 @@ fn sqlite3_errstr_impl(rc: i32) -> *const std::ffi::c_char {
         "datatype mismatch",                    // SQLITE_MISMATCH
         "bad parameter or other API misuse",    // SQLITE_MISUSE
         #[cfg(feature = "lfs")]
-        "",     // SQLITE_NOLFS
+        "",      // SQLITE_NOLFS
         #[cfg(not(feature = "lfs"))]
         "large file support is disabled", // SQLITE_NOLFS
         "authorization denied",                 // SQLITE_AUTH

--- a/sqlite3/src/lib.rs
+++ b/sqlite3/src/lib.rs
@@ -884,7 +884,7 @@ fn sqlite3_errstr_impl(rc: i32) -> *const std::ffi::c_char {
         "datatype mismatch",                    // SQLITE_MISMATCH
         "bad parameter or other API misuse",    // SQLITE_MISUSE
         #[cfg(feature = "lfs")]
-        "",      // SQLITE_NOLFS
+        "",     // SQLITE_NOLFS
         #[cfg(not(feature = "lfs"))]
         "large file support is disabled", // SQLITE_NOLFS
         "authorization denied",                 // SQLITE_AUTH

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -21,6 +21,7 @@ limbo_core = { path = "../core" }
 rustyline = "12.0.0"
 rusqlite = "0.29.0"
 tempfile = "3.0.7"
+log = "0.4.22"
 
 [dev-dependencies]
 rstest = "0.18.2"

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -20,6 +20,7 @@ env_logger = "0.10.1"
 limbo_core = { path = "../core" }
 rustyline = "12.0.0"
 rusqlite = "0.29.0"
+tempfile = "3.0.7"
 
 [dev-dependencies]
 rstest = "0.18.2"

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,8 +1,7 @@
 use limbo_core::Database;
-use std::env;
-use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tempfile::TempDir;
 
 #[allow(dead_code)]
 struct TempDatabase {
@@ -13,12 +12,9 @@ struct TempDatabase {
 #[allow(dead_code, clippy::arc_with_non_send_sync)]
 impl TempDatabase {
     pub fn new(table_sql: &str) -> Self {
-        let mut path = env::current_dir().unwrap();
+        let mut path = TempDir::new().unwrap().into_path();
         path.push("test.db");
         {
-            if path.exists() {
-                fs::remove_file(&path).unwrap();
-            }
             let connection = rusqlite::Connection::open(&path).unwrap();
             connection.execute(table_sql, ()).unwrap();
         }
@@ -47,7 +43,7 @@ mod tests {
         let conn = tmp_db.connect_limbo();
 
         let list_query = "SELECT * FROM test";
-        let max_iterations = 10000;
+        let max_iterations = 1000;
         for i in 0..max_iterations {
             if (i % 100) == 0 {
                 let progress = (i as f64 / max_iterations as f64) * 100.0;

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,6 +1,9 @@
 use limbo_core::Database;
+use log::{LevelFilter, Record};
+use std::io::Write;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::Once;
+use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
 
 #[allow(dead_code)]
@@ -43,7 +46,7 @@ mod tests {
         let conn = tmp_db.connect_limbo();
 
         let list_query = "SELECT * FROM test";
-        let max_iterations = 10000;
+        let max_iterations = 1000;
         for i in 0..max_iterations {
             if (i % 100) == 0 {
                 let progress = (i as f64 / max_iterations as f64) * 100.0;
@@ -93,6 +96,60 @@ mod tests {
             }
             conn.cacheflush()?;
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_btree_splitting() -> anyhow::Result<()> {
+        static INIT: Once = Once::new();
+        let log_buffer = Arc::new(Mutex::new(Vec::new()));
+        let log_buffer_clone = Arc::clone(&log_buffer);
+
+        INIT.call_once(|| {
+            env_logger::builder()
+                .format(move |buf, record: &Record| {
+                    let mut log_buffer = log_buffer_clone.lock().unwrap();
+                    writeln!(log_buffer, "{}", record.args()).unwrap();
+                    writeln!(buf, "{}", record.args())?;
+                    Ok(())
+                })
+                .filter_level(LevelFilter::Trace)
+                .init();
+        });
+
+        let tmp_db = TempDatabase::new("CREATE TABLE test (x INTEGER PRIMARY KEY);");
+        let conn = tmp_db.connect_limbo();
+
+        let max_iterations = 10000;
+        let mut page_split_log_found = false;
+        for i in 0..max_iterations {
+            let insert_query = format!("INSERT INTO test VALUES ({})", i);
+            match conn.query(insert_query) {
+                Ok(Some(ref mut rows)) => loop {
+                    match rows.next_row()? {
+                        RowResult::IO => {
+                            tmp_db.io.run_once()?;
+                        }
+                        RowResult::Done => break,
+                        _ => unreachable!(),
+                    }
+                },
+                Ok(None) => {}
+                Err(err) => {
+                    eprintln!("{}", err);
+                }
+            };
+            conn.cacheflush()?;
+
+            let logs = log_buffer.lock().unwrap();
+            let logs_str = String::from_utf8_lossy(&logs);
+            if logs_str.contains("Balancing root") && logs_str.contains("Balancing leaf") {
+                page_split_log_found = true;
+                break;
+            }
+        }
+
+        assert!(page_split_log_found, "Expected root page split but not executed");
         Ok(())
     }
 

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -4,11 +4,13 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+#[allow(dead_code)]
 struct TempDatabase {
     pub path: PathBuf,
     pub io: Arc<dyn limbo_core::IO>,
 }
 
+#[allow(dead_code, clippy::arc_with_non_send_sync)]
 impl TempDatabase {
     pub fn new(table_sql: &str) -> Self {
         let mut path = env::current_dir().unwrap();
@@ -174,7 +176,7 @@ mod tests {
         let mut huge_texts = Vec::new();
         for i in 0..iterations {
             let mut huge_text = String::new();
-            for j in 0..8192 {
+            for _j in 0..8192 {
                 huge_text.push((b'A' + i as u8) as char);
             }
             huge_texts.push(huge_text);

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -43,7 +43,7 @@ mod tests {
         let conn = tmp_db.connect_limbo();
 
         let list_query = "SELECT * FROM test";
-        let max_iterations = 1000;
+        let max_iterations = 10000;
         for i in 0..max_iterations {
             if (i % 100) == 0 {
                 let progress = (i as f64 / max_iterations as f64) * 100.0;


### PR DESCRIPTION
### AS-IS 

- `test_sequential_write` has 2 purposes 
  - test sequential write 
  - check whether btree page splitting works fine 

### TO-BE 

- `test_sequential_write` has single purpose to test sequential write. Therefore we can reduce the `max_iterations` 
- `test_btree_splitting` is added to check whether btree leaf, root page splitting works fine 

### Note 

- This has to be merged after this [PR](https://github.com/penberg/limbo/pull/329) 
