### PR TITLE
Fix Wasm packaging

### DIFF
--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -1,0 +1,9 @@
+# Limbo Wasm bindings
+
+This source tree contains Limbo Wasm bindings.
+
+## Building
+
+```
+./scripts/build
+```

--- a/bindings/wasm/examples/example.js
+++ b/bindings/wasm/examples/example.js
@@ -2,4 +2,4 @@ import { Database } from 'limbo-wasm';
 
 const db = new Database('hello.db');
 
-db.exec("SELECT 'hello, world' AS message");
+console.log(db.exec("SELECT 'hello, world' AS message"));

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "limbo-wasm",
+  "collaborators": [
+    "the Limbo authors"
+  ],
+  "version": "0.0.4",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/penberg/limbo"
+  },
+  "files": [
+    "snippets",
+    "limbo_wasm_bg.wasm",
+    "limbo_wasm.js",
+    "limbo_wasm.d.ts"
+  ],
+  "main": "limbo_wasm.js",
+  "types": "limbo_wasm.d.ts"
+}

--- a/bindings/wasm/scripts/build
+++ b/bindings/wasm/scripts/build
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+wasm-pack build --no-pack --target nodejs
+cp package.json pkg/package.json


### PR DESCRIPTION
The `wasm-pack` too has a known bug where it forgets to add snippets to `package.json`:

https://github.com/rustwasm/wasm-pack/issues/1206

Let's fix that with some bash magic.