### PR TITLE
core: Make JSON support configurable

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,8 +14,13 @@ name = "limbo_core"
 path = "lib.rs"
 
 [features]
-default = ["fs"]
+default = ["fs", "json"]
 fs = []
+json = [
+    "dep:jsonb",
+    "dep:pest",
+    "dep:pest_derive",
+]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = "0.6.1"
@@ -41,11 +46,11 @@ getrandom = { version = "0.2.15", features = ["js"] }
 regex = "1.10.5"
 chrono = "0.4.38"
 julian_day_converter = "0.3.2"
-jsonb = "0.4.1"
+jsonb = { version = "0.4.1", optional = true }
 indexmap = { version="2.2.6", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
-pest = "2.0"
-pest_derive = "2.0"
+pest = { version = "2.0", optional = true }
+pest_derive = { version = "2.0", optional = true }
 mockall = "0.13.0"
 rand = "0.8.5"
 

--- a/core/function.rs
+++ b/core/function.rs
@@ -1,11 +1,13 @@
 use std::fmt;
 use std::fmt::Display;
 
+#[cfg(feature = "json")]
 #[derive(Debug, Clone, PartialEq)]
 pub enum JsonFunc {
     Json,
 }
 
+#[cfg(feature = "json")]
 impl Display for JsonFunc {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -129,6 +131,7 @@ impl Display for ScalarFunc {
 pub enum Func {
     Agg(AggFunc),
     Scalar(ScalarFunc),
+    #[cfg(feature = "json")]
     Json(JsonFunc),
 }
 
@@ -137,6 +140,7 @@ impl Display for Func {
         match self {
             Func::Agg(agg_func) => write!(f, "{}", agg_func.to_string()),
             Func::Scalar(scalar_func) => write!(f, "{}", scalar_func),
+            #[cfg(feature = "json")]
             Func::Json(json_func) => write!(f, "{}", json_func),
         }
     }
@@ -189,6 +193,7 @@ impl Func {
             "unicode" => Ok(Func::Scalar(ScalarFunc::Unicode)),
             "quote" => Ok(Func::Scalar(ScalarFunc::Quote)),
             "sqlite_version" => Ok(Func::Scalar(ScalarFunc::SqliteVersion)),
+            #[cfg(feature = "json")]
             "json" => Ok(Func::Json(JsonFunc::Json)),
             "unixepoch" => Ok(Func::Scalar(ScalarFunc::UnixEpoch)),
             "hex" => Ok(Func::Scalar(ScalarFunc::Hex)),

--- a/core/lib.rs
+++ b/core/lib.rs
@@ -1,6 +1,7 @@
 mod error;
 mod function;
 mod io;
+#[cfg(feature = "json")]
 mod json;
 mod pseudo;
 mod schema;

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -1,11 +1,13 @@
-use crate::{function::JsonFunc, Result};
 use sqlite3_parser::ast::{self, UnaryOperator};
 
 use super::optimizer::CachedResult;
+#[cfg(feature = "json")]
+use crate::function::JsonFunc;
 use crate::function::{AggFunc, Func, FuncCtx, ScalarFunc};
 use crate::schema::{PseudoTable, Table, Type};
 use crate::util::normalize_ident;
 use crate::vdbe::{builder::ProgramBuilder, BranchOffset, Insn};
+use crate::Result;
 
 use super::plan::{Aggregate, BTreeTableReference};
 
@@ -742,6 +744,7 @@ pub fn translate_expr(
                 Func::Agg(_) => {
                     crate::bail_parse_error!("aggregation function in non-aggregation context")
                 }
+                #[cfg(feature = "json")]
                 Func::Json(j) => match j {
                     JsonFunc::Json => {
                         let args = if let Some(args) = args {


### PR DESCRIPTION
This adds a `json` feature flag, which allows users to disable JSON support if needed.