### PR TITLE
Make LIKE expressions case-insensitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -1968,7 +1968,7 @@ fn exec_char(values: Vec<OwnedValue>) -> OwnedValue {
 }
 
 fn construct_like_regex(pattern: &str) -> Regex {
-    let mut regex_pattern = String::from("^");
+    let mut regex_pattern = String::from("(?i)^");
     regex_pattern.push_str(&pattern.replace('%', ".*").replace('_', "."));
     regex_pattern.push('$');
     Regex::new(&regex_pattern).unwrap()

--- a/testing/like.test
+++ b/testing/like.test
@@ -22,6 +22,19 @@ do_execsql_test where-like {
 } {4|sweater|25.0
 5|sweatshirt|74.0}
 
+do_execsql_test where-like-case-insensitive {
+    select * from products where name like 'SWEAT%';
+} {4|sweater|25.0
+5|sweatshirt|74.0}
+
+do_execsql_test where-like-underscore {
+    select * from products where name like 'sweat_r';
+} {4|sweater|25.0}
+
+do_execsql_test where-like-underscore-case-insensitive {
+    select * from products where name like 'SwEaT_R';
+} {4|sweater|25.0}
+
 do_execsql_test where-like-fn {
     select * from products where like('sweat%', name)=1
 } {4|sweater|25.0


### PR DESCRIPTION
Per the sqlite docs, LIKE is case-insensitive.

> The LIKE operator does a pattern matching comparison. The operand to the right of the LIKE operator contains the pattern and the left hand operand contains the string to match against the pattern. A percent symbol ("%") in the LIKE pattern matches any sequence of zero or more characters in the string. An underscore ("_") in the LIKE pattern matches any single character in the string. **Any other character matches itself or its lower/upper case equivalent (i.e. case-insensitive matching)**. Important Note: SQLite only understands upper/lower case for ASCII characters by default. The LIKE operator is case sensitive by default for unicode characters that are beyond the ASCII range. For example, the expression 'a' LIKE 'A' is TRUE but 'æ' LIKE 'Æ' is FALSE. The ICU extension to SQLite includes an enhanced version of the LIKE operator that does case folding across all unicode characters.

Note that sqlite does not support case-insensitive comparisons of unicode characters by default. This PR _does not_ match that behavior currently. I can change things to not support unicode-case-insensitivity, but as I understand it, doing so may require disable the unicode-case feature on the regex crate, and potentially using a `regex::bytes::Regex`, instead of a `regex::Regex`. (Basically, doing some stuff that would not match anyone's initial assumptions about how this would work).

