### PR TITLE
refactor: min max function

### DIFF
--- a/core/types.rs
+++ b/core/types.rs
@@ -100,9 +100,23 @@ impl PartialOrd<OwnedValue> for OwnedValue {
             (OwnedValue::Float(float_left), OwnedValue::Float(float_right)) => {
                 float_left.partial_cmp(float_right)
             }
+            // Numeric vs Text/Blob
+            (
+                OwnedValue::Integer(_) | OwnedValue::Float(_),
+                OwnedValue::Text(_) | OwnedValue::Blob(_),
+            ) => Some(std::cmp::Ordering::Less),
+            (
+                OwnedValue::Text(_) | OwnedValue::Blob(_),
+                OwnedValue::Integer(_) | OwnedValue::Float(_),
+            ) => Some(std::cmp::Ordering::Greater),
+
             (OwnedValue::Text(text_left), OwnedValue::Text(text_right)) => {
                 text_left.partial_cmp(text_right)
             }
+            // Text vs Blob
+            (OwnedValue::Text(_), OwnedValue::Blob(_)) => Some(std::cmp::Ordering::Less),
+            (OwnedValue::Blob(_), OwnedValue::Text(_)) => Some(std::cmp::Ordering::Greater),
+
             (OwnedValue::Blob(blob_left), OwnedValue::Blob(blob_right)) => {
                 blob_left.partial_cmp(blob_right)
             }

--- a/testing/scalar-functions.test
+++ b/testing/scalar-functions.test
@@ -295,6 +295,22 @@ do_execsql_test min-str {
   select min('b','a','z')
 } {a}
 
+do_execsql_test min-str-number {
+  select min('42',100)
+} {100}
+
+do_execsql_test min-blob-number {
+  select min(3.14,x'616263')
+} {3.14}
+
+do_execsql_test max-str-number {
+  select max('42',100)
+} {42}
+
+do_execsql_test max-blob-number {
+  select max(3.14,x'616263')
+} {abc}
+
 do_execsql_test min-null {
   select min(null,null)
 } {}


### PR DESCRIPTION
In the current implementation, there is an issue with the `min`/`max` functions when the input contains both numbers and text. This merge request fixes the problem.
I have also changed the `minmax` function by splitting it into two separate functions to be able to add unit tests for both functions, just like for the other functions