### PR TITLE
bindings/wasm: Fix VFS.sync() function signature

### DIFF
--- a/bindings/wasm/lib.rs
+++ b/bindings/wasm/lib.rs
@@ -256,7 +256,7 @@ extern "C" {
     fn size(this: &VFS, fd: i32) -> u64;
 
     #[wasm_bindgen(method)]
-    fn sync(this: &VFS, fd: i32) -> u64;
+    fn sync(this: &VFS, fd: i32);
 }
 
 #[wasm_bindgen(start)]

--- a/bindings/wasm/vfs.js
+++ b/bindings/wasm/vfs.js
@@ -26,7 +26,7 @@ class VFS {
   }
 
   sync(fd) {
-    return fs.fsyncSync(fd);
+    fs.fsyncSync(fd);
   }
 }
 


### PR DESCRIPTION
We don't expect any return value from the underlying `fsync()` so fix the function signature accordingly.

Fixes the following obscure error:

```
TypeError: Cannot convert undefined to a BigInt
    at wasm://wasm/00942492:wasm-function[1501]:0x1c4dc1
    at wasm://wasm/00942492:wasm-function[694]:0x189586
    at wasm://wasm/00942492:wasm-function[50]:0x143d7
    at wasm://wasm/00942492:wasm-function[60]:0x3f91a
    at new Database (/Users/penberg/src/penberg/limbo/bindings/wasm/pkg/limbo_wasm.js:162:26)
    at file:///Users/penberg/src/penberg/limbo/bindings/wasm/perf/perf-limbo.js:5:12
    at ModuleJob.run (node:internal/modules/esm/module_job:195:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:336:24)
    at async loadESM (node:internal/process/esm_loader:34:7)
    at async handleMainPromise (node:internal/modules/run_main:106:12)
```