### PR TITLE
bindings/wasm: "SELECT 1" benchmark

### DIFF
--- a/bindings/wasm/perf/package.json
+++ b/bindings/wasm/perf/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "limbo-perf",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "limbo-wasm": "../pkg",
+    "better-sqlite3": "^9.5.0",
+    "libsql": "..",
+    "mitata": "^0.1.11"
+  }
+}

--- a/bindings/wasm/perf/perf-better-sqlite3.js
+++ b/bindings/wasm/perf/perf-better-sqlite3.js
@@ -1,0 +1,23 @@
+import { run, bench, group, baseline } from 'mitata';
+
+import Database from 'better-sqlite3';
+
+const db = new Database('limbo.db');
+
+const stmt = db.prepare("SELECT 1");
+
+group('Statement', () => {
+  bench('SELECT 1', () => {
+    stmt.all();
+  });
+});
+
+await run({
+  units: false,
+  silent: false,
+  avg: true,
+  json: false,
+  colors: true,
+  min_max: true,
+  percentiles: true,
+});

--- a/bindings/wasm/perf/perf-limbo.js
+++ b/bindings/wasm/perf/perf-limbo.js
@@ -1,0 +1,23 @@
+import { run, bench, group, baseline } from 'mitata';
+
+import { Database } from 'limbo-wasm';
+
+const db = new Database('limbo.db');
+
+const stmt = db.prepare("SELECT 1");
+
+group('Statement', () => {
+  bench('SELECT 1', () => {
+    stmt.all();
+  });
+});
+
+await run({
+  units: false,
+  silent: false,
+  avg: true,
+  json: false,
+  colors: true,
+  min_max: true,
+  percentiles: true,
+});


### PR DESCRIPTION
This adds a benchmark for "SELECT 1" that essentially just evaluates the
overhead of calling into the library. Looks like WebAssembly adds 2.5x
overhead compared to native code...

```
penberg@vonneumann perf % node perf-limbo.js
cpu: Apple M1
runtime: node v18.19.0 (arm64-darwin)

benchmark      time (avg)             (min … max)       p75       p99      p999
------------------------------------------------- -----------------------------
• Statement
------------------------------------------------- -----------------------------
SELECT 1      771 ns/iter     (624 ns … 2'183 µs)    750 ns  1'085 ns  1'750 ns

summary for Statement
  SELECT 1
penberg@vonneumann perf % node perf-better-sqlite3.js
cpu: Apple M1
runtime: node v18.19.0 (arm64-darwin)

benchmark      time (avg)             (min … max)       p75       p99      p999
------------------------------------------------- -----------------------------
• Statement
------------------------------------------------- -----------------------------
SELECT 1      302 ns/iter       (166 ns … 779 µs)    292 ns    375 ns  1'000 ns

summary for Statement
  SELECT 1
```