### PR TITLE
Add support for Python 3.13 and drop support for Python 3.8

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,11 +21,11 @@ jobs:
           - macos-latest
           - windows-latest
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     runs-on: ${{ matrix.os }}
 
     defaults:

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -5,17 +5,17 @@ build-backend = 'maturin'
 [project]
 name = 'limbo'
 description = "Limbo is a work-in-progress, in-process OLTP database management system, compatible with SQLite."
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 classifiers = [
     'Development Status :: 3 - Alpha',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Programming Language :: Rust',
     'License :: OSI Approved :: MIT License',
     'Operating System :: POSIX :: Linux',


### PR DESCRIPTION
The 7th of October 2024 was the first day of Python 3.13 and the last of Python 3.8 official support.

For reference: https://devguide.python.org/versions/