### PR TITLE
support parenthesized(single expr) in translate_expr()

### DIFF
--- a/core/vdbe/mod.rs
+++ b/core/vdbe/mod.rs
@@ -583,6 +583,10 @@ impl Program {
                         (OwnedValue::Float(lhs), OwnedValue::Float(rhs)) => {
                             state.registers[dest] = OwnedValue::Float(lhs + rhs);
                         }
+                        (OwnedValue::Float(f), OwnedValue::Integer(i))
+                        | (OwnedValue::Integer(i), OwnedValue::Float(f)) => {
+                            state.registers[dest] = OwnedValue::Float(*f + *i as f64);
+                        }
                         (OwnedValue::Null, _) | (_, OwnedValue::Null) => {
                             state.registers[dest] = OwnedValue::Null;
                         }

--- a/testing/select.test
+++ b/testing/select.test
@@ -50,3 +50,7 @@ do_execsql_test table-star-2 {
 do_execsql_test seekrowid {
     select * from users u where u.id = 5;
 } {"5|Edward|Miller|christiankramer@example.com|725-281-1033|08522 English Plain|Lake Keith|ID|23283|15"}
+
+do_execsql_test select_parenthesized {
+  select (price + 100) from products limit 1;
+} {179.0}


### PR DESCRIPTION
fix #397 (for the most part)