### PR TITLE
core: (another) refactor of read path query processing logic

### DIFF
--- a/core/lib.rs
+++ b/core/lib.rs
@@ -235,8 +235,8 @@ impl Connection {
                 Cmd::ExplainQueryPlan(stmt) => {
                     match stmt {
                         ast::Stmt::Select(select) => {
-                            let plan = prepare_select_plan(&self.schema.borrow(), select)?;
-                            let (plan, _) = optimize_plan(plan)?;
+                            let plan = prepare_select_plan(&*self.schema.borrow(), select)?;
+                            let plan = optimize_plan(plan)?;
                             println!("{}", plan);
                         }
                         _ => todo!(),

--- a/core/schema.rs
+++ b/core/schema.rs
@@ -90,7 +90,7 @@ impl Table {
                 None => None,
             },
             Table::Pseudo(table) => match table.columns.get(index) {
-                Some(column) => Some(&column.name),
+                Some(_) => None,
                 None => None,
             },
         }

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1713,14 +1713,12 @@ fn order_by_sorter_insert(
     );
     Ok(())
 }
-/// We need to handle the case where we are emitting to sorter.
-/// In that case the first columns should be the sort key columns, and the rest is the result columns of the select.
-/// In case any of the sort keys are exactly equal to a result column, we can skip emitting that result column.
-/// We need to do this before rewriting the result columns to registers because we need to know which columns to skip.
-/// Moreover, we need to keep track what index in the ORDER BY sorter the result columns have, because the result columns
-/// should be emitted in the SELECT clause order, not the ORDER BY clause order.
+
+/// In case any of the ORDER BY sort keys are exactly equal to a result column, we can skip emitting that result column.
+/// If we skip a result column, we need to keep track what index in the ORDER BY sorter the result columns have,
+/// because the result columns should be emitted in the SELECT clause order, not the ORDER BY clause order.
 ///
-/// If any result columsn can be skipped, returns list of 2-tuples of (SkippedResultColumnIndex: usize, ResultColumnIndexInOrderBySorter: usize)
+/// If any result columns can be skipped, this returns list of 2-tuples of (SkippedResultColumnIndex: usize, ResultColumnIndexInOrderBySorter: usize)
 fn order_by_deduplicate_result_columns(
     order_by: &Vec<(ast::Expr, Direction)>,
     result_columns: &Vec<ResultSetColumn>,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1653,8 +1653,7 @@ fn agg_without_group_by_emit(
             func: agg.func.clone(),
         });
     }
-    // we now have the group by columns in registers (group_exprs_start_register..group_exprs_start_register + group_by.len() - 1)
-    // and the agg results in (agg_start_reg..agg_start_reg + aggregates.len() - 1)
+    // we now have the agg results in (agg_start_reg..agg_start_reg + aggregates.len() - 1)
     // we need to call translate_expr on each result column, but replace the expr with a register copy in case any part of the
     // result column expression matches a) a group by column or b) an aggregation result.
     let mut precomputed_exprs_to_register = Vec::with_capacity(aggregates.len());

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -963,6 +963,9 @@ fn inner_loop_source_emit(
                         }
                     }
                     ResultSetColumn::Agg(agg) => {
+                        // TODO: implement a custom equality check for expressions
+                        // there are lots of examples where this breaks, even simple ones like
+                        // sum(x) != SUM(x)
                         let found = order_by
                             .iter()
                             .enumerate()
@@ -1525,6 +1528,9 @@ fn group_by_emit(
                     }
                 }
                 ResultSetColumn::Agg(agg) => {
+                    // TODO: implement a custom equality check for expressions
+                    // there are lots of examples where this breaks, even simple ones like
+                    // sum(x) != SUM(x)
                     let found = order_by
                         .iter()
                         .enumerate()

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -237,7 +237,7 @@ pub fn emit_program(
     // EMIT RESULT ROWS FROM THE ORDER BY SORTER
     if let Some(ref mut order_by) = plan.order_by {
         if order_by_necessary {
-            sort_order_by(
+            order_by_emit(
                 &mut program,
                 order_by,
                 &plan.result_columns,
@@ -1694,7 +1694,7 @@ fn agg_without_group_by_emit(
     Ok(())
 }
 
-fn sort_order_by(
+fn order_by_emit(
     program: &mut ProgramBuilder,
     order_by: &Vec<(ast::Expr, Direction)>,
     result_columns: &Vec<ResultSetColumn>,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1008,7 +1008,7 @@ fn inner_loop_source_emit(
             let agg_final_label = program.allocate_label();
             m.termination_label_stack.push(agg_final_label);
             let num_aggs = aggregates.len();
-            let start_reg = program.alloc_registers(result_columns.len());
+            let start_reg = program.alloc_registers(num_aggs);
             m.aggregation_start_register = Some(start_reg);
             for (i, agg) in aggregates.iter().enumerate() {
                 let reg = start_reg + i;

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -17,9 +17,8 @@ use super::expr::{
     translate_aggregation, translate_condition_expr, translate_expr, translate_table_columns,
     ConditionMetadata,
 };
-use super::optimizer::ExpressionResultCache;
-use super::plan::{BTreeTableReference, Plan};
-use super::plan::{Operator, ProjectionColumn};
+use super::plan::{Aggregate, BTreeTableReference, Direction, Plan};
+use super::plan::{ResultSetColumn, SourceOperator};
 
 /**
  * The Emitter trait is used to emit bytecode instructions for a given operator in the query plan.
@@ -27,28 +26,28 @@ use super::plan::{Operator, ProjectionColumn};
  * - step: perform a single step of the operator, emitting bytecode instructions as needed,
      and returning a result indicating whether the operator is ready to emit a result row
 */
-pub trait Emitter {
-    fn step(
-        &mut self,
-        pb: &mut ProgramBuilder,
-        m: &mut Metadata,
-        referenced_tables: &[BTreeTableReference],
-    ) -> Result<OpStepResult>;
-    fn result_columns(
-        &self,
-        program: &mut ProgramBuilder,
-        referenced_tables: &[BTreeTableReference],
-        metadata: &mut Metadata,
-        cursor_override: Option<&SortCursorOverride>,
-    ) -> Result<usize>;
-    fn result_row(
-        &mut self,
-        program: &mut ProgramBuilder,
-        referenced_tables: &[BTreeTableReference],
-        metadata: &mut Metadata,
-        cursor_override: Option<&SortCursorOverride>,
-    ) -> Result<()>;
-}
+// pub trait Emitter {
+//     fn step(
+//         &mut self,
+//         pb: &mut ProgramBuilder,
+//         m: &mut Metadata,
+//         referenced_tables: &[BTreeTableReference],
+//     ) -> Result<OpStepResult>;
+//     fn result_columns(
+//         &self,
+//         program: &mut ProgramBuilder,
+//         referenced_tables: &[BTreeTableReference],
+//         metadata: &mut Metadata,
+//         cursor_override: Option<&SortCursorOverride>,
+//     ) -> Result<usize>;
+//     fn result_row(
+//         &mut self,
+//         program: &mut ProgramBuilder,
+//         referenced_tables: &[BTreeTableReference],
+//         metadata: &mut Metadata,
+//         cursor_override: Option<&SortCursorOverride>,
+//     ) -> Result<()>;
+// }
 
 #[derive(Debug)]
 pub struct LeftJoinMetadata {
@@ -136,1552 +135,1493 @@ pub struct Metadata {
     sorts: HashMap<usize, SortMetadata>,
     // mapping between Join operator id and associated metadata (for left joins only)
     left_joins: HashMap<usize, LeftJoinMetadata>,
-    expr_result_cache: ExpressionResultCache,
+    // register holding the start of the result set
+    result_set_register_start: usize,
 }
 
-/// Emitters return one of three possible results from the step() method:
-/// - Continue: the operator is not yet ready to emit a result row
-/// - ReadyToEmit: the operator is ready to emit a result row
-/// - Done: the operator has completed execution
-///   For example, a Scan operator will return Continue until it has opened a cursor, rewound it and applied any predicates.
-///   At that point, it will return ReadyToEmit.
-///   Finally, when the Scan operator has emitted a Next instruction, it will return Done.
-///
-/// Parent operators are free to make decisions based on the result a child operator's step() method.
-///
-/// When the root operator of a Plan returns ReadyToEmit, a ResultRow will always be emitted.
-/// When the root operator returns Done, the bytecode plan is complete.
-#[derive(Debug, PartialEq)]
-pub enum OpStepResult {
-    Continue,
-    ReadyToEmit,
-    Done,
-}
-
-impl Emitter for Operator {
-    fn step(
-        &mut self,
-        program: &mut ProgramBuilder,
-        m: &mut Metadata,
-        referenced_tables: &[BTreeTableReference],
-    ) -> Result<OpStepResult> {
-        let current_operator_column_count = self.column_count(referenced_tables);
-        match self {
-            Operator::Scan {
-                table_reference,
-                id,
-                step,
-                predicates,
-                iter_dir,
-            } => {
-                *step += 1;
-                const SCAN_OPEN_READ: usize = 1;
-                const SCAN_BODY: usize = 2;
-                const SCAN_NEXT: usize = 3;
-                let reverse = iter_dir
-                    .as_ref()
-                    .is_some_and(|iter_dir| *iter_dir == IterationDirection::Backwards);
-                match *step {
-                    SCAN_OPEN_READ => {
-                        let cursor_id = program.alloc_cursor_id(
-                            Some(table_reference.table_identifier.clone()),
-                            Some(Table::BTree(table_reference.table.clone())),
-                        );
-                        let root_page = table_reference.table.root_page;
-                        let next_row_label = program.allocate_label();
-                        m.next_row_labels.insert(*id, next_row_label);
-                        program.emit_insn(Insn::OpenReadAsync {
-                            cursor_id,
-                            root_page,
-                        });
-                        program.emit_insn(Insn::OpenReadAwait);
-
-                        Ok(OpStepResult::Continue)
-                    }
-                    SCAN_BODY => {
-                        let cursor_id =
-                            program.resolve_cursor_id(&table_reference.table_identifier, None);
-                        if reverse {
-                            program.emit_insn(Insn::LastAsync { cursor_id });
-                        } else {
-                            program.emit_insn(Insn::RewindAsync { cursor_id });
-                        }
-                        let scan_loop_body_label = program.allocate_label();
-                        let halt_label = m.termination_label_stack.last().unwrap();
-                        program.emit_insn_with_label_dependency(
-                            if reverse {
-                                Insn::LastAwait {
-                                    cursor_id,
-                                    pc_if_empty: *halt_label,
-                                }
-                            } else {
-                                Insn::RewindAwait {
-                                    cursor_id,
-                                    pc_if_empty: *halt_label,
-                                }
-                            },
-                            *halt_label,
-                        );
-                        m.scan_loop_body_labels.push(scan_loop_body_label);
-                        program.defer_label_resolution(
-                            scan_loop_body_label,
-                            program.offset() as usize,
-                        );
-
-                        let jump_label = m.next_row_labels.get(id).unwrap_or(halt_label);
-                        if let Some(preds) = predicates {
-                            for expr in preds {
-                                let jump_target_when_true = program.allocate_label();
-                                let condition_metadata = ConditionMetadata {
-                                    jump_if_condition_is_true: false,
-                                    jump_target_when_true,
-                                    jump_target_when_false: *jump_label,
-                                };
-                                translate_condition_expr(
-                                    program,
-                                    referenced_tables,
-                                    expr,
-                                    None,
-                                    condition_metadata,
-                                )?;
-                                program.resolve_label(jump_target_when_true, program.offset());
-                            }
-                        }
-
-                        Ok(OpStepResult::ReadyToEmit)
-                    }
-                    SCAN_NEXT => {
-                        let cursor_id =
-                            program.resolve_cursor_id(&table_reference.table_identifier, None);
-                        program
-                            .resolve_label(*m.next_row_labels.get(id).unwrap(), program.offset());
-                        if reverse {
-                            program.emit_insn(Insn::PrevAsync { cursor_id });
-                        } else {
-                            program.emit_insn(Insn::NextAsync { cursor_id });
-                        }
-                        let jump_label = m.scan_loop_body_labels.pop().unwrap();
-
-                        if reverse {
-                            program.emit_insn_with_label_dependency(
-                                Insn::PrevAwait {
-                                    cursor_id,
-                                    pc_if_next: jump_label,
-                                },
-                                jump_label,
-                            );
-                        } else {
-                            program.emit_insn_with_label_dependency(
-                                Insn::NextAwait {
-                                    cursor_id,
-                                    pc_if_next: jump_label,
-                                },
-                                jump_label,
-                            );
-                        }
-                        Ok(OpStepResult::Done)
-                    }
-                    _ => Ok(OpStepResult::Done),
-                }
-            }
-            Operator::Search {
-                table_reference,
-                search,
-                predicates,
-                step,
-                id,
-                ..
-            } => {
-                *step += 1;
-                const SEARCH_OPEN_READ: usize = 1;
-                const SEARCH_BODY: usize = 2;
-                const SEARCH_NEXT: usize = 3;
-                match *step {
-                    SEARCH_OPEN_READ => {
-                        let table_cursor_id = program.alloc_cursor_id(
-                            Some(table_reference.table_identifier.clone()),
-                            Some(Table::BTree(table_reference.table.clone())),
-                        );
-
-                        let next_row_label = program.allocate_label();
-
-                        if !matches!(search, Search::PrimaryKeyEq { .. }) {
-                            // Primary key equality search is handled with a SeekRowid instruction which does not loop, since it is a single row lookup.
-                            m.next_row_labels.insert(*id, next_row_label);
-                        }
-
-                        let scan_loop_body_label = program.allocate_label();
-                        m.scan_loop_body_labels.push(scan_loop_body_label);
-                        program.emit_insn(Insn::OpenReadAsync {
-                            cursor_id: table_cursor_id,
-                            root_page: table_reference.table.root_page,
-                        });
-                        program.emit_insn(Insn::OpenReadAwait);
-
-                        if let Search::IndexSearch { index, .. } = search {
-                            let index_cursor_id = program.alloc_cursor_id(
-                                Some(index.name.clone()),
-                                Some(Table::Index(index.clone())),
-                            );
-                            program.emit_insn(Insn::OpenReadAsync {
-                                cursor_id: index_cursor_id,
-                                root_page: index.root_page,
-                            });
-                            program.emit_insn(Insn::OpenReadAwait);
-                        }
-                        Ok(OpStepResult::Continue)
-                    }
-                    SEARCH_BODY => {
-                        let table_cursor_id =
-                            program.resolve_cursor_id(&table_reference.table_identifier, None);
-
-                        // Open the loop for the index search.
-                        // Primary key equality search is handled with a SeekRowid instruction which does not loop, since it is a single row lookup.
-                        if !matches!(search, Search::PrimaryKeyEq { .. }) {
-                            let index_cursor_id = if let Search::IndexSearch { index, .. } = search
-                            {
-                                Some(program.resolve_cursor_id(&index.name, None))
-                            } else {
-                                None
-                            };
-                            let scan_loop_body_label = *m.scan_loop_body_labels.last().unwrap();
-                            let cmp_reg = program.alloc_register();
-                            let (cmp_expr, cmp_op) = match search {
-                                Search::IndexSearch {
-                                    cmp_expr, cmp_op, ..
-                                } => (cmp_expr, cmp_op),
-                                Search::PrimaryKeySearch { cmp_expr, cmp_op } => (cmp_expr, cmp_op),
-                                Search::PrimaryKeyEq { .. } => unreachable!(),
-                            };
-                            // TODO this only handles ascending indexes
-                            match cmp_op {
-                                ast::Operator::Equals
-                                | ast::Operator::Greater
-                                | ast::Operator::GreaterEquals => {
-                                    translate_expr(
-                                        program,
-                                        Some(referenced_tables),
-                                        cmp_expr,
-                                        cmp_reg,
-                                        None,
-                                        None,
-                                    )?;
-                                }
-                                ast::Operator::Less | ast::Operator::LessEquals => {
-                                    program.emit_insn(Insn::Null {
-                                        dest: cmp_reg,
-                                        dest_end: None,
-                                    });
-                                }
-                                _ => unreachable!(),
-                            }
-                            program.emit_insn_with_label_dependency(
-                                match cmp_op {
-                                    ast::Operator::Equals | ast::Operator::GreaterEquals => {
-                                        Insn::SeekGE {
-                                            is_index: index_cursor_id.is_some(),
-                                            cursor_id: index_cursor_id.unwrap_or(table_cursor_id),
-                                            start_reg: cmp_reg,
-                                            num_regs: 1,
-                                            target_pc: *m.termination_label_stack.last().unwrap(),
-                                        }
-                                    }
-                                    ast::Operator::Greater
-                                    | ast::Operator::Less
-                                    | ast::Operator::LessEquals => Insn::SeekGT {
-                                        is_index: index_cursor_id.is_some(),
-                                        cursor_id: index_cursor_id.unwrap_or(table_cursor_id),
-                                        start_reg: cmp_reg,
-                                        num_regs: 1,
-                                        target_pc: *m.termination_label_stack.last().unwrap(),
-                                    },
-                                    _ => unreachable!(),
-                                },
-                                *m.termination_label_stack.last().unwrap(),
-                            );
-                            if *cmp_op == ast::Operator::Less
-                                || *cmp_op == ast::Operator::LessEquals
-                            {
-                                translate_expr(
-                                    program,
-                                    Some(referenced_tables),
-                                    cmp_expr,
-                                    cmp_reg,
-                                    None,
-                                    None,
-                                )?;
-                            }
-
-                            program.defer_label_resolution(
-                                scan_loop_body_label,
-                                program.offset() as usize,
-                            );
-                            // TODO: We are currently only handling ascending indexes.
-                            // For conditions like index_key > 10, we have already seeked to the first key greater than 10, and can just scan forward.
-                            // For conditions like index_key < 10, we are at the beginning of the index, and will scan forward and emit IdxGE(10) with a conditional jump to the end.
-                            // For conditions like index_key = 10, we have already seeked to the first key greater than or equal to 10, and can just scan forward and emit IdxGT(10) with a conditional jump to the end.
-                            // For conditions like index_key >= 10, we have already seeked to the first key greater than or equal to 10, and can just scan forward.
-                            // For conditions like index_key <= 10, we are at the beginning of the index, and will scan forward and emit IdxGT(10) with a conditional jump to the end.
-                            // For conditions like index_key != 10, TODO. probably the optimal way is not to use an index at all.
-                            //
-                            // For primary key searches we emit RowId and then compare it to the seek value.
-
-                            let abort_jump_target = *m
-                                .next_row_labels
-                                .get(id)
-                                .unwrap_or(m.termination_label_stack.last().unwrap());
-                            match cmp_op {
-                                ast::Operator::Equals | ast::Operator::LessEquals => {
-                                    if let Some(index_cursor_id) = index_cursor_id {
-                                        program.emit_insn_with_label_dependency(
-                                            Insn::IdxGT {
-                                                cursor_id: index_cursor_id,
-                                                start_reg: cmp_reg,
-                                                num_regs: 1,
-                                                target_pc: abort_jump_target,
-                                            },
-                                            abort_jump_target,
-                                        );
-                                    } else {
-                                        let rowid_reg = program.alloc_register();
-                                        program.emit_insn(Insn::RowId {
-                                            cursor_id: table_cursor_id,
-                                            dest: rowid_reg,
-                                        });
-                                        program.emit_insn_with_label_dependency(
-                                            Insn::Gt {
-                                                lhs: rowid_reg,
-                                                rhs: cmp_reg,
-                                                target_pc: abort_jump_target,
-                                            },
-                                            abort_jump_target,
-                                        );
-                                    }
-                                }
-                                ast::Operator::Less => {
-                                    if let Some(index_cursor_id) = index_cursor_id {
-                                        program.emit_insn_with_label_dependency(
-                                            Insn::IdxGE {
-                                                cursor_id: index_cursor_id,
-                                                start_reg: cmp_reg,
-                                                num_regs: 1,
-                                                target_pc: abort_jump_target,
-                                            },
-                                            abort_jump_target,
-                                        );
-                                    } else {
-                                        let rowid_reg = program.alloc_register();
-                                        program.emit_insn(Insn::RowId {
-                                            cursor_id: table_cursor_id,
-                                            dest: rowid_reg,
-                                        });
-                                        program.emit_insn_with_label_dependency(
-                                            Insn::Ge {
-                                                lhs: rowid_reg,
-                                                rhs: cmp_reg,
-                                                target_pc: abort_jump_target,
-                                            },
-                                            abort_jump_target,
-                                        );
-                                    }
-                                }
-                                _ => {}
-                            }
-
-                            if let Some(index_cursor_id) = index_cursor_id {
-                                program.emit_insn(Insn::DeferredSeek {
-                                    index_cursor_id,
-                                    table_cursor_id,
-                                });
-                            }
-                        }
-
-                        let jump_label = m
-                            .next_row_labels
-                            .get(id)
-                            .unwrap_or(m.termination_label_stack.last().unwrap());
-
-                        if let Search::PrimaryKeyEq { cmp_expr } = search {
-                            let src_reg = program.alloc_register();
-                            translate_expr(
-                                program,
-                                Some(referenced_tables),
-                                cmp_expr,
-                                src_reg,
-                                None,
-                                None,
-                            )?;
-                            program.emit_insn_with_label_dependency(
-                                Insn::SeekRowid {
-                                    cursor_id: table_cursor_id,
-                                    src_reg,
-                                    target_pc: *jump_label,
-                                },
-                                *jump_label,
-                            );
-                        }
-                        if let Some(predicates) = predicates {
-                            for predicate in predicates.iter() {
-                                let jump_target_when_true = program.allocate_label();
-                                let condition_metadata = ConditionMetadata {
-                                    jump_if_condition_is_true: false,
-                                    jump_target_when_true,
-                                    jump_target_when_false: *jump_label,
-                                };
-                                translate_condition_expr(
-                                    program,
-                                    referenced_tables,
-                                    predicate,
-                                    None,
-                                    condition_metadata,
-                                )?;
-                                program.resolve_label(jump_target_when_true, program.offset());
-                            }
-                        }
-
-                        Ok(OpStepResult::ReadyToEmit)
-                    }
-                    SEARCH_NEXT => {
-                        if matches!(search, Search::PrimaryKeyEq { .. }) {
-                            // Primary key equality search is handled with a SeekRowid instruction which does not loop, so there is no need to emit a NextAsync instruction.
-                            return Ok(OpStepResult::Done);
-                        }
-                        let cursor_id = match search {
-                            Search::IndexSearch { index, .. } => {
-                                program.resolve_cursor_id(&index.name, None)
-                            }
-                            Search::PrimaryKeySearch { .. } => {
-                                program.resolve_cursor_id(&table_reference.table_identifier, None)
-                            }
-                            Search::PrimaryKeyEq { .. } => unreachable!(),
-                        };
-                        program
-                            .resolve_label(*m.next_row_labels.get(id).unwrap(), program.offset());
-                        program.emit_insn(Insn::NextAsync { cursor_id });
-                        let jump_label = m.scan_loop_body_labels.pop().unwrap();
-                        program.emit_insn_with_label_dependency(
-                            Insn::NextAwait {
-                                cursor_id,
-                                pc_if_next: jump_label,
-                            },
-                            jump_label,
-                        );
-                        Ok(OpStepResult::Done)
-                    }
-                    _ => Ok(OpStepResult::Done),
-                }
-            }
-            Operator::Join {
-                left,
-                right,
-                outer,
-                predicates,
-                step,
-                id,
-                ..
-            } => {
-                *step += 1;
-                const JOIN_INIT: usize = 1;
-                const JOIN_DO_JOIN: usize = 2;
-                const JOIN_END: usize = 3;
-                match *step {
-                    JOIN_INIT => {
-                        if *outer {
-                            let lj_metadata = LeftJoinMetadata {
-                                match_flag_register: program.alloc_register(),
-                                set_match_flag_true_label: program.allocate_label(),
-                                check_match_flag_label: program.allocate_label(),
-                                on_match_jump_to_label: program.allocate_label(),
-                            };
-                            m.left_joins.insert(*id, lj_metadata);
-                        }
-                        left.step(program, m, referenced_tables)?;
-                        right.step(program, m, referenced_tables)?;
-
-                        Ok(OpStepResult::Continue)
-                    }
-                    JOIN_DO_JOIN => {
-                        left.step(program, m, referenced_tables)?;
-
-                        let mut jump_target_when_false = *m
-                            .next_row_labels
-                            .get(&right.id())
-                            .or(m.next_row_labels.get(&left.id()))
-                            .unwrap_or(m.termination_label_stack.last().unwrap());
-
-                        if *outer {
-                            let lj_meta = m.left_joins.get(id).unwrap();
-                            program.emit_insn(Insn::Integer {
-                                value: 0,
-                                dest: lj_meta.match_flag_register,
-                            });
-                            jump_target_when_false = lj_meta.check_match_flag_label;
-                        }
-                        m.next_row_labels.insert(right.id(), jump_target_when_false);
-
-                        right.step(program, m, referenced_tables)?;
-
-                        if let Some(predicates) = predicates {
-                            let jump_target_when_true = program.allocate_label();
-                            let condition_metadata = ConditionMetadata {
-                                jump_if_condition_is_true: false,
-                                jump_target_when_true,
-                                jump_target_when_false,
-                            };
-                            for predicate in predicates.iter() {
-                                translate_condition_expr(
-                                    program,
-                                    referenced_tables,
-                                    predicate,
-                                    None,
-                                    condition_metadata,
-                                )?;
-                            }
-                            program.resolve_label(jump_target_when_true, program.offset());
-                        }
-
-                        if *outer {
-                            let lj_meta = m.left_joins.get(id).unwrap();
-                            program.defer_label_resolution(
-                                lj_meta.set_match_flag_true_label,
-                                program.offset() as usize,
-                            );
-                            program.emit_insn(Insn::Integer {
-                                value: 1,
-                                dest: lj_meta.match_flag_register,
-                            });
-                        }
-
-                        Ok(OpStepResult::ReadyToEmit)
-                    }
-                    JOIN_END => {
-                        right.step(program, m, referenced_tables)?;
-
-                        if *outer {
-                            let lj_meta = m.left_joins.get(id).unwrap();
-                            // If the left join match flag has been set to 1, we jump to the next row on the outer table (result row has been emitted already)
-                            program.resolve_label(lj_meta.check_match_flag_label, program.offset());
-                            program.emit_insn_with_label_dependency(
-                                Insn::IfPos {
-                                    reg: lj_meta.match_flag_register,
-                                    target_pc: lj_meta.on_match_jump_to_label,
-                                    decrement_by: 0,
-                                },
-                                lj_meta.on_match_jump_to_label,
-                            );
-                            // If not, we set the right table cursor's "pseudo null bit" on, which means any Insn::Column will return NULL
-                            let right_cursor_id = match right.as_ref() {
-                                Operator::Scan {
-                                    table_reference, ..
-                                } => program
-                                    .resolve_cursor_id(&table_reference.table_identifier, None),
-                                Operator::Search {
-                                    table_reference, ..
-                                } => program
-                                    .resolve_cursor_id(&table_reference.table_identifier, None),
-                                _ => unreachable!(),
-                            };
-                            program.emit_insn(Insn::NullRow {
-                                cursor_id: right_cursor_id,
-                            });
-                            // Jump to setting the left join match flag to 1 again, but this time the right table cursor will set everything to null
-                            program.emit_insn_with_label_dependency(
-                                Insn::Goto {
-                                    target_pc: lj_meta.set_match_flag_true_label,
-                                },
-                                lj_meta.set_match_flag_true_label,
-                            );
-                        }
-                        let next_row_label = if *outer {
-                            m.left_joins.get(id).unwrap().on_match_jump_to_label
-                        } else {
-                            *m.next_row_labels.get(&right.id()).unwrap()
-                        };
-                        // This points to the NextAsync instruction of the left table
-                        program.resolve_label(next_row_label, program.offset());
-                        left.step(program, m, referenced_tables)?;
-
-                        Ok(OpStepResult::Done)
-                    }
-                    _ => Ok(OpStepResult::Done),
-                }
-            }
-            Operator::Aggregate {
-                id,
-                source,
-                aggregates,
-                group_by,
-                step,
-                ..
-            } => {
-                *step += 1;
-
-                // Group by aggregation eg. SELECT a, b, sum(c) FROM t GROUP BY a, b
-                if let Some(group_by) = group_by {
-                    const GROUP_BY_INIT: usize = 1;
-                    const GROUP_BY_INSERT_INTO_SORTER: usize = 2;
-                    const GROUP_BY_SORT_AND_COMPARE: usize = 3;
-                    const GROUP_BY_PREPARE_ROW: usize = 4;
-                    const GROUP_BY_CLEAR_ACCUMULATOR_SUBROUTINE: usize = 5;
-                    match *step {
-                        GROUP_BY_INIT => {
-                            let agg_final_label = program.allocate_label();
-                            m.termination_label_stack.push(agg_final_label);
-                            let num_aggs = aggregates.len();
-
-                            let sort_cursor = program.alloc_cursor_id(None, None);
-
-                            let abort_flag_register = program.alloc_register();
-                            let data_in_accumulator_indicator_register = program.alloc_register();
-                            let group_exprs_comparison_register =
-                                program.alloc_registers(group_by.len());
-                            let group_exprs_accumulator_register =
-                                program.alloc_registers(group_by.len());
-                            let agg_exprs_start_reg = program.alloc_registers(num_aggs);
-                            m.aggregation_start_registers
-                                .insert(*id, agg_exprs_start_reg);
-                            let sorter_key_register = program.alloc_register();
-
-                            let subroutine_accumulator_clear_label = program.allocate_label();
-                            let subroutine_accumulator_output_label = program.allocate_label();
-                            let sorter_data_label = program.allocate_label();
-                            let grouping_done_label = program.allocate_label();
-
-                            let mut order = Vec::new();
-                            const ASCENDING: i64 = 0;
-                            for _ in group_by.iter() {
-                                order.push(OwnedValue::Integer(ASCENDING));
-                            }
-                            program.emit_insn(Insn::SorterOpen {
-                                cursor_id: sort_cursor,
-                                columns: current_operator_column_count,
-                                order: OwnedRecord::new(order),
-                            });
-
-                            program.add_comment(program.offset(), "clear group by abort flag");
-                            program.emit_insn(Insn::Integer {
-                                value: 0,
-                                dest: abort_flag_register,
-                            });
-
-                            program.add_comment(
-                                program.offset(),
-                                "initialize group by comparison registers to NULL",
-                            );
-                            program.emit_insn(Insn::Null {
-                                dest: group_exprs_comparison_register,
-                                dest_end: if group_by.len() > 1 {
-                                    Some(group_exprs_comparison_register + group_by.len() - 1)
-                                } else {
-                                    None
-                                },
-                            });
-
-                            program.add_comment(
-                                program.offset(),
-                                "go to clear accumulator subroutine",
-                            );
-
-                            let subroutine_accumulator_clear_return_offset_register =
-                                program.alloc_register();
-                            program.emit_insn_with_label_dependency(
-                                Insn::Gosub {
-                                    target_pc: subroutine_accumulator_clear_label,
-                                    return_reg: subroutine_accumulator_clear_return_offset_register,
-                                },
-                                subroutine_accumulator_clear_label,
-                            );
-
-                            m.group_bys.insert(
-                                *id,
-                                GroupByMetadata {
-                                    sort_cursor,
-                                    subroutine_accumulator_clear_label,
-                                    subroutine_accumulator_clear_return_offset_register,
-                                    subroutine_accumulator_output_label,
-                                    subroutine_accumulator_output_return_offset_register: program
-                                        .alloc_register(),
-                                    accumulator_indicator_set_true_label: program.allocate_label(),
-                                    sorter_data_label,
-                                    grouping_done_label,
-                                    abort_flag_register,
-                                    data_in_accumulator_indicator_register,
-                                    group_exprs_accumulator_register,
-                                    group_exprs_comparison_register,
-                                    sorter_key_register,
-                                },
-                            );
-
-                            loop {
-                                match source.step(program, m, referenced_tables)? {
-                                    OpStepResult::Continue => continue,
-                                    OpStepResult::ReadyToEmit => {
-                                        return Ok(OpStepResult::Continue);
-                                    }
-                                    OpStepResult::Done => {
-                                        return Ok(OpStepResult::Done);
-                                    }
-                                }
-                            }
-                        }
-                        GROUP_BY_INSERT_INTO_SORTER => {
-                            let sort_keys_count = group_by.len();
-                            let start_reg = program.alloc_registers(current_operator_column_count);
-                            for (i, expr) in group_by.iter().enumerate() {
-                                let key_reg = start_reg + i;
-                                translate_expr(
-                                    program,
-                                    Some(referenced_tables),
-                                    expr,
-                                    key_reg,
-                                    None,
-                                    None,
-                                )?;
-                            }
-                            for (i, agg) in aggregates.iter().enumerate() {
-                                // TODO it's a hack to assume aggregate functions have exactly one argument.
-                                // Counterpoint e.g. GROUP_CONCAT(expr, separator).
-                                //
-                                // Here we are collecting scalars for the group by sorter, which will include
-                                // both the group by expressions and the aggregate arguments.
-                                // e.g. in `select u.first_name, sum(u.age) from users group by u.first_name`
-                                // the sorter will have two scalars: u.first_name and u.age.
-                                // these are then sorted by u.first_name, and for each u.first_name, we sum the u.age.
-                                // the actual aggregation is done later in GROUP_BY_SORT_AND_COMPARE below.
-                                //
-                                // This is why we take the first argument of each aggregate function currently.
-                                // It's mostly an artifact of the current architecture being a bit poor; we should recognize
-                                // which scalars are dependencies of aggregate functions and explicitly collect those.
-                                let expr = &agg.args[0];
-                                let agg_reg = start_reg + sort_keys_count + i;
-                                translate_expr(
-                                    program,
-                                    Some(referenced_tables),
-                                    expr,
-                                    agg_reg,
-                                    None,
-                                    None,
-                                )?;
-                            }
-
-                            let group_by_metadata = m.group_bys.get(id).unwrap();
-
-                            program.emit_insn(Insn::MakeRecord {
-                                start_reg,
-                                count: current_operator_column_count,
-                                dest_reg: group_by_metadata.sorter_key_register,
-                            });
-
-                            let group_by_metadata = m.group_bys.get(id).unwrap();
-                            program.emit_insn(Insn::SorterInsert {
-                                cursor_id: group_by_metadata.sort_cursor,
-                                record_reg: group_by_metadata.sorter_key_register,
-                            });
-
-                            return Ok(OpStepResult::Continue);
-                        }
-                        #[allow(clippy::never_loop)]
-                        GROUP_BY_SORT_AND_COMPARE => {
-                            loop {
-                                match source.step(program, m, referenced_tables)? {
-                                    OpStepResult::Done => {
-                                        break;
-                                    }
-                                    _ => unreachable!(),
-                                }
-                            }
-
-                            let group_by_metadata = m.group_bys.get_mut(id).unwrap();
-
-                            let GroupByMetadata {
-                                group_exprs_comparison_register: comparison_register,
-                                subroutine_accumulator_output_return_offset_register,
-                                subroutine_accumulator_output_label,
-                                subroutine_accumulator_clear_return_offset_register,
-                                subroutine_accumulator_clear_label,
-                                data_in_accumulator_indicator_register,
-                                accumulator_indicator_set_true_label,
-                                group_exprs_accumulator_register: group_exprs_start_register,
-                                abort_flag_register,
-                                sorter_key_register,
-                                ..
-                            } = *group_by_metadata;
-                            let halt_label = *m.termination_label_stack.first().unwrap();
-
-                            let mut column_names =
-                                Vec::with_capacity(current_operator_column_count);
-                            for expr in group_by
-                                .iter()
-                                .chain(aggregates.iter().map(|agg| &agg.args[0]))
-                            // FIXME: just blindly taking the first arg is a hack
-                            {
-                                // Sorter column names for group by are now just determined by stringifying the expression, since the group by
-                                // columns and aggregations can be practically anything.
-                                // FIXME: either come up with something more robust, or make this something like expr.to_canonical_string() so that we can handle
-                                // things like `count(1)` and `COUNT(1)` the same way
-                                column_names.push(expr.to_string());
-                            }
-                            let pseudo_columns = column_names
-                                .iter()
-                                .map(|name| Column {
-                                    name: name.clone(),
-                                    primary_key: false,
-                                    ty: crate::schema::Type::Null,
-                                })
-                                .collect::<Vec<_>>();
-
-                            let pseudo_table = Rc::new(PseudoTable {
-                                columns: pseudo_columns,
-                            });
-
-                            let pseudo_cursor = program
-                                .alloc_cursor_id(None, Some(Table::Pseudo(pseudo_table.clone())));
-
-                            program.emit_insn(Insn::OpenPseudo {
-                                cursor_id: pseudo_cursor,
-                                content_reg: sorter_key_register,
-                                num_fields: current_operator_column_count,
-                            });
-
-                            let group_by_metadata = m.group_bys.get(id).unwrap();
-                            program.emit_insn_with_label_dependency(
-                                Insn::SorterSort {
-                                    cursor_id: group_by_metadata.sort_cursor,
-                                    pc_if_empty: group_by_metadata.grouping_done_label,
-                                },
-                                group_by_metadata.grouping_done_label,
-                            );
-
-                            program.defer_label_resolution(
-                                group_by_metadata.sorter_data_label,
-                                program.offset() as usize,
-                            );
-                            program.emit_insn(Insn::SorterData {
-                                cursor_id: group_by_metadata.sort_cursor,
-                                dest_reg: group_by_metadata.sorter_key_register,
-                                pseudo_cursor,
-                            });
-
-                            let groups_start_reg = program.alloc_registers(group_by.len());
-                            for (i, expr) in group_by.iter().enumerate() {
-                                let sorter_column_index =
-                                    resolve_ident_pseudo_table(&expr.to_string(), &pseudo_table)?;
-                                let group_reg = groups_start_reg + i;
-                                program.emit_insn(Insn::Column {
-                                    cursor_id: pseudo_cursor,
-                                    column: sorter_column_index,
-                                    dest: group_reg,
-                                });
-                            }
-
-                            program.emit_insn(Insn::Compare {
-                                start_reg_a: comparison_register,
-                                start_reg_b: groups_start_reg,
-                                count: group_by.len(),
-                            });
-
-                            let agg_step_label = program.allocate_label();
-
-                            program.add_comment(
-                                program.offset(),
-                                "start new group if comparison is not equal",
-                            );
-                            program.emit_insn_with_label_dependency(
-                                Insn::Jump {
-                                    target_pc_lt: program.offset() + 1,
-                                    target_pc_eq: agg_step_label,
-                                    target_pc_gt: program.offset() + 1,
-                                },
-                                agg_step_label,
-                            );
-
-                            program.emit_insn(Insn::Move {
-                                source_reg: groups_start_reg,
-                                dest_reg: comparison_register,
-                                count: group_by.len(),
-                            });
-
-                            program.add_comment(
-                                program.offset(),
-                                "check if ended group had data, and output if so",
-                            );
-                            program.emit_insn_with_label_dependency(
-                                Insn::Gosub {
-                                    target_pc: subroutine_accumulator_output_label,
-                                    return_reg:
-                                        subroutine_accumulator_output_return_offset_register,
-                                },
-                                subroutine_accumulator_output_label,
-                            );
-
-                            program.add_comment(program.offset(), "check abort flag");
-                            program.emit_insn_with_label_dependency(
-                                Insn::IfPos {
-                                    reg: abort_flag_register,
-                                    target_pc: halt_label,
-                                    decrement_by: 0,
-                                },
-                                m.termination_label_stack[0],
-                            );
-
-                            program
-                                .add_comment(program.offset(), "goto clear accumulator subroutine");
-                            program.emit_insn_with_label_dependency(
-                                Insn::Gosub {
-                                    target_pc: subroutine_accumulator_clear_label,
-                                    return_reg: subroutine_accumulator_clear_return_offset_register,
-                                },
-                                subroutine_accumulator_clear_label,
-                            );
-
-                            program.resolve_label(agg_step_label, program.offset());
-                            let start_reg = m.aggregation_start_registers.get(id).unwrap();
-                            for (i, agg) in aggregates.iter().enumerate() {
-                                let agg_result_reg = start_reg + i;
-                                translate_aggregation(
-                                    program,
-                                    referenced_tables,
-                                    agg,
-                                    agg_result_reg,
-                                    Some(pseudo_cursor),
-                                )?;
-                            }
-
-                            program.add_comment(
-                                program.offset(),
-                                "don't emit group columns if continuing existing group",
-                            );
-                            program.emit_insn_with_label_dependency(
-                                Insn::If {
-                                    target_pc: accumulator_indicator_set_true_label,
-                                    reg: data_in_accumulator_indicator_register,
-                                    null_reg: 0, // unused in this case
-                                },
-                                accumulator_indicator_set_true_label,
-                            );
-
-                            for (i, expr) in group_by.iter().enumerate() {
-                                let key_reg = group_exprs_start_register + i;
-                                let sorter_column_index =
-                                    resolve_ident_pseudo_table(&expr.to_string(), &pseudo_table)?;
-                                program.emit_insn(Insn::Column {
-                                    cursor_id: pseudo_cursor,
-                                    column: sorter_column_index,
-                                    dest: key_reg,
-                                });
-                            }
-
-                            program.resolve_label(
-                                accumulator_indicator_set_true_label,
-                                program.offset(),
-                            );
-                            program.add_comment(program.offset(), "indicate data in accumulator");
-                            program.emit_insn(Insn::Integer {
-                                value: 1,
-                                dest: data_in_accumulator_indicator_register,
-                            });
-
-                            return Ok(OpStepResult::Continue);
-                        }
-                        GROUP_BY_PREPARE_ROW => {
-                            let group_by_metadata = m.group_bys.get(id).unwrap();
-                            program.emit_insn_with_label_dependency(
-                                Insn::SorterNext {
-                                    cursor_id: group_by_metadata.sort_cursor,
-                                    pc_if_next: group_by_metadata.sorter_data_label,
-                                },
-                                group_by_metadata.sorter_data_label,
-                            );
-
-                            program.resolve_label(
-                                group_by_metadata.grouping_done_label,
-                                program.offset(),
-                            );
-
-                            program.add_comment(program.offset(), "emit row for final group");
-                            program.emit_insn_with_label_dependency(
-                                Insn::Gosub {
-                                    target_pc: group_by_metadata
-                                        .subroutine_accumulator_output_label,
-                                    return_reg: group_by_metadata
-                                        .subroutine_accumulator_output_return_offset_register,
-                                },
-                                group_by_metadata.subroutine_accumulator_output_label,
-                            );
-
-                            program.add_comment(program.offset(), "group by finished");
-                            let termination_label =
-                                m.termination_label_stack[m.termination_label_stack.len() - 2];
-                            program.emit_insn_with_label_dependency(
-                                Insn::Goto {
-                                    target_pc: termination_label,
-                                },
-                                termination_label,
-                            );
-                            program.emit_insn(Insn::Integer {
-                                value: 1,
-                                dest: group_by_metadata.abort_flag_register,
-                            });
-                            program.emit_insn(Insn::Return {
-                                return_reg: group_by_metadata
-                                    .subroutine_accumulator_output_return_offset_register,
-                            });
-
-                            program.resolve_label(
-                                group_by_metadata.subroutine_accumulator_output_label,
-                                program.offset(),
-                            );
-
-                            program.add_comment(
-                                program.offset(),
-                                "output group by row subroutine start",
-                            );
-                            let termination_label = *m.termination_label_stack.last().unwrap();
-                            program.emit_insn_with_label_dependency(
-                                Insn::IfPos {
-                                    reg: group_by_metadata.data_in_accumulator_indicator_register,
-                                    target_pc: termination_label,
-                                    decrement_by: 0,
-                                },
-                                termination_label,
-                            );
-                            program.emit_insn(Insn::Return {
-                                return_reg: group_by_metadata
-                                    .subroutine_accumulator_output_return_offset_register,
-                            });
-
-                            return Ok(OpStepResult::ReadyToEmit);
-                        }
-                        GROUP_BY_CLEAR_ACCUMULATOR_SUBROUTINE => {
-                            let group_by_metadata = m.group_bys.get(id).unwrap();
-                            program.emit_insn(Insn::Return {
-                                return_reg: group_by_metadata
-                                    .subroutine_accumulator_output_return_offset_register,
-                            });
-
-                            program.add_comment(
-                                program.offset(),
-                                "clear accumulator subroutine start",
-                            );
-                            program.resolve_label(
-                                group_by_metadata.subroutine_accumulator_clear_label,
-                                program.offset(),
-                            );
-                            let start_reg = group_by_metadata.group_exprs_accumulator_register;
-                            program.emit_insn(Insn::Null {
-                                dest: start_reg,
-                                dest_end: Some(start_reg + group_by.len() + aggregates.len() - 1),
-                            });
-
-                            program.emit_insn(Insn::Integer {
-                                value: 0,
-                                dest: group_by_metadata.data_in_accumulator_indicator_register,
-                            });
-                            program.emit_insn(Insn::Return {
-                                return_reg: group_by_metadata
-                                    .subroutine_accumulator_clear_return_offset_register,
-                            });
-                        }
-                        _ => {
-                            return Ok(OpStepResult::Done);
-                        }
-                    }
-                }
-
-                // Non-grouped aggregation e.g. SELECT COUNT(*) FROM t
-
-                const AGGREGATE_INIT: usize = 1;
-                const AGGREGATE_WAIT_UNTIL_SOURCE_READY: usize = 2;
-                match *step {
-                    AGGREGATE_INIT => {
-                        let agg_final_label = program.allocate_label();
-                        m.termination_label_stack.push(agg_final_label);
-                        let num_aggs = aggregates.len();
-                        let start_reg = program.alloc_registers(num_aggs);
-                        m.aggregation_start_registers.insert(*id, start_reg);
-
-                        Ok(OpStepResult::Continue)
-                    }
-                    AGGREGATE_WAIT_UNTIL_SOURCE_READY => loop {
-                        match source.step(program, m, referenced_tables)? {
-                            OpStepResult::Continue => {}
-                            OpStepResult::ReadyToEmit => {
-                                let start_reg = m.aggregation_start_registers.get(id).unwrap();
-                                for (i, agg) in aggregates.iter().enumerate() {
-                                    let agg_result_reg = start_reg + i;
-                                    translate_aggregation(
-                                        program,
-                                        referenced_tables,
-                                        agg,
-                                        agg_result_reg,
-                                        None,
-                                    )?;
-                                }
-                            }
-                            OpStepResult::Done => {
-                                return Ok(OpStepResult::ReadyToEmit);
-                            }
-                        }
-                    },
-                    _ => Ok(OpStepResult::Done),
-                }
-            }
-            Operator::Filter { .. } => unreachable!("predicates have been pushed down"),
-            Operator::Limit { source, step, .. } => {
-                *step += 1;
-                loop {
-                    match source.step(program, m, referenced_tables)? {
-                        OpStepResult::Continue => continue,
-                        OpStepResult::ReadyToEmit => {
-                            return Ok(OpStepResult::ReadyToEmit);
-                        }
-                        OpStepResult::Done => return Ok(OpStepResult::Done),
-                    }
-                }
-            }
-            Operator::Order {
-                id,
-                source,
-                key,
-                step,
-            } => {
-                *step += 1;
-                const ORDER_INIT: usize = 1;
-                const ORDER_INSERT_INTO_SORTER: usize = 2;
-                const ORDER_SORT_AND_OPEN_LOOP: usize = 3;
-                const ORDER_NEXT: usize = 4;
-                match *step {
-                    ORDER_INIT => {
-                        m.termination_label_stack.push(program.allocate_label());
-                        let sort_cursor = program.alloc_cursor_id(None, None);
-                        m.sorts.insert(
-                            *id,
-                            SortMetadata {
-                                sort_cursor,
-                                pseudo_table_cursor: usize::MAX, // will be set later
-                                sorter_data_register: program.alloc_register(),
-                                sorter_data_label: program.allocate_label(),
-                                done_label: program.allocate_label(),
-                            },
-                        );
-                        let mut order = Vec::new();
-                        for (_, direction) in key.iter() {
-                            order.push(OwnedValue::Integer(*direction as i64));
-                        }
-                        program.emit_insn(Insn::SorterOpen {
-                            cursor_id: sort_cursor,
-                            columns: key.len(),
-                            order: OwnedRecord::new(order),
-                        });
-
-                        loop {
-                            match source.step(program, m, referenced_tables)? {
-                                OpStepResult::Continue => continue,
-                                OpStepResult::ReadyToEmit => {
-                                    return Ok(OpStepResult::Continue);
-                                }
-                                OpStepResult::Done => {
-                                    return Ok(OpStepResult::Done);
-                                }
-                            }
-                        }
-                    }
-                    ORDER_INSERT_INTO_SORTER => {
-                        let sort_keys_count = key.len();
-                        let source_cols_count = source.column_count(referenced_tables);
-                        let start_reg = program.alloc_registers(sort_keys_count);
-                        source.result_columns(program, referenced_tables, m, None)?;
-
-                        for (i, (expr, _)) in key.iter().enumerate() {
-                            let key_reg = start_reg + i;
-                            translate_expr(
-                                program,
-                                Some(referenced_tables),
-                                expr,
-                                key_reg,
-                                None,
-                                m.expr_result_cache
-                                    .get_cached_result_registers(*id, i)
-                                    .as_ref(),
-                            )?;
-                        }
-
-                        let sort_metadata = m.sorts.get_mut(id).unwrap();
-                        program.emit_insn(Insn::MakeRecord {
-                            start_reg,
-                            count: sort_keys_count + source_cols_count,
-                            dest_reg: sort_metadata.sorter_data_register,
-                        });
-
-                        program.emit_insn(Insn::SorterInsert {
-                            cursor_id: sort_metadata.sort_cursor,
-                            record_reg: sort_metadata.sorter_data_register,
-                        });
-
-                        Ok(OpStepResult::Continue)
-                    }
-                    #[allow(clippy::never_loop)]
-                    ORDER_SORT_AND_OPEN_LOOP => {
-                        loop {
-                            match source.step(program, m, referenced_tables)? {
-                                OpStepResult::Done => {
-                                    break;
-                                }
-                                _ => unreachable!(),
-                            }
-                        }
-                        program.resolve_label(
-                            m.termination_label_stack.pop().unwrap(),
-                            program.offset(),
-                        );
-                        let column_names = source.column_names();
-                        let mut pseudo_columns = vec![];
-                        for (i, _) in key.iter().enumerate() {
-                            pseudo_columns.push(Column {
-                                name: format!("sort_key_{}", i),
-                                primary_key: false,
-                                ty: crate::schema::Type::Null,
-                            });
-                        }
-                        for name in column_names {
-                            pseudo_columns.push(Column {
-                                name: name.clone(),
-                                primary_key: false,
-                                ty: crate::schema::Type::Null,
-                            });
-                        }
-
-                        let num_fields = pseudo_columns.len();
-
-                        let pseudo_cursor = program.alloc_cursor_id(
-                            None,
-                            Some(Table::Pseudo(Rc::new(PseudoTable {
-                                columns: pseudo_columns,
-                            }))),
-                        );
-                        let sort_metadata = m.sorts.get(id).unwrap();
-
-                        program.emit_insn(Insn::OpenPseudo {
-                            cursor_id: pseudo_cursor,
-                            content_reg: sort_metadata.sorter_data_register,
-                            num_fields,
-                        });
-
-                        program.emit_insn_with_label_dependency(
-                            Insn::SorterSort {
-                                cursor_id: sort_metadata.sort_cursor,
-                                pc_if_empty: sort_metadata.done_label,
-                            },
-                            sort_metadata.done_label,
-                        );
-
-                        program.defer_label_resolution(
-                            sort_metadata.sorter_data_label,
-                            program.offset() as usize,
-                        );
-                        program.emit_insn(Insn::SorterData {
-                            cursor_id: sort_metadata.sort_cursor,
-                            dest_reg: sort_metadata.sorter_data_register,
-                            pseudo_cursor,
-                        });
-
-                        let sort_metadata = m.sorts.get_mut(id).unwrap();
-
-                        sort_metadata.pseudo_table_cursor = pseudo_cursor;
-
-                        Ok(OpStepResult::ReadyToEmit)
-                    }
-                    ORDER_NEXT => {
-                        let sort_metadata = m.sorts.get(id).unwrap();
-                        program.emit_insn_with_label_dependency(
-                            Insn::SorterNext {
-                                cursor_id: sort_metadata.sort_cursor,
-                                pc_if_next: sort_metadata.sorter_data_label,
-                            },
-                            sort_metadata.sorter_data_label,
-                        );
-
-                        program.resolve_label(sort_metadata.done_label, program.offset());
-
-                        Ok(OpStepResult::Done)
-                    }
-                    _ => unreachable!(),
-                }
-            }
-            Operator::Projection { source, step, .. } => {
-                *step += 1;
-                const PROJECTION_WAIT_UNTIL_SOURCE_READY: usize = 1;
-                const PROJECTION_FINALIZE_SOURCE: usize = 2;
-                match *step {
-                    PROJECTION_WAIT_UNTIL_SOURCE_READY => loop {
-                        match source.step(program, m, referenced_tables)? {
-                            OpStepResult::Continue => continue,
-                            OpStepResult::ReadyToEmit | OpStepResult::Done => {
-                                if matches!(**source, Operator::Aggregate { .. }) {
-                                    source.result_columns(program, referenced_tables, m, None)?;
-                                }
-                                return Ok(OpStepResult::ReadyToEmit);
-                            }
-                        }
-                    },
-                    PROJECTION_FINALIZE_SOURCE => {
-                        match source.step(program, m, referenced_tables)? {
-                            OpStepResult::Done => Ok(OpStepResult::Done),
-                            _ => unreachable!(),
-                        }
-                    }
-                    _ => Ok(OpStepResult::Done),
-                }
-            }
-            Operator::Nothing => Ok(OpStepResult::Done),
-        }
-    }
-    fn result_columns(
-        &self,
-        program: &mut ProgramBuilder,
-        referenced_tables: &[BTreeTableReference],
-        m: &mut Metadata,
-        cursor_override: Option<&SortCursorOverride>,
-    ) -> Result<usize> {
-        let col_count = self.column_count(referenced_tables);
-        match self {
-            Operator::Scan {
-                table_reference, ..
-            } => {
-                let start_reg = program.alloc_registers(col_count);
-                let table = cursor_override
-                    .map(|c| c.pseudo_table.clone())
-                    .unwrap_or_else(|| Table::BTree(table_reference.table.clone()));
-                let cursor_id = cursor_override.map(|c| c.cursor_id).unwrap_or_else(|| {
-                    program.resolve_cursor_id(&table_reference.table_identifier, None)
-                });
-                let start_column_offset = cursor_override.map(|c| c.sort_key_len).unwrap_or(0);
-                translate_table_columns(program, cursor_id, &table, start_column_offset, start_reg);
-
-                Ok(start_reg)
-            }
-            Operator::Search {
-                table_reference, ..
-            } => {
-                let start_reg = program.alloc_registers(col_count);
-                let table = cursor_override
-                    .map(|c| c.pseudo_table.clone())
-                    .unwrap_or_else(|| Table::BTree(table_reference.table.clone()));
-                let cursor_id = cursor_override.map(|c| c.cursor_id).unwrap_or_else(|| {
-                    program.resolve_cursor_id(&table_reference.table_identifier, None)
-                });
-                let start_column_offset = cursor_override.map(|c| c.sort_key_len).unwrap_or(0);
-                translate_table_columns(program, cursor_id, &table, start_column_offset, start_reg);
-
-                Ok(start_reg)
-            }
-            Operator::Join { left, right, .. } => {
-                let left_start_reg =
-                    left.result_columns(program, referenced_tables, m, cursor_override)?;
-                right.result_columns(program, referenced_tables, m, cursor_override)?;
-
-                Ok(left_start_reg)
-            }
-            Operator::Aggregate {
-                id,
-                aggregates,
-                group_by,
-                ..
-            } => {
-                let agg_start_reg = m.aggregation_start_registers.get(id).unwrap();
-                program.resolve_label(m.termination_label_stack.pop().unwrap(), program.offset());
-                let mut result_column_idx = 0;
-                for (i, agg) in aggregates.iter().enumerate() {
-                    let agg_result_reg = *agg_start_reg + i;
-                    program.emit_insn(Insn::AggFinal {
-                        register: agg_result_reg,
-                        func: agg.func.clone(),
-                    });
-                    m.expr_result_cache.cache_result_register(
-                        *id,
-                        result_column_idx,
-                        agg_result_reg,
-                        agg.original_expr.clone(),
-                    );
-                    result_column_idx += 1;
-                }
-
-                if let Some(group_by) = group_by {
-                    let output_row_start_reg =
-                        program.alloc_registers(aggregates.len() + group_by.len());
-                    let group_by_metadata = m.group_bys.get(id).unwrap();
-                    program.emit_insn(Insn::Copy {
-                        src_reg: group_by_metadata.group_exprs_accumulator_register,
-                        dst_reg: output_row_start_reg,
-                        amount: group_by.len() - 1,
-                    });
-                    for (i, source_expr) in group_by.iter().enumerate() {
-                        m.expr_result_cache.cache_result_register(
-                            *id,
-                            result_column_idx + i,
-                            output_row_start_reg + i,
-                            source_expr.clone(),
-                        );
-                    }
-                    program.emit_insn(Insn::Copy {
-                        src_reg: *agg_start_reg,
-                        dst_reg: output_row_start_reg + group_by.len(),
-                        amount: aggregates.len() - 1,
-                    });
-
-                    Ok(output_row_start_reg)
-                } else {
-                    Ok(*agg_start_reg)
-                }
-            }
-            Operator::Filter { .. } => unreachable!("predicates have been pushed down"),
-            Operator::Limit { .. } => {
-                unimplemented!()
-            }
-            Operator::Order { id, key, .. } => {
-                let cursor_id = m.sorts.get(id).unwrap().pseudo_table_cursor;
-                let pseudo_table = program.resolve_cursor_to_table(cursor_id).unwrap();
-                let start_column_offset = key.len();
-                let column_count = pseudo_table.columns().len() - start_column_offset;
-                let start_reg = program.alloc_registers(column_count);
-                translate_table_columns(
-                    program,
-                    cursor_id,
-                    &pseudo_table,
-                    start_column_offset,
-                    start_reg,
-                );
-
-                Ok(start_reg)
-            }
-            Operator::Projection {
-                expressions, id, ..
-            } => {
-                let expr_count = expressions
-                    .iter()
-                    .map(|e| e.column_count(referenced_tables))
-                    .sum();
-                let start_reg = program.alloc_registers(expr_count);
-                let mut cur_reg = start_reg;
-                for expr in expressions {
-                    match expr {
-                        ProjectionColumn::Column(expr) => {
-                            translate_expr(
-                                program,
-                                Some(referenced_tables),
-                                expr,
-                                cur_reg,
-                                cursor_override.map(|c| c.cursor_id),
-                                m.expr_result_cache
-                                    .get_cached_result_registers(*id, cur_reg - start_reg)
-                                    .as_ref(),
-                            )?;
-                            m.expr_result_cache.cache_result_register(
-                                *id,
-                                cur_reg - start_reg,
-                                cur_reg,
-                                expr.clone(),
-                            );
-                            cur_reg += 1;
-                        }
-                        ProjectionColumn::Star => {
-                            for table_reference in referenced_tables.iter() {
-                                let table = cursor_override
-                                    .map(|c| c.pseudo_table.clone())
-                                    .unwrap_or_else(|| Table::BTree(table_reference.table.clone()));
-                                let cursor_id =
-                                    cursor_override.map(|c| c.cursor_id).unwrap_or_else(|| {
-                                        program.resolve_cursor_id(
-                                            &table_reference.table_identifier,
-                                            None,
-                                        )
-                                    });
-                                let start_column_offset =
-                                    cursor_override.map(|c| c.sort_key_len).unwrap_or(0);
-                                cur_reg = translate_table_columns(
-                                    program,
-                                    cursor_id,
-                                    &table,
-                                    start_column_offset,
-                                    cur_reg,
-                                );
-                            }
-                        }
-                        ProjectionColumn::TableStar(table_reference) => {
-                            let table_ref = referenced_tables
-                                .iter()
-                                .find(|t| t.table_identifier == table_reference.table_identifier)
-                                .unwrap();
-
-                            let table = cursor_override
-                                .map(|c| c.pseudo_table.clone())
-                                .unwrap_or_else(|| Table::BTree(table_ref.table.clone()));
-                            let cursor_id =
-                                cursor_override.map(|c| c.cursor_id).unwrap_or_else(|| {
-                                    program
-                                        .resolve_cursor_id(&table_reference.table_identifier, None)
-                                });
-                            let start_column_offset =
-                                cursor_override.map(|c| c.sort_key_len).unwrap_or(0);
-                            cur_reg = translate_table_columns(
-                                program,
-                                cursor_id,
-                                &table,
-                                start_column_offset,
-                                cur_reg,
-                            );
-                        }
-                    }
-                }
-
-                Ok(start_reg)
-            }
-            Operator::Nothing => unimplemented!(),
-        }
-    }
-    fn result_row(
-        &mut self,
-        program: &mut ProgramBuilder,
-        referenced_tables: &[BTreeTableReference],
-        m: &mut Metadata,
-        cursor_override: Option<&SortCursorOverride>,
-    ) -> Result<()> {
-        match self {
-            Operator::Limit { source, limit, .. } => {
-                source.result_row(program, referenced_tables, m, cursor_override)?;
-                let limit_reg = program.alloc_register();
-                program.emit_insn(Insn::Integer {
-                    value: *limit as i64,
-                    dest: limit_reg,
-                });
-                program.mark_last_insn_constant();
-                let jump_label = m.termination_label_stack.first().unwrap();
-                program.emit_insn_with_label_dependency(
-                    Insn::DecrJumpZero {
-                        reg: limit_reg,
-                        target_pc: *jump_label,
-                    },
-                    *jump_label,
-                );
-
-                Ok(())
-            }
-            operator => {
-                let start_reg =
-                    operator.result_columns(program, referenced_tables, m, cursor_override)?;
-                program.emit_insn(Insn::ResultRow {
-                    start_reg,
-                    count: operator.column_count(referenced_tables),
-                });
-                Ok(())
-            }
-        }
-    }
-}
-
-fn prologue(
-    cache: ExpressionResultCache,
-) -> Result<(ProgramBuilder, Metadata, BranchOffset, BranchOffset)> {
+// /// Emitters return one of three possible results from the step() method:
+// /// - Continue: the operator is not yet ready to emit a result row
+// /// - ReadyToEmit: the operator is ready to emit a result row
+// /// - Done: the operator has completed execution
+// ///   For example, a Scan operator will return Continue until it has opened a cursor, rewound it and applied any predicates.
+// ///   At that point, it will return ReadyToEmit.
+// ///   Finally, when the Scan operator has emitted a Next instruction, it will return Done.
+// ///
+// /// Parent operators are free to make decisions based on the result a child operator's step() method.
+// ///
+// /// When the root operator of a Plan returns ReadyToEmit, a ResultRow will always be emitted.
+// /// When the root operator returns Done, the bytecode plan is complete.
+// #[derive(Debug, PartialEq)]
+// pub enum OpStepResult {
+//     Continue,
+//     ReadyToEmit,
+//     Done,
+// }
+
+// impl Emitter for SourceOperator {
+//     fn step(
+//         &mut self,
+//         program: &mut ProgramBuilder,
+//         m: &mut Metadata,
+//         referenced_tables: &[BTreeTableReference],
+//     ) -> Result<OpStepResult> {
+//         let current_operator_column_count = self.column_count(referenced_tables);
+//         match self {
+//             SourceOperator::Scan {
+//                 table_reference,
+//                 id,
+//                 step,
+//                 predicates,
+//                 iter_dir,
+//             } => {
+//                 *step += 1;
+//                 const SCAN_OPEN_READ: usize = 1;
+//                 const SCAN_BODY: usize = 2;
+//                 const SCAN_NEXT: usize = 3;
+//                 let reverse = iter_dir
+//                     .as_ref()
+//                     .is_some_and(|iter_dir| *iter_dir == IterationDirection::Backwards);
+//                 match *step {
+//                     SCAN_OPEN_READ => {
+//                         let cursor_id = program.alloc_cursor_id(
+//                             Some(table_reference.table_identifier.clone()),
+//                             Some(Table::BTree(table_reference.table.clone())),
+//                         );
+//                         let root_page = table_reference.table.root_page;
+//                         let next_row_label = program.allocate_label();
+//                         m.next_row_labels.insert(*id, next_row_label);
+//                         program.emit_insn(Insn::OpenReadAsync {
+//                             cursor_id,
+//                             root_page,
+//                         });
+//                         program.emit_insn(Insn::OpenReadAwait);
+
+//                         Ok(OpStepResult::Continue)
+//                     }
+//                     SCAN_BODY => {
+//                         let cursor_id =
+//                             program.resolve_cursor_id(&table_reference.table_identifier, None);
+//                         if reverse {
+//                             program.emit_insn(Insn::LastAsync { cursor_id });
+//                         } else {
+//                             program.emit_insn(Insn::RewindAsync { cursor_id });
+//                         }
+//                         let scan_loop_body_label = program.allocate_label();
+//                         let halt_label = m.termination_label_stack.last().unwrap();
+//                         program.emit_insn_with_label_dependency(
+//                             if reverse {
+//                                 Insn::LastAwait {
+//                                     cursor_id,
+//                                     pc_if_empty: *halt_label,
+//                                 }
+//                             } else {
+//                                 Insn::RewindAwait {
+//                                     cursor_id,
+//                                     pc_if_empty: *halt_label,
+//                                 }
+//                             },
+//                             *halt_label,
+//                         );
+//                         m.scan_loop_body_labels.push(scan_loop_body_label);
+//                         program.defer_label_resolution(
+//                             scan_loop_body_label,
+//                             program.offset() as usize,
+//                         );
+
+//                         let jump_label = m.next_row_labels.get(id).unwrap_or(halt_label);
+//                         if let Some(preds) = predicates {
+//                             for expr in preds {
+//                                 let jump_target_when_true = program.allocate_label();
+//                                 let condition_metadata = ConditionMetadata {
+//                                     jump_if_condition_is_true: false,
+//                                     jump_target_when_true,
+//                                     jump_target_when_false: *jump_label,
+//                                 };
+//                                 translate_condition_expr(
+//                                     program,
+//                                     referenced_tables,
+//                                     expr,
+//                                     None,
+//                                     condition_metadata,
+//                                     m.result_set_register_start,
+//                                 )?;
+//                                 program.resolve_label(jump_target_when_true, program.offset());
+//                             }
+//                         }
+
+//                         Ok(OpStepResult::ReadyToEmit)
+//                     }
+//                     SCAN_NEXT => {
+//                         let cursor_id =
+//                             program.resolve_cursor_id(&table_reference.table_identifier, None);
+//                         program
+//                             .resolve_label(*m.next_row_labels.get(id).unwrap(), program.offset());
+//                         if reverse {
+//                             program.emit_insn(Insn::PrevAsync { cursor_id });
+//                         } else {
+//                             program.emit_insn(Insn::NextAsync { cursor_id });
+//                         }
+//                         let jump_label = m.scan_loop_body_labels.pop().unwrap();
+
+//                         if reverse {
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::PrevAwait {
+//                                     cursor_id,
+//                                     pc_if_next: jump_label,
+//                                 },
+//                                 jump_label,
+//                             );
+//                         } else {
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::NextAwait {
+//                                     cursor_id,
+//                                     pc_if_next: jump_label,
+//                                 },
+//                                 jump_label,
+//                             );
+//                         }
+//                         Ok(OpStepResult::Done)
+//                     }
+//                     _ => Ok(OpStepResult::Done),
+//                 }
+//             }
+//             SourceOperator::Search {
+//                 table_reference,
+//                 search,
+//                 predicates,
+//                 step,
+//                 id,
+//                 ..
+//             } => {
+//                 *step += 1;
+//                 const SEARCH_OPEN_READ: usize = 1;
+//                 const SEARCH_BODY: usize = 2;
+//                 const SEARCH_NEXT: usize = 3;
+//                 match *step {
+//                     SEARCH_OPEN_READ => {
+//                         let table_cursor_id = program.alloc_cursor_id(
+//                             Some(table_reference.table_identifier.clone()),
+//                             Some(Table::BTree(table_reference.table.clone())),
+//                         );
+
+//                         let next_row_label = program.allocate_label();
+
+//                         if !matches!(search, Search::PrimaryKeyEq { .. }) {
+//                             // Primary key equality search is handled with a SeekRowid instruction which does not loop, since it is a single row lookup.
+//                             m.next_row_labels.insert(*id, next_row_label);
+//                         }
+
+//                         let scan_loop_body_label = program.allocate_label();
+//                         m.scan_loop_body_labels.push(scan_loop_body_label);
+//                         program.emit_insn(Insn::OpenReadAsync {
+//                             cursor_id: table_cursor_id,
+//                             root_page: table_reference.table.root_page,
+//                         });
+//                         program.emit_insn(Insn::OpenReadAwait);
+
+//                         if let Search::IndexSearch { index, .. } = search {
+//                             let index_cursor_id = program.alloc_cursor_id(
+//                                 Some(index.name.clone()),
+//                                 Some(Table::Index(index.clone())),
+//                             );
+//                             program.emit_insn(Insn::OpenReadAsync {
+//                                 cursor_id: index_cursor_id,
+//                                 root_page: index.root_page,
+//                             });
+//                             program.emit_insn(Insn::OpenReadAwait);
+//                         }
+//                         Ok(OpStepResult::Continue)
+//                     }
+//                     SEARCH_BODY => {
+//                         let table_cursor_id =
+//                             program.resolve_cursor_id(&table_reference.table_identifier, None);
+
+//                         // Open the loop for the index search.
+//                         // Primary key equality search is handled with a SeekRowid instruction which does not loop, since it is a single row lookup.
+//                         if !matches!(search, Search::PrimaryKeyEq { .. }) {
+//                             let index_cursor_id = if let Search::IndexSearch { index, .. } = search
+//                             {
+//                                 Some(program.resolve_cursor_id(&index.name, None))
+//                             } else {
+//                                 None
+//                             };
+//                             let scan_loop_body_label = *m.scan_loop_body_labels.last().unwrap();
+//                             let cmp_reg = program.alloc_register();
+//                             let (cmp_expr, cmp_op) = match search {
+//                                 Search::IndexSearch {
+//                                     cmp_expr, cmp_op, ..
+//                                 } => (cmp_expr, cmp_op),
+//                                 Search::PrimaryKeySearch { cmp_expr, cmp_op } => (cmp_expr, cmp_op),
+//                                 Search::PrimaryKeyEq { .. } => unreachable!(),
+//                             };
+//                             // TODO this only handles ascending indexes
+//                             match cmp_op {
+//                                 ast::Operator::Equals
+//                                 | ast::Operator::Greater
+//                                 | ast::Operator::GreaterEquals => {
+//                                     translate_expr(
+//                                         program,
+//                                         Some(referenced_tables),
+//                                         cmp_expr,
+//                                         cmp_reg,
+//                                         None,
+//                                         m.result_set_register_start,
+//                                     )?;
+//                                 }
+//                                 ast::Operator::Less | ast::Operator::LessEquals => {
+//                                     program.emit_insn(Insn::Null {
+//                                         dest: cmp_reg,
+//                                         dest_end: None,
+//                                     });
+//                                 }
+//                                 _ => unreachable!(),
+//                             }
+//                             program.emit_insn_with_label_dependency(
+//                                 match cmp_op {
+//                                     ast::Operator::Equals | ast::Operator::GreaterEquals => {
+//                                         Insn::SeekGE {
+//                                             is_index: index_cursor_id.is_some(),
+//                                             cursor_id: index_cursor_id.unwrap_or(table_cursor_id),
+//                                             start_reg: cmp_reg,
+//                                             num_regs: 1,
+//                                             target_pc: *m.termination_label_stack.last().unwrap(),
+//                                         }
+//                                     }
+//                                     ast::Operator::Greater
+//                                     | ast::Operator::Less
+//                                     | ast::Operator::LessEquals => Insn::SeekGT {
+//                                         is_index: index_cursor_id.is_some(),
+//                                         cursor_id: index_cursor_id.unwrap_or(table_cursor_id),
+//                                         start_reg: cmp_reg,
+//                                         num_regs: 1,
+//                                         target_pc: *m.termination_label_stack.last().unwrap(),
+//                                     },
+//                                     _ => unreachable!(),
+//                                 },
+//                                 *m.termination_label_stack.last().unwrap(),
+//                             );
+//                             if *cmp_op == ast::Operator::Less
+//                                 || *cmp_op == ast::Operator::LessEquals
+//                             {
+//                                 translate_expr(
+//                                     program,
+//                                     Some(referenced_tables),
+//                                     cmp_expr,
+//                                     cmp_reg,
+//                                     None,
+//                                     m.result_set_register_start,
+//                                 )?;
+//                             }
+
+//                             program.defer_label_resolution(
+//                                 scan_loop_body_label,
+//                                 program.offset() as usize,
+//                             );
+//                             // TODO: We are currently only handling ascending indexes.
+//                             // For conditions like index_key > 10, we have already seeked to the first key greater than 10, and can just scan forward.
+//                             // For conditions like index_key < 10, we are at the beginning of the index, and will scan forward and emit IdxGE(10) with a conditional jump to the end.
+//                             // For conditions like index_key = 10, we have already seeked to the first key greater than or equal to 10, and can just scan forward and emit IdxGT(10) with a conditional jump to the end.
+//                             // For conditions like index_key >= 10, we have already seeked to the first key greater than or equal to 10, and can just scan forward.
+//                             // For conditions like index_key <= 10, we are at the beginning of the index, and will scan forward and emit IdxGT(10) with a conditional jump to the end.
+//                             // For conditions like index_key != 10, TODO. probably the optimal way is not to use an index at all.
+//                             //
+//                             // For primary key searches we emit RowId and then compare it to the seek value.
+
+//                             let abort_jump_target = *m
+//                                 .next_row_labels
+//                                 .get(id)
+//                                 .unwrap_or(m.termination_label_stack.last().unwrap());
+//                             match cmp_op {
+//                                 ast::Operator::Equals | ast::Operator::LessEquals => {
+//                                     if let Some(index_cursor_id) = index_cursor_id {
+//                                         program.emit_insn_with_label_dependency(
+//                                             Insn::IdxGT {
+//                                                 cursor_id: index_cursor_id,
+//                                                 start_reg: cmp_reg,
+//                                                 num_regs: 1,
+//                                                 target_pc: abort_jump_target,
+//                                             },
+//                                             abort_jump_target,
+//                                         );
+//                                     } else {
+//                                         let rowid_reg = program.alloc_register();
+//                                         program.emit_insn(Insn::RowId {
+//                                             cursor_id: table_cursor_id,
+//                                             dest: rowid_reg,
+//                                         });
+//                                         program.emit_insn_with_label_dependency(
+//                                             Insn::Gt {
+//                                                 lhs: rowid_reg,
+//                                                 rhs: cmp_reg,
+//                                                 target_pc: abort_jump_target,
+//                                             },
+//                                             abort_jump_target,
+//                                         );
+//                                     }
+//                                 }
+//                                 ast::Operator::Less => {
+//                                     if let Some(index_cursor_id) = index_cursor_id {
+//                                         program.emit_insn_with_label_dependency(
+//                                             Insn::IdxGE {
+//                                                 cursor_id: index_cursor_id,
+//                                                 start_reg: cmp_reg,
+//                                                 num_regs: 1,
+//                                                 target_pc: abort_jump_target,
+//                                             },
+//                                             abort_jump_target,
+//                                         );
+//                                     } else {
+//                                         let rowid_reg = program.alloc_register();
+//                                         program.emit_insn(Insn::RowId {
+//                                             cursor_id: table_cursor_id,
+//                                             dest: rowid_reg,
+//                                         });
+//                                         program.emit_insn_with_label_dependency(
+//                                             Insn::Ge {
+//                                                 lhs: rowid_reg,
+//                                                 rhs: cmp_reg,
+//                                                 target_pc: abort_jump_target,
+//                                             },
+//                                             abort_jump_target,
+//                                         );
+//                                     }
+//                                 }
+//                                 _ => {}
+//                             }
+
+//                             if let Some(index_cursor_id) = index_cursor_id {
+//                                 program.emit_insn(Insn::DeferredSeek {
+//                                     index_cursor_id,
+//                                     table_cursor_id,
+//                                 });
+//                             }
+//                         }
+
+//                         let jump_label = m
+//                             .next_row_labels
+//                             .get(id)
+//                             .unwrap_or(m.termination_label_stack.last().unwrap());
+
+//                         if let Search::PrimaryKeyEq { cmp_expr } = search {
+//                             let src_reg = program.alloc_register();
+//                             translate_expr(
+//                                 program,
+//                                 Some(referenced_tables),
+//                                 cmp_expr,
+//                                 src_reg,
+//                                 None,
+//                                 m.result_set_register_start,
+//                             )?;
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::SeekRowid {
+//                                     cursor_id: table_cursor_id,
+//                                     src_reg,
+//                                     target_pc: *jump_label,
+//                                 },
+//                                 *jump_label,
+//                             );
+//                         }
+//                         if let Some(predicates) = predicates {
+//                             for predicate in predicates.iter() {
+//                                 let jump_target_when_true = program.allocate_label();
+//                                 let condition_metadata = ConditionMetadata {
+//                                     jump_if_condition_is_true: false,
+//                                     jump_target_when_true,
+//                                     jump_target_when_false: *jump_label,
+//                                 };
+//                                 translate_condition_expr(
+//                                     program,
+//                                     referenced_tables,
+//                                     predicate,
+//                                     None,
+//                                     condition_metadata,
+//                                     m.result_set_register_start,
+//                                 )?;
+//                                 program.resolve_label(jump_target_when_true, program.offset());
+//                             }
+//                         }
+
+//                         Ok(OpStepResult::ReadyToEmit)
+//                     }
+//                     SEARCH_NEXT => {
+//                         if matches!(search, Search::PrimaryKeyEq { .. }) {
+//                             // Primary key equality search is handled with a SeekRowid instruction which does not loop, so there is no need to emit a NextAsync instruction.
+//                             return Ok(OpStepResult::Done);
+//                         }
+//                         let cursor_id = match search {
+//                             Search::IndexSearch { index, .. } => {
+//                                 program.resolve_cursor_id(&index.name, None)
+//                             }
+//                             Search::PrimaryKeySearch { .. } => {
+//                                 program.resolve_cursor_id(&table_reference.table_identifier, None)
+//                             }
+//                             Search::PrimaryKeyEq { .. } => unreachable!(),
+//                         };
+//                         program
+//                             .resolve_label(*m.next_row_labels.get(id).unwrap(), program.offset());
+//                         program.emit_insn(Insn::NextAsync { cursor_id });
+//                         let jump_label = m.scan_loop_body_labels.pop().unwrap();
+//                         program.emit_insn_with_label_dependency(
+//                             Insn::NextAwait {
+//                                 cursor_id,
+//                                 pc_if_next: jump_label,
+//                             },
+//                             jump_label,
+//                         );
+//                         Ok(OpStepResult::Done)
+//                     }
+//                     _ => Ok(OpStepResult::Done),
+//                 }
+//             }
+//             SourceOperator::Join {
+//                 left,
+//                 right,
+//                 outer,
+//                 predicates,
+//                 step,
+//                 id,
+//                 ..
+//             } => {
+//                 *step += 1;
+//                 const JOIN_INIT: usize = 1;
+//                 const JOIN_DO_JOIN: usize = 2;
+//                 const JOIN_END: usize = 3;
+//                 match *step {
+//                     JOIN_INIT => {
+//                         if *outer {
+//                             let lj_metadata = LeftJoinMetadata {
+//                                 match_flag_register: program.alloc_register(),
+//                                 set_match_flag_true_label: program.allocate_label(),
+//                                 check_match_flag_label: program.allocate_label(),
+//                                 on_match_jump_to_label: program.allocate_label(),
+//                             };
+//                             m.left_joins.insert(*id, lj_metadata);
+//                         }
+//                         left.step(program, m, referenced_tables)?;
+//                         right.step(program, m, referenced_tables)?;
+
+//                         Ok(OpStepResult::Continue)
+//                     }
+//                     JOIN_DO_JOIN => {
+//                         left.step(program, m, referenced_tables)?;
+
+//                         let mut jump_target_when_false = *m
+//                             .next_row_labels
+//                             .get(&right.id())
+//                             .or(m.next_row_labels.get(&left.id()))
+//                             .unwrap_or(m.termination_label_stack.last().unwrap());
+
+//                         if *outer {
+//                             let lj_meta = m.left_joins.get(id).unwrap();
+//                             program.emit_insn(Insn::Integer {
+//                                 value: 0,
+//                                 dest: lj_meta.match_flag_register,
+//                             });
+//                             jump_target_when_false = lj_meta.check_match_flag_label;
+//                         }
+//                         m.next_row_labels.insert(right.id(), jump_target_when_false);
+
+//                         right.step(program, m, referenced_tables)?;
+
+//                         if let Some(predicates) = predicates {
+//                             let jump_target_when_true = program.allocate_label();
+//                             let condition_metadata = ConditionMetadata {
+//                                 jump_if_condition_is_true: false,
+//                                 jump_target_when_true,
+//                                 jump_target_when_false,
+//                             };
+//                             for predicate in predicates.iter() {
+//                                 translate_condition_expr(
+//                                     program,
+//                                     referenced_tables,
+//                                     predicate,
+//                                     None,
+//                                     condition_metadata,
+//                                     m.result_set_register_start,
+//                                 )?;
+//                             }
+//                             program.resolve_label(jump_target_when_true, program.offset());
+//                         }
+
+//                         if *outer {
+//                             let lj_meta = m.left_joins.get(id).unwrap();
+//                             program.defer_label_resolution(
+//                                 lj_meta.set_match_flag_true_label,
+//                                 program.offset() as usize,
+//                             );
+//                             program.emit_insn(Insn::Integer {
+//                                 value: 1,
+//                                 dest: lj_meta.match_flag_register,
+//                             });
+//                         }
+
+//                         Ok(OpStepResult::ReadyToEmit)
+//                     }
+//                     JOIN_END => {
+//                         right.step(program, m, referenced_tables)?;
+
+//                         if *outer {
+//                             let lj_meta = m.left_joins.get(id).unwrap();
+//                             // If the left join match flag has been set to 1, we jump to the next row on the outer table (result row has been emitted already)
+//                             program.resolve_label(lj_meta.check_match_flag_label, program.offset());
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::IfPos {
+//                                     reg: lj_meta.match_flag_register,
+//                                     target_pc: lj_meta.on_match_jump_to_label,
+//                                     decrement_by: 0,
+//                                 },
+//                                 lj_meta.on_match_jump_to_label,
+//                             );
+//                             // If not, we set the right table cursor's "pseudo null bit" on, which means any Insn::Column will return NULL
+//                             let right_cursor_id = match right.as_ref() {
+//                                 SourceOperator::Scan {
+//                                     table_reference, ..
+//                                 } => program
+//                                     .resolve_cursor_id(&table_reference.table_identifier, None),
+//                                 SourceOperator::Search {
+//                                     table_reference, ..
+//                                 } => program
+//                                     .resolve_cursor_id(&table_reference.table_identifier, None),
+//                                 _ => unreachable!(),
+//                             };
+//                             program.emit_insn(Insn::NullRow {
+//                                 cursor_id: right_cursor_id,
+//                             });
+//                             // Jump to setting the left join match flag to 1 again, but this time the right table cursor will set everything to null
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::Goto {
+//                                     target_pc: lj_meta.set_match_flag_true_label,
+//                                 },
+//                                 lj_meta.set_match_flag_true_label,
+//                             );
+//                         }
+//                         let next_row_label = if *outer {
+//                             m.left_joins.get(id).unwrap().on_match_jump_to_label
+//                         } else {
+//                             *m.next_row_labels.get(&right.id()).unwrap()
+//                         };
+//                         // This points to the NextAsync instruction of the left table
+//                         program.resolve_label(next_row_label, program.offset());
+//                         left.step(program, m, referenced_tables)?;
+
+//                         Ok(OpStepResult::Done)
+//                     }
+//                     _ => Ok(OpStepResult::Done),
+//                 }
+//             }
+//             SourceOperator::Projection {
+//                 id,
+//                 source,
+//                 expressions,
+//                 aggregates,
+//                 group_by,
+//                 step,
+//                 ..
+//             } => {
+//                 *step += 1;
+
+//                 if !aggregates.is_empty() && group_by.is_none() {
+//                     const PROJECTION_WAIT_UNTIL_SOURCE_READY: usize = 1;
+//                     const PROJECTION_FINALIZE_SOURCE: usize = 2;
+//                     match *step {
+//                         PROJECTION_WAIT_UNTIL_SOURCE_READY => loop {
+//                             match source.step(program, m, referenced_tables)? {
+//                                 OpStepResult::Continue => continue,
+//                                 OpStepResult::ReadyToEmit | OpStepResult::Done => {
+//                                     return Ok(OpStepResult::ReadyToEmit);
+//                                 }
+//                             }
+//                         },
+//                         PROJECTION_FINALIZE_SOURCE => {
+//                             match source.step(program, m, referenced_tables)? {
+//                                 OpStepResult::Done => return Ok(OpStepResult::Done),
+//                                 _ => unreachable!(),
+//                             }
+//                         }
+//                         _ => return Ok(OpStepResult::Done),
+//                     }
+//                 }
+
+//                 // Group by aggregation eg. SELECT a, b, sum(c) FROM t GROUP BY a, b
+//                 if let Some(group_by) = group_by {
+//                     const GROUP_BY_INIT: usize = 1;
+//                     const GROUP_BY_INSERT_INTO_SORTER: usize = 2;
+//                     const GROUP_BY_SORT_AND_COMPARE: usize = 3;
+//                     const GROUP_BY_PREPARE_ROW: usize = 4;
+//                     const GROUP_BY_CLEAR_ACCUMULATOR_SUBROUTINE: usize = 5;
+//                     match *step {
+//                         GROUP_BY_INIT => {
+//                             let agg_final_label = program.allocate_label();
+//                             m.termination_label_stack.push(agg_final_label);
+//                             let num_aggs = aggregates.len();
+
+//                             let sort_cursor = program.alloc_cursor_id(None, None);
+
+//                             let abort_flag_register = program.alloc_register();
+//                             let data_in_accumulator_indicator_register = program.alloc_register();
+//                             let group_exprs_comparison_register =
+//                                 program.alloc_registers(group_by.len());
+//                             let group_exprs_accumulator_register =
+//                                 program.alloc_registers(group_by.len());
+//                             let agg_exprs_start_reg = program.alloc_registers(num_aggs);
+//                             m.aggregation_start_registers
+//                                 .insert(*id, agg_exprs_start_reg);
+//                             let sorter_key_register = program.alloc_register();
+
+//                             let subroutine_accumulator_clear_label = program.allocate_label();
+//                             let subroutine_accumulator_output_label = program.allocate_label();
+//                             let sorter_data_label = program.allocate_label();
+//                             let grouping_done_label = program.allocate_label();
+
+//                             let mut order = Vec::new();
+//                             const ASCENDING: i64 = 0;
+//                             for _ in group_by.iter() {
+//                                 order.push(OwnedValue::Integer(ASCENDING));
+//                             }
+//                             program.emit_insn(Insn::SorterOpen {
+//                                 cursor_id: sort_cursor,
+//                                 columns: current_operator_column_count,
+//                                 order: OwnedRecord::new(order),
+//                             });
+
+//                             program.add_comment(program.offset(), "clear group by abort flag");
+//                             program.emit_insn(Insn::Integer {
+//                                 value: 0,
+//                                 dest: abort_flag_register,
+//                             });
+
+//                             program.add_comment(
+//                                 program.offset(),
+//                                 "initialize group by comparison registers to NULL",
+//                             );
+//                             program.emit_insn(Insn::Null {
+//                                 dest: group_exprs_comparison_register,
+//                                 dest_end: if group_by.len() > 1 {
+//                                     Some(group_exprs_comparison_register + group_by.len() - 1)
+//                                 } else {
+//                                     None
+//                                 },
+//                             });
+
+//                             program.add_comment(
+//                                 program.offset(),
+//                                 "go to clear accumulator subroutine",
+//                             );
+
+//                             let subroutine_accumulator_clear_return_offset_register =
+//                                 program.alloc_register();
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::Gosub {
+//                                     target_pc: subroutine_accumulator_clear_label,
+//                                     return_reg: subroutine_accumulator_clear_return_offset_register,
+//                                 },
+//                                 subroutine_accumulator_clear_label,
+//                             );
+
+//                             m.group_bys.insert(
+//                                 *id,
+//                                 GroupByMetadata {
+//                                     sort_cursor,
+//                                     subroutine_accumulator_clear_label,
+//                                     subroutine_accumulator_clear_return_offset_register,
+//                                     subroutine_accumulator_output_label,
+//                                     subroutine_accumulator_output_return_offset_register: program
+//                                         .alloc_register(),
+//                                     accumulator_indicator_set_true_label: program.allocate_label(),
+//                                     sorter_data_label,
+//                                     grouping_done_label,
+//                                     abort_flag_register,
+//                                     data_in_accumulator_indicator_register,
+//                                     group_exprs_accumulator_register,
+//                                     group_exprs_comparison_register,
+//                                     sorter_key_register,
+//                                 },
+//                             );
+
+//                             loop {
+//                                 match source.step(program, m, referenced_tables)? {
+//                                     OpStepResult::Continue => continue,
+//                                     OpStepResult::ReadyToEmit => {
+//                                         return Ok(OpStepResult::Continue);
+//                                     }
+//                                     OpStepResult::Done => {
+//                                         return Ok(OpStepResult::Done);
+//                                     }
+//                                 }
+//                             }
+//                         }
+//                         GROUP_BY_INSERT_INTO_SORTER => {
+//                             let sort_keys_count = group_by.len();
+//                             let start_reg = program.alloc_registers(current_operator_column_count);
+//                             for (i, expr) in group_by.iter().enumerate() {
+//                                 let key_reg = start_reg + i;
+//                                 translate_expr(
+//                                     program,
+//                                     Some(referenced_tables),
+//                                     expr,
+//                                     key_reg,
+//                                     None,
+//                                     m.result_set_register_start,
+//                                 )?;
+//                             }
+//                             for (i, agg) in aggregates.iter().enumerate() {
+//                                 // TODO it's a hack to assume aggregate functions have exactly one argument.
+//                                 // Counterpoint e.g. GROUP_CONCAT(expr, separator).
+//                                 //
+//                                 // Here we are collecting scalars for the group by sorter, which will include
+//                                 // both the group by expressions and the aggregate arguments.
+//                                 // e.g. in `select u.first_name, sum(u.age) from users group by u.first_name`
+//                                 // the sorter will have two scalars: u.first_name and u.age.
+//                                 // these are then sorted by u.first_name, and for each u.first_name, we sum the u.age.
+//                                 // the actual aggregation is done later in GROUP_BY_SORT_AND_COMPARE below.
+//                                 //
+//                                 // This is why we take the first argument of each aggregate function currently.
+//                                 // It's mostly an artifact of the current architecture being a bit poor; we should recognize
+//                                 // which scalars are dependencies of aggregate functions and explicitly collect those.
+//                                 let expr = &agg.args[0];
+//                                 let agg_reg = start_reg + sort_keys_count + i;
+//                                 translate_expr(
+//                                     program,
+//                                     Some(referenced_tables),
+//                                     expr,
+//                                     agg_reg,
+//                                     None,
+//                                     m.result_set_register_start,
+//                                 )?;
+//                             }
+
+//                             let group_by_metadata = m.group_bys.get(id).unwrap();
+
+//                             program.emit_insn(Insn::MakeRecord {
+//                                 start_reg,
+//                                 count: current_operator_column_count,
+//                                 dest_reg: group_by_metadata.sorter_key_register,
+//                             });
+
+//                             let group_by_metadata = m.group_bys.get(id).unwrap();
+//                             program.emit_insn(Insn::SorterInsert {
+//                                 cursor_id: group_by_metadata.sort_cursor,
+//                                 record_reg: group_by_metadata.sorter_key_register,
+//                             });
+
+//                             return Ok(OpStepResult::Continue);
+//                         }
+//                         #[allow(clippy::never_loop)]
+//                         GROUP_BY_SORT_AND_COMPARE => {
+//                             loop {
+//                                 match source.step(program, m, referenced_tables)? {
+//                                     OpStepResult::Done => {
+//                                         break;
+//                                     }
+//                                     _ => unreachable!(),
+//                                 }
+//                             }
+
+//                             let group_by_metadata = m.group_bys.get_mut(id).unwrap();
+
+//                             let GroupByMetadata {
+//                                 group_exprs_comparison_register: comparison_register,
+//                                 subroutine_accumulator_output_return_offset_register,
+//                                 subroutine_accumulator_output_label,
+//                                 subroutine_accumulator_clear_return_offset_register,
+//                                 subroutine_accumulator_clear_label,
+//                                 data_in_accumulator_indicator_register,
+//                                 accumulator_indicator_set_true_label,
+//                                 group_exprs_accumulator_register: group_exprs_start_register,
+//                                 abort_flag_register,
+//                                 sorter_key_register,
+//                                 ..
+//                             } = *group_by_metadata;
+//                             let halt_label = *m.termination_label_stack.first().unwrap();
+
+//                             let mut column_names =
+//                                 Vec::with_capacity(current_operator_column_count);
+//                             for expr in group_by
+//                                 .iter()
+//                                 .chain(aggregates.iter().map(|agg| &agg.args[0]))
+//                             // FIXME: just blindly taking the first arg is a hack
+//                             {
+//                                 // Sorter column names for group by are now just determined by stringifying the expression, since the group by
+//                                 // columns and aggregations can be practically anything.
+//                                 // FIXME: either come up with something more robust, or make this something like expr.to_canonical_string() so that we can handle
+//                                 // things like `count(1)` and `COUNT(1)` the same way
+//                                 column_names.push(expr.to_string());
+//                             }
+//                             let pseudo_columns = column_names
+//                                 .iter()
+//                                 .map(|name| Column {
+//                                     name: name.clone(),
+//                                     primary_key: false,
+//                                     ty: crate::schema::Type::Null,
+//                                 })
+//                                 .collect::<Vec<_>>();
+
+//                             let pseudo_table = Rc::new(PseudoTable {
+//                                 columns: pseudo_columns,
+//                             });
+
+//                             let pseudo_cursor = program
+//                                 .alloc_cursor_id(None, Some(Table::Pseudo(pseudo_table.clone())));
+
+//                             program.emit_insn(Insn::OpenPseudo {
+//                                 cursor_id: pseudo_cursor,
+//                                 content_reg: sorter_key_register,
+//                                 num_fields: current_operator_column_count,
+//                             });
+
+//                             let group_by_metadata = m.group_bys.get(id).unwrap();
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::SorterSort {
+//                                     cursor_id: group_by_metadata.sort_cursor,
+//                                     pc_if_empty: group_by_metadata.grouping_done_label,
+//                                 },
+//                                 group_by_metadata.grouping_done_label,
+//                             );
+
+//                             program.defer_label_resolution(
+//                                 group_by_metadata.sorter_data_label,
+//                                 program.offset() as usize,
+//                             );
+//                             program.emit_insn(Insn::SorterData {
+//                                 cursor_id: group_by_metadata.sort_cursor,
+//                                 dest_reg: group_by_metadata.sorter_key_register,
+//                                 pseudo_cursor,
+//                             });
+
+//                             let groups_start_reg = program.alloc_registers(group_by.len());
+//                             for (i, expr) in group_by.iter().enumerate() {
+//                                 let sorter_column_index =
+//                                     resolve_ident_pseudo_table(&expr.to_string(), &pseudo_table)?;
+//                                 let group_reg = groups_start_reg + i;
+//                                 program.emit_insn(Insn::Column {
+//                                     cursor_id: pseudo_cursor,
+//                                     column: sorter_column_index,
+//                                     dest: group_reg,
+//                                 });
+//                             }
+
+//                             program.emit_insn(Insn::Compare {
+//                                 start_reg_a: comparison_register,
+//                                 start_reg_b: groups_start_reg,
+//                                 count: group_by.len(),
+//                             });
+
+//                             let agg_step_label = program.allocate_label();
+
+//                             program.add_comment(
+//                                 program.offset(),
+//                                 "start new group if comparison is not equal",
+//                             );
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::Jump {
+//                                     target_pc_lt: program.offset() + 1,
+//                                     target_pc_eq: agg_step_label,
+//                                     target_pc_gt: program.offset() + 1,
+//                                 },
+//                                 agg_step_label,
+//                             );
+
+//                             program.emit_insn(Insn::Move {
+//                                 source_reg: groups_start_reg,
+//                                 dest_reg: comparison_register,
+//                                 count: group_by.len(),
+//                             });
+
+//                             program.add_comment(
+//                                 program.offset(),
+//                                 "check if ended group had data, and output if so",
+//                             );
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::Gosub {
+//                                     target_pc: subroutine_accumulator_output_label,
+//                                     return_reg:
+//                                         subroutine_accumulator_output_return_offset_register,
+//                                 },
+//                                 subroutine_accumulator_output_label,
+//                             );
+
+//                             program.add_comment(program.offset(), "check abort flag");
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::IfPos {
+//                                     reg: abort_flag_register,
+//                                     target_pc: halt_label,
+//                                     decrement_by: 0,
+//                                 },
+//                                 m.termination_label_stack[0],
+//                             );
+
+//                             program
+//                                 .add_comment(program.offset(), "goto clear accumulator subroutine");
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::Gosub {
+//                                     target_pc: subroutine_accumulator_clear_label,
+//                                     return_reg: subroutine_accumulator_clear_return_offset_register,
+//                                 },
+//                                 subroutine_accumulator_clear_label,
+//                             );
+
+//                             program.resolve_label(agg_step_label, program.offset());
+//                             let start_reg = m.aggregation_start_registers.get(id).unwrap();
+//                             for (i, agg) in aggregates.iter().enumerate() {
+//                                 let agg_result_reg = start_reg + i;
+//                                 translate_aggregation(
+//                                     program,
+//                                     referenced_tables,
+//                                     agg,
+//                                     agg_result_reg,
+//                                     Some(pseudo_cursor),
+//                                 )?;
+//                             }
+
+//                             program.add_comment(
+//                                 program.offset(),
+//                                 "don't emit group columns if continuing existing group",
+//                             );
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::If {
+//                                     target_pc: accumulator_indicator_set_true_label,
+//                                     reg: data_in_accumulator_indicator_register,
+//                                     null_reg: 0, // unused in this case
+//                                 },
+//                                 accumulator_indicator_set_true_label,
+//                             );
+
+//                             for (i, expr) in group_by.iter().enumerate() {
+//                                 let key_reg = group_exprs_start_register + i;
+//                                 let sorter_column_index =
+//                                     resolve_ident_pseudo_table(&expr.to_string(), &pseudo_table)?;
+//                                 program.emit_insn(Insn::Column {
+//                                     cursor_id: pseudo_cursor,
+//                                     column: sorter_column_index,
+//                                     dest: key_reg,
+//                                 });
+//                             }
+
+//                             program.resolve_label(
+//                                 accumulator_indicator_set_true_label,
+//                                 program.offset(),
+//                             );
+//                             program.add_comment(program.offset(), "indicate data in accumulator");
+//                             program.emit_insn(Insn::Integer {
+//                                 value: 1,
+//                                 dest: data_in_accumulator_indicator_register,
+//                             });
+
+//                             return Ok(OpStepResult::Continue);
+//                         }
+//                         GROUP_BY_PREPARE_ROW => {
+//                             let group_by_metadata = m.group_bys.get(id).unwrap();
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::SorterNext {
+//                                     cursor_id: group_by_metadata.sort_cursor,
+//                                     pc_if_next: group_by_metadata.sorter_data_label,
+//                                 },
+//                                 group_by_metadata.sorter_data_label,
+//                             );
+
+//                             program.resolve_label(
+//                                 group_by_metadata.grouping_done_label,
+//                                 program.offset(),
+//                             );
+
+//                             program.add_comment(program.offset(), "emit row for final group");
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::Gosub {
+//                                     target_pc: group_by_metadata
+//                                         .subroutine_accumulator_output_label,
+//                                     return_reg: group_by_metadata
+//                                         .subroutine_accumulator_output_return_offset_register,
+//                                 },
+//                                 group_by_metadata.subroutine_accumulator_output_label,
+//                             );
+
+//                             program.add_comment(program.offset(), "group by finished");
+//                             let termination_label =
+//                                 m.termination_label_stack[m.termination_label_stack.len() - 2];
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::Goto {
+//                                     target_pc: termination_label,
+//                                 },
+//                                 termination_label,
+//                             );
+//                             program.emit_insn(Insn::Integer {
+//                                 value: 1,
+//                                 dest: group_by_metadata.abort_flag_register,
+//                             });
+//                             program.emit_insn(Insn::Return {
+//                                 return_reg: group_by_metadata
+//                                     .subroutine_accumulator_output_return_offset_register,
+//                             });
+
+//                             program.resolve_label(
+//                                 group_by_metadata.subroutine_accumulator_output_label,
+//                                 program.offset(),
+//                             );
+
+//                             program.add_comment(
+//                                 program.offset(),
+//                                 "output group by row subroutine start",
+//                             );
+//                             let termination_label = *m.termination_label_stack.last().unwrap();
+//                             program.emit_insn_with_label_dependency(
+//                                 Insn::IfPos {
+//                                     reg: group_by_metadata.data_in_accumulator_indicator_register,
+//                                     target_pc: termination_label,
+//                                     decrement_by: 0,
+//                                 },
+//                                 termination_label,
+//                             );
+//                             program.emit_insn(Insn::Return {
+//                                 return_reg: group_by_metadata
+//                                     .subroutine_accumulator_output_return_offset_register,
+//                             });
+
+//                             return Ok(OpStepResult::ReadyToEmit);
+//                         }
+//                         GROUP_BY_CLEAR_ACCUMULATOR_SUBROUTINE => {
+//                             let group_by_metadata = m.group_bys.get(id).unwrap();
+//                             program.emit_insn(Insn::Return {
+//                                 return_reg: group_by_metadata
+//                                     .subroutine_accumulator_output_return_offset_register,
+//                             });
+
+//                             program.add_comment(
+//                                 program.offset(),
+//                                 "clear accumulator subroutine start",
+//                             );
+//                             program.resolve_label(
+//                                 group_by_metadata.subroutine_accumulator_clear_label,
+//                                 program.offset(),
+//                             );
+//                             let start_reg = group_by_metadata.group_exprs_accumulator_register;
+//                             program.emit_insn(Insn::Null {
+//                                 dest: start_reg,
+//                                 dest_end: Some(start_reg + group_by.len() + aggregates.len() - 1),
+//                             });
+
+//                             program.emit_insn(Insn::Integer {
+//                                 value: 0,
+//                                 dest: group_by_metadata.data_in_accumulator_indicator_register,
+//                             });
+//                             program.emit_insn(Insn::Return {
+//                                 return_reg: group_by_metadata
+//                                     .subroutine_accumulator_clear_return_offset_register,
+//                             });
+//                         }
+//                         _ => {
+//                             return Ok(OpStepResult::Done);
+//                         }
+//                     }
+//                 }
+
+//                 // Non-grouped aggregation e.g. SELECT COUNT(*) FROM t
+
+//                 const AGGREGATE_INIT: usize = 1;
+//                 const AGGREGATE_WAIT_UNTIL_SOURCE_READY: usize = 2;
+//                 match *step {
+//                     AGGREGATE_INIT => {
+//                         let agg_final_label = program.allocate_label();
+//                         m.termination_label_stack.push(agg_final_label);
+//                         let num_aggs = aggregates.len();
+//                         let start_reg = program.alloc_registers(num_aggs);
+//                         m.aggregation_start_registers.insert(*id, start_reg);
+
+//                         Ok(OpStepResult::Continue)
+//                     }
+//                     AGGREGATE_WAIT_UNTIL_SOURCE_READY => loop {
+//                         match source.step(program, m, referenced_tables)? {
+//                             OpStepResult::Continue => {}
+//                             OpStepResult::ReadyToEmit => {
+//                                 let start_reg = m.aggregation_start_registers.get(id).unwrap();
+//                                 for (i, agg) in aggregates.iter().enumerate() {
+//                                     let agg_result_reg = start_reg + i;
+//                                     translate_aggregation(
+//                                         program,
+//                                         referenced_tables,
+//                                         agg,
+//                                         agg_result_reg,
+//                                         None,
+//                                     )?;
+//                                 }
+//                             }
+//                             OpStepResult::Done => {
+//                                 return Ok(OpStepResult::ReadyToEmit);
+//                             }
+//                         }
+//                     },
+//                     _ => Ok(OpStepResult::Done),
+//                 }
+//             }
+//             SourceOperator::Filter { .. } => unreachable!("predicates have been pushed down"),
+//             SourceOperator::Limit { source, step, .. } => {
+//                 *step += 1;
+//                 loop {
+//                     match source.step(program, m, referenced_tables)? {
+//                         OpStepResult::Continue => continue,
+//                         OpStepResult::ReadyToEmit => {
+//                             return Ok(OpStepResult::ReadyToEmit);
+//                         }
+//                         OpStepResult::Done => return Ok(OpStepResult::Done),
+//                     }
+//                 }
+//             }
+//             SourceOperator::Order {
+//                 id,
+//                 source,
+//                 key,
+//                 step,
+//             } => {
+//                 *step += 1;
+//                 const ORDER_INIT: usize = 1;
+//                 const ORDER_INSERT_INTO_SORTER: usize = 2;
+//                 const ORDER_SORT_AND_OPEN_LOOP: usize = 3;
+//                 const ORDER_NEXT: usize = 4;
+//                 match *step {
+//                     ORDER_INIT => {
+//                         m.termination_label_stack.push(program.allocate_label());
+//                         let sort_cursor = program.alloc_cursor_id(None, None);
+//                         m.sorts.insert(
+//                             *id,
+//                             SortMetadata {
+//                                 sort_cursor,
+//                                 pseudo_table_cursor: usize::MAX, // will be set later
+//                                 sorter_data_register: program.alloc_register(),
+//                                 sorter_data_label: program.allocate_label(),
+//                                 done_label: program.allocate_label(),
+//                             },
+//                         );
+//                         let mut order = Vec::new();
+//                         for (_, direction) in key.iter() {
+//                             order.push(OwnedValue::Integer(*direction as i64));
+//                         }
+//                         program.emit_insn(Insn::SorterOpen {
+//                             cursor_id: sort_cursor,
+//                             columns: key.len(),
+//                             order: OwnedRecord::new(order),
+//                         });
+
+//                         loop {
+//                             match source.step(program, m, referenced_tables)? {
+//                                 OpStepResult::Continue => continue,
+//                                 OpStepResult::ReadyToEmit => {
+//                                     return Ok(OpStepResult::Continue);
+//                                 }
+//                                 OpStepResult::Done => {
+//                                     return Ok(OpStepResult::Done);
+//                                 }
+//                             }
+//                         }
+//                     }
+//                     ORDER_INSERT_INTO_SORTER => {
+//                         let sort_keys_count = key.len();
+//                         let source_cols_count = source.column_count(referenced_tables);
+//                         let start_reg = program.alloc_registers(sort_keys_count);
+//                         source.result_columns(program, referenced_tables, m, None)?;
+
+//                         for (i, (expr, _)) in key.iter().enumerate() {
+//                             let key_reg = start_reg + i;
+//                             translate_expr(
+//                                 program,
+//                                 Some(referenced_tables),
+//                                 expr,
+//                                 key_reg,
+//                                 None,
+//                                 m.result_set_register_start,
+//                             )?;
+//                         }
+
+//                         let sort_metadata = m.sorts.get_mut(id).unwrap();
+//                         program.emit_insn(Insn::MakeRecord {
+//                             start_reg,
+//                             count: sort_keys_count + source_cols_count,
+//                             dest_reg: sort_metadata.sorter_data_register,
+//                         });
+
+//                         program.emit_insn(Insn::SorterInsert {
+//                             cursor_id: sort_metadata.sort_cursor,
+//                             record_reg: sort_metadata.sorter_data_register,
+//                         });
+
+//                         Ok(OpStepResult::Continue)
+//                     }
+//                     #[allow(clippy::never_loop)]
+//                     ORDER_SORT_AND_OPEN_LOOP => {
+//                         loop {
+//                             match source.step(program, m, referenced_tables)? {
+//                                 OpStepResult::Done => {
+//                                     break;
+//                                 }
+//                                 _ => unreachable!(),
+//                             }
+//                         }
+//                         program.resolve_label(
+//                             m.termination_label_stack.pop().unwrap(),
+//                             program.offset(),
+//                         );
+//                         let column_names = source.column_names();
+//                         let mut pseudo_columns = vec![];
+//                         for (i, _) in key.iter().enumerate() {
+//                             pseudo_columns.push(Column {
+//                                 name: format!("sort_key_{}", i),
+//                                 primary_key: false,
+//                                 ty: crate::schema::Type::Null,
+//                             });
+//                         }
+//                         for name in column_names {
+//                             pseudo_columns.push(Column {
+//                                 name: name.clone(),
+//                                 primary_key: false,
+//                                 ty: crate::schema::Type::Null,
+//                             });
+//                         }
+
+//                         let num_fields = pseudo_columns.len();
+
+//                         let pseudo_cursor = program.alloc_cursor_id(
+//                             None,
+//                             Some(Table::Pseudo(Rc::new(PseudoTable {
+//                                 columns: pseudo_columns,
+//                             }))),
+//                         );
+//                         let sort_metadata = m.sorts.get(id).unwrap();
+
+//                         program.emit_insn(Insn::OpenPseudo {
+//                             cursor_id: pseudo_cursor,
+//                             content_reg: sort_metadata.sorter_data_register,
+//                             num_fields,
+//                         });
+
+//                         program.emit_insn_with_label_dependency(
+//                             Insn::SorterSort {
+//                                 cursor_id: sort_metadata.sort_cursor,
+//                                 pc_if_empty: sort_metadata.done_label,
+//                             },
+//                             sort_metadata.done_label,
+//                         );
+
+//                         program.defer_label_resolution(
+//                             sort_metadata.sorter_data_label,
+//                             program.offset() as usize,
+//                         );
+//                         program.emit_insn(Insn::SorterData {
+//                             cursor_id: sort_metadata.sort_cursor,
+//                             dest_reg: sort_metadata.sorter_data_register,
+//                             pseudo_cursor,
+//                         });
+
+//                         let sort_metadata = m.sorts.get_mut(id).unwrap();
+
+//                         sort_metadata.pseudo_table_cursor = pseudo_cursor;
+
+//                         Ok(OpStepResult::ReadyToEmit)
+//                     }
+//                     ORDER_NEXT => {
+//                         let sort_metadata = m.sorts.get(id).unwrap();
+//                         program.emit_insn_with_label_dependency(
+//                             Insn::SorterNext {
+//                                 cursor_id: sort_metadata.sort_cursor,
+//                                 pc_if_next: sort_metadata.sorter_data_label,
+//                             },
+//                             sort_metadata.sorter_data_label,
+//                         );
+
+//                         program.resolve_label(sort_metadata.done_label, program.offset());
+
+//                         Ok(OpStepResult::Done)
+//                     }
+//                     _ => unreachable!(),
+//                 }
+//             }
+//             SourceOperator::Nothing => Ok(OpStepResult::Done),
+//         }
+//     }
+//     fn result_columns(
+//         &self,
+//         program: &mut ProgramBuilder,
+//         referenced_tables: &[BTreeTableReference],
+//         m: &mut Metadata,
+//         cursor_override: Option<&SortCursorOverride>,
+//     ) -> Result<usize> {
+//         let col_count = self.column_count(referenced_tables);
+//         match self {
+//             SourceOperator::Scan {
+//                 table_reference, ..
+//             } => {
+//                 let start_reg = program.alloc_registers(col_count);
+//                 let table = cursor_override
+//                     .map(|c| c.pseudo_table.clone())
+//                     .unwrap_or_else(|| Table::BTree(table_reference.table.clone()));
+//                 let cursor_id = cursor_override.map(|c| c.cursor_id).unwrap_or_else(|| {
+//                     program.resolve_cursor_id(&table_reference.table_identifier, None)
+//                 });
+//                 let start_column_offset = cursor_override.map(|c| c.sort_key_len).unwrap_or(0);
+//                 translate_table_columns(program, cursor_id, &table, start_column_offset, start_reg);
+
+//                 Ok(start_reg)
+//             }
+//             SourceOperator::Search {
+//                 table_reference, ..
+//             } => {
+//                 let start_reg = program.alloc_registers(col_count);
+//                 let table = cursor_override
+//                     .map(|c| c.pseudo_table.clone())
+//                     .unwrap_or_else(|| Table::BTree(table_reference.table.clone()));
+//                 let cursor_id = cursor_override.map(|c| c.cursor_id).unwrap_or_else(|| {
+//                     program.resolve_cursor_id(&table_reference.table_identifier, None)
+//                 });
+//                 let start_column_offset = cursor_override.map(|c| c.sort_key_len).unwrap_or(0);
+//                 translate_table_columns(program, cursor_id, &table, start_column_offset, start_reg);
+
+//                 Ok(start_reg)
+//             }
+//             SourceOperator::Join { left, right, .. } => {
+//                 let left_start_reg =
+//                     left.result_columns(program, referenced_tables, m, cursor_override)?;
+//                 right.result_columns(program, referenced_tables, m, cursor_override)?;
+
+//                 Ok(left_start_reg)
+//             }
+//             SourceOperator::Projection {
+//                 id,
+//                 expressions,
+//                 aggregates,
+//                 group_by,
+//                 ..
+//             } => {
+//                 if aggregates.is_empty() && group_by.is_none() {
+//                     let expr_count = expressions.len();
+//                     let start_reg = program.alloc_registers(expr_count);
+//                     let mut cur_reg = start_reg;
+//                     m.result_set_register_start = start_reg;
+//                     for expr in expressions {
+//                         translate_expr(
+//                             program,
+//                             Some(referenced_tables),
+//                             expr,
+//                             cur_reg,
+//                             cursor_override.map(|c| c.cursor_id),
+//                             m.result_set_register_start,
+//                         )?;
+//                         cur_reg += 1;
+//                     }
+
+//                     return Ok(start_reg);
+//                 }
+//                 let agg_start_reg = m.aggregation_start_registers.get(id).unwrap();
+//                 program.resolve_label(m.termination_label_stack.pop().unwrap(), program.offset());
+//                 for (i, agg) in aggregates.iter().enumerate() {
+//                     let agg_result_reg = *agg_start_reg + i;
+//                     program.emit_insn(Insn::AggFinal {
+//                         register: agg_result_reg,
+//                         func: agg.func.clone(),
+//                     });
+//                 }
+
+//                 if let Some(group_by) = group_by {
+//                     let output_row_start_reg =
+//                         program.alloc_registers(aggregates.len() + group_by.len());
+//                     let group_by_metadata = m.group_bys.get(id).unwrap();
+//                     program.emit_insn(Insn::Copy {
+//                         src_reg: group_by_metadata.group_exprs_accumulator_register,
+//                         dst_reg: output_row_start_reg,
+//                         amount: group_by.len() - 1,
+//                     });
+//                     program.emit_insn(Insn::Copy {
+//                         src_reg: *agg_start_reg,
+//                         dst_reg: output_row_start_reg + group_by.len(),
+//                         amount: aggregates.len() - 1,
+//                     });
+
+//                     Ok(output_row_start_reg)
+//                 } else {
+//                     Ok(*agg_start_reg)
+//                 }
+//             }
+//             SourceOperator::Filter { .. } => unreachable!("predicates have been pushed down"),
+//             SourceOperator::Limit { .. } => {
+//                 unimplemented!()
+//             }
+//             SourceOperator::Order { id, key, .. } => {
+//                 let cursor_id = m.sorts.get(id).unwrap().pseudo_table_cursor;
+//                 let pseudo_table = program.resolve_cursor_to_table(cursor_id).unwrap();
+//                 let start_column_offset = key.len();
+//                 let column_count = pseudo_table.columns().len() - start_column_offset;
+//                 let start_reg = program.alloc_registers(column_count);
+//                 translate_table_columns(
+//                     program,
+//                     cursor_id,
+//                     &pseudo_table,
+//                     start_column_offset,
+//                     start_reg,
+//                 );
+
+//                 Ok(start_reg)
+//             }
+//             SourceOperator::Projection {
+//                 expressions, id, ..
+//             } => {
+//                 let expr_count = expressions.len();
+//                 let start_reg = program.alloc_registers(expr_count);
+//                 let mut cur_reg = start_reg;
+//                 m.result_set_register_start = start_reg;
+//                 for expr in expressions {
+//                     translate_expr(
+//                         program,
+//                         Some(referenced_tables),
+//                         expr,
+//                         cur_reg,
+//                         cursor_override.map(|c| c.cursor_id),
+//                         m.result_set_register_start,
+//                     )?;
+//                     cur_reg += 1;
+//                 }
+
+//                 Ok(start_reg)
+//             }
+//             SourceOperator::Nothing => unimplemented!(),
+//         }
+//     }
+//     fn result_row(
+//         &mut self,
+//         program: &mut ProgramBuilder,
+//         referenced_tables: &[BTreeTableReference],
+//         m: &mut Metadata,
+//         cursor_override: Option<&SortCursorOverride>,
+//     ) -> Result<()> {
+//         match self {
+//             SourceOperator::Limit { source, limit, .. } => {
+//                 source.result_row(program, referenced_tables, m, cursor_override)?;
+//                 let limit_reg = program.alloc_register();
+//                 program.emit_insn(Insn::Integer {
+//                     value: *limit as i64,
+//                     dest: limit_reg,
+//                 });
+//                 program.mark_last_insn_constant();
+//                 let jump_label = m.termination_label_stack.first().unwrap();
+//                 program.emit_insn_with_label_dependency(
+//                     Insn::DecrJumpZero {
+//                         reg: limit_reg,
+//                         target_pc: *jump_label,
+//                     },
+//                     *jump_label,
+//                 );
+
+//                 Ok(())
+//             }
+//             operator => {
+//                 let start_reg =
+//                     operator.result_columns(program, referenced_tables, m, cursor_override)?;
+//                 program.emit_insn(Insn::ResultRow {
+//                     start_reg,
+//                     count: operator.column_count(referenced_tables),
+//                 });
+//                 Ok(())
+//             }
+//         }
+//     }
+// }
+
+fn prologue() -> Result<(ProgramBuilder, Metadata, BranchOffset, BranchOffset)> {
     let mut program = ProgramBuilder::new();
     let init_label = program.allocate_label();
     let halt_label = program.allocate_label();
@@ -1697,13 +1637,13 @@ fn prologue(
 
     let metadata = Metadata {
         termination_label_stack: vec![halt_label],
-        expr_result_cache: cache,
         aggregation_start_registers: HashMap::new(),
         group_bys: HashMap::new(),
         left_joins: HashMap::new(),
         next_row_labels: HashMap::new(),
         scan_loop_body_labels: vec![],
         sorts: HashMap::new(),
+        result_set_register_start: 0,
     };
 
     Ok((program, metadata, init_label, start_offset))
@@ -1740,28 +1680,1195 @@ fn epilogue(
 pub fn emit_program(
     database_header: Rc<RefCell<DatabaseHeader>>,
     mut plan: Plan,
-    cache: ExpressionResultCache,
     connection: Weak<Connection>,
 ) -> Result<Program> {
-    let (mut program, mut metadata, init_label, start_offset) = prologue(cache)?;
-    loop {
-        match plan
-            .root_operator
-            .step(&mut program, &mut metadata, &plan.referenced_tables)?
-        {
-            OpStepResult::Continue => {}
-            OpStepResult::ReadyToEmit => {
-                plan.root_operator.result_row(
-                    &mut program,
-                    &plan.referenced_tables,
-                    &mut metadata,
-                    None,
-                )?;
-            }
-            OpStepResult::Done => {
-                epilogue(&mut program, &mut metadata, init_label, start_offset)?;
-                return Ok(program.build(database_header, connection));
-            }
+    let (mut program, mut metadata, init_label, start_offset) = prologue()?;
+
+    let mut order_by_necessary = plan.order_by.is_some();
+
+    // OPEN CURSORS ETC
+    if let Some(ref mut order_by) = plan.order_by {
+        init_order_by(&mut program, order_by, &mut metadata)?;
+    }
+
+    if let Some(ref mut group_by) = plan.group_by {
+        let aggregates = plan.aggregates.as_mut().unwrap();
+        init_group_by(&mut program, group_by, aggregates, &mut metadata)?;
+    }
+    init_source(&mut program, &plan.source, &mut metadata)?;
+
+    // REWIND CURSORS, EMIT CONDITIONS
+    open_loop(
+        &mut program,
+        &mut plan.source,
+        &plan.referenced_tables,
+        &mut metadata,
+    )?;
+
+    // EMIT COLUMNS AND OTHER EXPRS IN INNER LOOP
+    inner_loop_emit(&mut program, &mut plan, &mut metadata)?;
+
+    // CLOSE LOOP
+    close_loop(
+        &mut program,
+        &mut plan.source,
+        &mut metadata,
+        &plan.referenced_tables,
+    )?;
+
+    // IF GROUP BY, SORT BY GROUPS AND DO AGGREGATION
+    if let Some(ref mut group_by) = plan.group_by {
+        sort_group_by(&mut program, group_by, &mut metadata)?;
+        finalize_group_by(&mut program, group_by, &mut metadata)?;
+    } else if let Some(ref mut aggregates) = plan.aggregates {
+        // Example: SELECT sum(x), count(*) FROM t;
+        finalize_agg_without_group_by(&mut program, aggregates, &mut metadata)?;
+        // If we have an aggregate without a group by, we don't need an order by because currently
+        // there can only be a single row result in those cases.
+        order_by_necessary = false;
+    }
+
+    // IF ORDER BY, SORT BY ORDER BY
+    if let Some(ref mut order_by) = plan.order_by {
+        if order_by_necessary {
+            sort_order_by(
+                &mut program,
+                order_by,
+                &plan.result_columns,
+                plan.limit.clone(),
+                &mut metadata,
+            )?;
         }
     }
+
+    // EPILOGUE
+    epilogue(&mut program, &mut metadata, init_label, start_offset)?;
+
+    Ok(program.build(database_header, connection))
+}
+
+const ORDER_BY_ID: usize = 0;
+const GROUP_BY_ID: usize = 1;
+const AGG_WITHOUT_GROUP_BY_ID: usize = 2;
+
+fn init_order_by(
+    program: &mut ProgramBuilder,
+    order_by: &Vec<(ast::Expr, Direction)>,
+    m: &mut Metadata,
+) -> Result<()> {
+    m.termination_label_stack.push(program.allocate_label());
+    let sort_cursor = program.alloc_cursor_id(None, None);
+    m.sorts.insert(
+        ORDER_BY_ID,
+        SortMetadata {
+            sort_cursor,
+            pseudo_table_cursor: usize::MAX, // will be set later
+            sorter_data_register: program.alloc_register(),
+            sorter_data_label: program.allocate_label(),
+            done_label: program.allocate_label(),
+        },
+    );
+    let mut order = Vec::new();
+    for (_, direction) in order_by.iter() {
+        order.push(OwnedValue::Integer(*direction as i64));
+    }
+    program.emit_insn(Insn::SorterOpen {
+        cursor_id: sort_cursor,
+        columns: order_by.len(),
+        order: OwnedRecord::new(order),
+    });
+    Ok(())
+}
+
+fn init_group_by(
+    program: &mut ProgramBuilder,
+    group_by: &Vec<ast::Expr>,
+    aggregates: &Vec<Aggregate>,
+    m: &mut Metadata,
+) -> Result<()> {
+    let agg_final_label = program.allocate_label();
+    m.termination_label_stack.push(agg_final_label);
+    let num_aggs = aggregates.len();
+
+    let sort_cursor = program.alloc_cursor_id(None, None);
+
+    let abort_flag_register = program.alloc_register();
+    let data_in_accumulator_indicator_register = program.alloc_register();
+    let group_exprs_comparison_register = program.alloc_registers(group_by.len());
+    let group_exprs_accumulator_register = program.alloc_registers(group_by.len());
+    let agg_exprs_start_reg = program.alloc_registers(num_aggs);
+    m.aggregation_start_registers
+        .insert(GROUP_BY_ID, agg_exprs_start_reg);
+    let sorter_key_register = program.alloc_register();
+
+    let subroutine_accumulator_clear_label = program.allocate_label();
+    let subroutine_accumulator_output_label = program.allocate_label();
+    let sorter_data_label = program.allocate_label();
+    let grouping_done_label = program.allocate_label();
+
+    let mut order = Vec::new();
+    const ASCENDING: i64 = 0;
+    for _ in group_by.iter() {
+        order.push(OwnedValue::Integer(ASCENDING));
+    }
+    program.emit_insn(Insn::SorterOpen {
+        cursor_id: sort_cursor,
+        columns: aggregates.len() + group_by.len(),
+        order: OwnedRecord::new(order),
+    });
+
+    program.add_comment(program.offset(), "clear group by abort flag");
+    program.emit_insn(Insn::Integer {
+        value: 0,
+        dest: abort_flag_register,
+    });
+
+    program.add_comment(
+        program.offset(),
+        "initialize group by comparison registers to NULL",
+    );
+    program.emit_insn(Insn::Null {
+        dest: group_exprs_comparison_register,
+        dest_end: if group_by.len() > 1 {
+            Some(group_exprs_comparison_register + group_by.len() - 1)
+        } else {
+            None
+        },
+    });
+
+    program.add_comment(program.offset(), "go to clear accumulator subroutine");
+
+    let subroutine_accumulator_clear_return_offset_register = program.alloc_register();
+    program.emit_insn_with_label_dependency(
+        Insn::Gosub {
+            target_pc: subroutine_accumulator_clear_label,
+            return_reg: subroutine_accumulator_clear_return_offset_register,
+        },
+        subroutine_accumulator_clear_label,
+    );
+
+    m.group_bys.insert(
+        GROUP_BY_ID,
+        GroupByMetadata {
+            sort_cursor,
+            subroutine_accumulator_clear_label,
+            subroutine_accumulator_clear_return_offset_register,
+            subroutine_accumulator_output_label,
+            subroutine_accumulator_output_return_offset_register: program.alloc_register(),
+            accumulator_indicator_set_true_label: program.allocate_label(),
+            sorter_data_label,
+            grouping_done_label,
+            abort_flag_register,
+            data_in_accumulator_indicator_register,
+            group_exprs_accumulator_register,
+            group_exprs_comparison_register,
+            sorter_key_register,
+        },
+    );
+    Ok(())
+}
+
+// fn init_agg_without_group_by(
+//     program: &mut ProgramBuilder,
+//     aggregates: &Vec<Aggregate>,
+//     m: &mut Metadata,
+// ) -> Result<()> {
+
+//     Ok(())
+// }
+
+fn init_source(
+    program: &mut ProgramBuilder,
+    source: &SourceOperator,
+    m: &mut Metadata,
+) -> Result<()> {
+    match source {
+        SourceOperator::Join {
+            id,
+            left,
+            right,
+            outer,
+            ..
+        } => {
+            if *outer {
+                let lj_metadata = LeftJoinMetadata {
+                    match_flag_register: program.alloc_register(),
+                    set_match_flag_true_label: program.allocate_label(),
+                    check_match_flag_label: program.allocate_label(),
+                    on_match_jump_to_label: program.allocate_label(),
+                };
+                m.left_joins.insert(*id, lj_metadata);
+            }
+            init_source(program, left, m)?;
+            init_source(program, right, m)?;
+
+            return Ok(());
+        }
+        SourceOperator::Scan {
+            id,
+            table_reference,
+            ..
+        } => {
+            let cursor_id = program.alloc_cursor_id(
+                Some(table_reference.table_identifier.clone()),
+                Some(Table::BTree(table_reference.table.clone())),
+            );
+            let root_page = table_reference.table.root_page;
+            let next_row_label = program.allocate_label();
+            m.next_row_labels.insert(*id, next_row_label);
+            program.emit_insn(Insn::OpenReadAsync {
+                cursor_id,
+                root_page,
+            });
+            program.emit_insn(Insn::OpenReadAwait);
+
+            return Ok(());
+        }
+        SourceOperator::Search {
+            id,
+            table_reference,
+            search,
+            ..
+        } => {
+            let table_cursor_id = program.alloc_cursor_id(
+                Some(table_reference.table_identifier.clone()),
+                Some(Table::BTree(table_reference.table.clone())),
+            );
+
+            let next_row_label = program.allocate_label();
+
+            if !matches!(search, Search::PrimaryKeyEq { .. }) {
+                // Primary key equality search is handled with a SeekRowid instruction which does not loop, since it is a single row lookup.
+                m.next_row_labels.insert(*id, next_row_label);
+            }
+
+            let scan_loop_body_label = program.allocate_label();
+            m.scan_loop_body_labels.push(scan_loop_body_label);
+            program.emit_insn(Insn::OpenReadAsync {
+                cursor_id: table_cursor_id,
+                root_page: table_reference.table.root_page,
+            });
+            program.emit_insn(Insn::OpenReadAwait);
+
+            if let Search::IndexSearch { index, .. } = search {
+                let index_cursor_id = program
+                    .alloc_cursor_id(Some(index.name.clone()), Some(Table::Index(index.clone())));
+                program.emit_insn(Insn::OpenReadAsync {
+                    cursor_id: index_cursor_id,
+                    root_page: index.root_page,
+                });
+                program.emit_insn(Insn::OpenReadAwait);
+            }
+
+            return Ok(());
+        }
+        SourceOperator::Nothing => {
+            return Ok(());
+        }
+    }
+}
+
+fn open_loop(
+    program: &mut ProgramBuilder,
+    source: &mut SourceOperator,
+    referenced_tables: &[BTreeTableReference],
+    m: &mut Metadata,
+) -> Result<()> {
+    match source {
+        SourceOperator::Join {
+            id,
+            left,
+            right,
+            predicates,
+            outer,
+            ..
+        } => {
+            open_loop(program, left, referenced_tables, m)?;
+
+            let mut jump_target_when_false = *m
+                .next_row_labels
+                .get(&right.id())
+                .or(m.next_row_labels.get(&left.id()))
+                .unwrap_or(m.termination_label_stack.last().unwrap());
+
+            if *outer {
+                let lj_meta = m.left_joins.get(id).unwrap();
+                program.emit_insn(Insn::Integer {
+                    value: 0,
+                    dest: lj_meta.match_flag_register,
+                });
+                jump_target_when_false = lj_meta.check_match_flag_label;
+            }
+            m.next_row_labels.insert(right.id(), jump_target_when_false);
+
+            open_loop(program, right, referenced_tables, m)?;
+
+            if let Some(predicates) = predicates {
+                let jump_target_when_true = program.allocate_label();
+                let condition_metadata = ConditionMetadata {
+                    jump_if_condition_is_true: false,
+                    jump_target_when_true,
+                    jump_target_when_false,
+                };
+                for predicate in predicates.iter() {
+                    translate_condition_expr(
+                        program,
+                        referenced_tables,
+                        predicate,
+                        None,
+                        condition_metadata,
+                        m.result_set_register_start,
+                    )?;
+                }
+                program.resolve_label(jump_target_when_true, program.offset());
+            }
+
+            if *outer {
+                let lj_meta = m.left_joins.get(id).unwrap();
+                program.defer_label_resolution(
+                    lj_meta.set_match_flag_true_label,
+                    program.offset() as usize,
+                );
+                program.emit_insn(Insn::Integer {
+                    value: 1,
+                    dest: lj_meta.match_flag_register,
+                });
+            }
+
+            return Ok(());
+        }
+        SourceOperator::Scan {
+            id,
+            table_reference,
+            predicates,
+            iter_dir,
+        } => {
+            let cursor_id = program.resolve_cursor_id(&table_reference.table_identifier, None);
+            if iter_dir
+                .as_ref()
+                .is_some_and(|dir| *dir == IterationDirection::Backwards)
+            {
+                program.emit_insn(Insn::LastAsync { cursor_id });
+            } else {
+                program.emit_insn(Insn::RewindAsync { cursor_id });
+            }
+            let scan_loop_body_label = program.allocate_label();
+            let halt_label = m.termination_label_stack.last().unwrap();
+            program.emit_insn_with_label_dependency(
+                if iter_dir
+                    .as_ref()
+                    .is_some_and(|dir| *dir == IterationDirection::Backwards)
+                {
+                    Insn::LastAwait {
+                        cursor_id,
+                        pc_if_empty: *halt_label,
+                    }
+                } else {
+                    Insn::RewindAwait {
+                        cursor_id,
+                        pc_if_empty: *halt_label,
+                    }
+                },
+                *halt_label,
+            );
+            m.scan_loop_body_labels.push(scan_loop_body_label);
+            program.defer_label_resolution(scan_loop_body_label, program.offset() as usize);
+
+            let jump_label = m.next_row_labels.get(id).unwrap_or(halt_label);
+            if let Some(preds) = predicates {
+                for expr in preds {
+                    let jump_target_when_true = program.allocate_label();
+                    let condition_metadata = ConditionMetadata {
+                        jump_if_condition_is_true: false,
+                        jump_target_when_true,
+                        jump_target_when_false: *jump_label,
+                    };
+                    translate_condition_expr(
+                        program,
+                        referenced_tables,
+                        expr,
+                        None,
+                        condition_metadata,
+                        m.result_set_register_start,
+                    )?;
+                    program.resolve_label(jump_target_when_true, program.offset());
+                }
+            }
+
+            return Ok(());
+        }
+        SourceOperator::Search {
+            id,
+            table_reference,
+            search,
+            predicates,
+            ..
+        } => {
+            let table_cursor_id =
+                program.resolve_cursor_id(&table_reference.table_identifier, None);
+
+            // Open the loop for the index search.
+            // Primary key equality search is handled with a SeekRowid instruction which does not loop, since it is a single row lookup.
+            if !matches!(search, Search::PrimaryKeyEq { .. }) {
+                let index_cursor_id = if let Search::IndexSearch { index, .. } = search {
+                    Some(program.resolve_cursor_id(&index.name, None))
+                } else {
+                    None
+                };
+                let scan_loop_body_label = *m.scan_loop_body_labels.last().unwrap();
+                let cmp_reg = program.alloc_register();
+                let (cmp_expr, cmp_op) = match search {
+                    Search::IndexSearch {
+                        cmp_expr, cmp_op, ..
+                    } => (cmp_expr, cmp_op),
+                    Search::PrimaryKeySearch { cmp_expr, cmp_op } => (cmp_expr, cmp_op),
+                    Search::PrimaryKeyEq { .. } => unreachable!(),
+                };
+                // TODO this only handles ascending indexes
+                match cmp_op {
+                    ast::Operator::Equals
+                    | ast::Operator::Greater
+                    | ast::Operator::GreaterEquals => {
+                        translate_expr(
+                            program,
+                            Some(referenced_tables),
+                            cmp_expr,
+                            cmp_reg,
+                            None,
+                            m.result_set_register_start,
+                        )?;
+                    }
+                    ast::Operator::Less | ast::Operator::LessEquals => {
+                        program.emit_insn(Insn::Null {
+                            dest: cmp_reg,
+                            dest_end: None,
+                        });
+                    }
+                    _ => unreachable!(),
+                }
+                program.emit_insn_with_label_dependency(
+                    match cmp_op {
+                        ast::Operator::Equals | ast::Operator::GreaterEquals => Insn::SeekGE {
+                            is_index: index_cursor_id.is_some(),
+                            cursor_id: index_cursor_id.unwrap_or(table_cursor_id),
+                            start_reg: cmp_reg,
+                            num_regs: 1,
+                            target_pc: *m.termination_label_stack.last().unwrap(),
+                        },
+                        ast::Operator::Greater
+                        | ast::Operator::Less
+                        | ast::Operator::LessEquals => Insn::SeekGT {
+                            is_index: index_cursor_id.is_some(),
+                            cursor_id: index_cursor_id.unwrap_or(table_cursor_id),
+                            start_reg: cmp_reg,
+                            num_regs: 1,
+                            target_pc: *m.termination_label_stack.last().unwrap(),
+                        },
+                        _ => unreachable!(),
+                    },
+                    *m.termination_label_stack.last().unwrap(),
+                );
+                if *cmp_op == ast::Operator::Less || *cmp_op == ast::Operator::LessEquals {
+                    translate_expr(
+                        program,
+                        Some(referenced_tables),
+                        cmp_expr,
+                        cmp_reg,
+                        None,
+                        m.result_set_register_start,
+                    )?;
+                }
+
+                program.defer_label_resolution(scan_loop_body_label, program.offset() as usize);
+                // TODO: We are currently only handling ascending indexes.
+                // For conditions like index_key > 10, we have already seeked to the first key greater than 10, and can just scan forward.
+                // For conditions like index_key < 10, we are at the beginning of the index, and will scan forward and emit IdxGE(10) with a conditional jump to the end.
+                // For conditions like index_key = 10, we have already seeked to the first key greater than or equal to 10, and can just scan forward and emit IdxGT(10) with a conditional jump to the end.
+                // For conditions like index_key >= 10, we have already seeked to the first key greater than or equal to 10, and can just scan forward.
+                // For conditions like index_key <= 10, we are at the beginning of the index, and will scan forward and emit IdxGT(10) with a conditional jump to the end.
+                // For conditions like index_key != 10, TODO. probably the optimal way is not to use an index at all.
+                //
+                // For primary key searches we emit RowId and then compare it to the seek value.
+
+                let abort_jump_target = *m
+                    .next_row_labels
+                    .get(id)
+                    .unwrap_or(m.termination_label_stack.last().unwrap());
+                match cmp_op {
+                    ast::Operator::Equals | ast::Operator::LessEquals => {
+                        if let Some(index_cursor_id) = index_cursor_id {
+                            program.emit_insn_with_label_dependency(
+                                Insn::IdxGT {
+                                    cursor_id: index_cursor_id,
+                                    start_reg: cmp_reg,
+                                    num_regs: 1,
+                                    target_pc: abort_jump_target,
+                                },
+                                abort_jump_target,
+                            );
+                        } else {
+                            let rowid_reg = program.alloc_register();
+                            program.emit_insn(Insn::RowId {
+                                cursor_id: table_cursor_id,
+                                dest: rowid_reg,
+                            });
+                            program.emit_insn_with_label_dependency(
+                                Insn::Gt {
+                                    lhs: rowid_reg,
+                                    rhs: cmp_reg,
+                                    target_pc: abort_jump_target,
+                                },
+                                abort_jump_target,
+                            );
+                        }
+                    }
+                    ast::Operator::Less => {
+                        if let Some(index_cursor_id) = index_cursor_id {
+                            program.emit_insn_with_label_dependency(
+                                Insn::IdxGE {
+                                    cursor_id: index_cursor_id,
+                                    start_reg: cmp_reg,
+                                    num_regs: 1,
+                                    target_pc: abort_jump_target,
+                                },
+                                abort_jump_target,
+                            );
+                        } else {
+                            let rowid_reg = program.alloc_register();
+                            program.emit_insn(Insn::RowId {
+                                cursor_id: table_cursor_id,
+                                dest: rowid_reg,
+                            });
+                            program.emit_insn_with_label_dependency(
+                                Insn::Ge {
+                                    lhs: rowid_reg,
+                                    rhs: cmp_reg,
+                                    target_pc: abort_jump_target,
+                                },
+                                abort_jump_target,
+                            );
+                        }
+                    }
+                    _ => {}
+                }
+
+                if let Some(index_cursor_id) = index_cursor_id {
+                    program.emit_insn(Insn::DeferredSeek {
+                        index_cursor_id,
+                        table_cursor_id,
+                    });
+                }
+            }
+
+            let jump_label = m
+                .next_row_labels
+                .get(id)
+                .unwrap_or(m.termination_label_stack.last().unwrap());
+
+            if let Search::PrimaryKeyEq { cmp_expr } = search {
+                let src_reg = program.alloc_register();
+                translate_expr(
+                    program,
+                    Some(referenced_tables),
+                    cmp_expr,
+                    src_reg,
+                    None,
+                    m.result_set_register_start,
+                )?;
+                program.emit_insn_with_label_dependency(
+                    Insn::SeekRowid {
+                        cursor_id: table_cursor_id,
+                        src_reg,
+                        target_pc: *jump_label,
+                    },
+                    *jump_label,
+                );
+            }
+            if let Some(predicates) = predicates {
+                for predicate in predicates.iter() {
+                    let jump_target_when_true = program.allocate_label();
+                    let condition_metadata = ConditionMetadata {
+                        jump_if_condition_is_true: false,
+                        jump_target_when_true,
+                        jump_target_when_false: *jump_label,
+                    };
+                    translate_condition_expr(
+                        program,
+                        referenced_tables,
+                        predicate,
+                        None,
+                        condition_metadata,
+                        m.result_set_register_start,
+                    )?;
+                    program.resolve_label(jump_target_when_true, program.offset());
+                }
+            }
+
+            return Ok(());
+        }
+        SourceOperator::Nothing => {
+            return Ok(());
+        }
+    }
+}
+
+pub enum InnerLoopEmitTarget<'a> {
+    GroupBySorter {
+        group_by: &'a Vec<ast::Expr>,
+        aggregates: &'a Vec<Aggregate>,
+    },
+    OrderBySorter {
+        order_by: &'a Vec<(ast::Expr, Direction)>,
+    },
+    ResultRow {
+        limit: Option<usize>,
+    },
+    AggStep,
+}
+
+fn inner_loop_emit(program: &mut ProgramBuilder, plan: &mut Plan, m: &mut Metadata) -> Result<()> {
+    // if we have a group by, we emit a record into the group by sorter.
+    if let Some(group_by) = &plan.group_by {
+        return inner_loop_source_emit(
+            program,
+            &plan.source,
+            &plan.result_columns,
+            &plan.aggregates,
+            m,
+            InnerLoopEmitTarget::GroupBySorter {
+                group_by,
+                aggregates: &plan.aggregates.as_ref().unwrap(),
+            },
+            &plan.referenced_tables,
+        );
+    }
+    // if we DONT have a group by, but we have aggregates, we emit without ResultRow.
+    // we also do not need to sort because we are emitting a single row.
+    if plan.aggregates.is_some() {
+        return inner_loop_source_emit(
+            program,
+            &plan.source,
+            &plan.result_columns,
+            &plan.aggregates,
+            m,
+            InnerLoopEmitTarget::AggStep,
+            &plan.referenced_tables,
+        );
+    }
+    // if we DONT have a group by, but we have an order by, we emit a record into the order by sorter.
+    if let Some(order_by) = &plan.order_by {
+        return inner_loop_source_emit(
+            program,
+            &plan.source,
+            &plan.result_columns,
+            &plan.aggregates,
+            m,
+            InnerLoopEmitTarget::OrderBySorter { order_by },
+            &plan.referenced_tables,
+        );
+    }
+    // if we have neither, we emit a ResultRow. In that case, if we have a Limit, we handle that with DecrJumpZero.
+    return inner_loop_source_emit(
+        program,
+        &plan.source,
+        &plan.result_columns,
+        &plan.aggregates,
+        m,
+        InnerLoopEmitTarget::ResultRow { limit: plan.limit },
+        &plan.referenced_tables,
+    );
+}
+
+fn inner_loop_source_emit(
+    program: &mut ProgramBuilder,
+    source: &SourceOperator,
+    result_columns: &Vec<ResultSetColumn>,
+    aggregates: &Option<Vec<Aggregate>>,
+    m: &mut Metadata,
+    emit_target: InnerLoopEmitTarget,
+    referenced_tables: &[BTreeTableReference],
+) -> Result<()> {
+    match emit_target {
+        InnerLoopEmitTarget::GroupBySorter {
+            group_by,
+            aggregates,
+        } => {
+            // TODO: DOESNT WORK YET
+            let sort_keys_count = group_by.len();
+            let column_count = sort_keys_count + aggregates.len();
+            let start_reg = program.alloc_registers(column_count);
+            for (i, expr) in group_by.iter().enumerate() {
+                let key_reg = start_reg + i;
+                translate_expr(
+                    program,
+                    Some(referenced_tables),
+                    expr,
+                    key_reg,
+                    None,
+                    m.result_set_register_start,
+                )?;
+            }
+            for (i, agg) in aggregates.iter().enumerate() {
+                // TODO it's a hack to assume aggregate functions have exactly one argument.
+                // Counterpoint e.g. GROUP_CONCAT(expr, separator).
+                //
+                // Here we are collecting scalars for the group by sorter, which will include
+                // both the group by expressions and the aggregate arguments.
+                // e.g. in `select u.first_name, sum(u.age) from users group by u.first_name`
+                // the sorter will have two scalars: u.first_name and u.age.
+                // these are then sorted by u.first_name, and for each u.first_name, we sum the u.age.
+                // the actual aggregation is done later in GROUP_BY_SORT_AND_COMPARE below.
+                //
+                // This is why we take the first argument of each aggregate function currently.
+                // It's mostly an artifact of the current architecture being a bit poor; we should recognize
+                // which scalars are dependencies of aggregate functions and explicitly collect those.
+                let expr = &agg.args[0];
+                let agg_reg = start_reg + sort_keys_count + i;
+                translate_expr(
+                    program,
+                    Some(referenced_tables),
+                    expr,
+                    agg_reg,
+                    None,
+                    m.result_set_register_start,
+                )?;
+            }
+
+            let group_by_metadata = m.group_bys.get(&GROUP_BY_ID).unwrap();
+
+            program.emit_insn(Insn::MakeRecord {
+                start_reg,
+                count: column_count,
+                dest_reg: group_by_metadata.sorter_key_register,
+            });
+
+            let group_by_metadata = m.group_bys.get(&GROUP_BY_ID).unwrap();
+            program.emit_insn(Insn::SorterInsert {
+                cursor_id: group_by_metadata.sort_cursor,
+                record_reg: group_by_metadata.sorter_key_register,
+            });
+
+            Ok(())
+        }
+        InnerLoopEmitTarget::OrderBySorter { order_by } => {
+            // TODO: DOESNT WORK YET
+            let sort_keys_count = order_by.len();
+            let source_cols_count = result_columns.len();
+            let start_reg = program.alloc_registers(sort_keys_count + source_cols_count);
+            for (i, (expr, _)) in order_by.iter().enumerate() {
+                let key_reg = start_reg + i;
+                translate_expr(
+                    program,
+                    Some(referenced_tables),
+                    expr,
+                    key_reg,
+                    None,
+                    m.result_set_register_start,
+                )?;
+            }
+            for (i, expr) in result_columns.iter().enumerate() {
+                match expr {
+                    ResultSetColumn::Scalar(expr) => {
+                        let reg = start_reg + sort_keys_count + i;
+                        translate_expr(
+                            program,
+                            Some(referenced_tables),
+                            expr,
+                            reg,
+                            None,
+                            m.result_set_register_start,
+                        )?;
+                    }
+                    other => todo!("{:?}", other),
+                }
+            }
+
+            let sort_metadata = m.sorts.get_mut(&ORDER_BY_ID).unwrap();
+            program.emit_insn(Insn::MakeRecord {
+                start_reg,
+                count: sort_keys_count + source_cols_count,
+                dest_reg: sort_metadata.sorter_data_register,
+            });
+
+            program.emit_insn(Insn::SorterInsert {
+                cursor_id: sort_metadata.sort_cursor,
+                record_reg: sort_metadata.sorter_data_register,
+            });
+
+            Ok(())
+        }
+        InnerLoopEmitTarget::AggStep => {
+            let aggregates = aggregates.as_ref().unwrap();
+            let agg_final_label = program.allocate_label();
+            m.termination_label_stack.push(agg_final_label);
+            let num_aggs = aggregates.len();
+            let start_reg = program.alloc_registers(result_columns.len());
+            m.aggregation_start_registers
+                .insert(AGG_WITHOUT_GROUP_BY_ID, start_reg);
+            for (i, agg) in aggregates.iter().enumerate() {
+                let reg = start_reg + i;
+                translate_aggregation(program, referenced_tables, agg, reg, None)?;
+            }
+            for (i, expr) in result_columns.iter().enumerate() {
+                match expr {
+                    ResultSetColumn::Scalar(expr) => {
+                        let reg = start_reg + num_aggs + i;
+                        translate_expr(
+                            program,
+                            Some(referenced_tables),
+                            expr,
+                            reg,
+                            None,
+                            m.result_set_register_start,
+                        )?;
+                    }
+                    ResultSetColumn::Agg(_) => { /* do nothing, aggregates are computed above */ }
+                    other => unreachable!("Unexpected non-scalar result column: {:?}", other),
+                }
+            }
+            Ok(())
+        }
+        InnerLoopEmitTarget::ResultRow { limit } => {
+            assert!(aggregates.is_none());
+            let start_reg = program.alloc_registers(result_columns.len());
+            for (i, expr) in result_columns.iter().enumerate() {
+                match expr {
+                    ResultSetColumn::Scalar(expr) => {
+                        let reg = start_reg + i;
+                        translate_expr(
+                            program,
+                            Some(referenced_tables),
+                            expr,
+                            reg,
+                            None,
+                            m.result_set_register_start,
+                        )?;
+                    }
+                    other => unreachable!("Unexpected non-scalar result column: {:?}", other),
+                }
+            }
+            program.emit_insn(Insn::ResultRow {
+                start_reg,
+                count: result_columns.len(),
+            });
+            if let Some(limit) = limit {
+                let jump_label = m.termination_label_stack.last().unwrap();
+                let limit_reg = program.alloc_register();
+                program.emit_insn(Insn::Integer {
+                    value: limit as i64,
+                    dest: limit_reg,
+                });
+                program.mark_last_insn_constant();
+                program.emit_insn_with_label_dependency(
+                    Insn::DecrJumpZero {
+                        reg: limit_reg,
+                        target_pc: *jump_label,
+                    },
+                    *jump_label,
+                );
+            }
+
+            Ok(())
+        }
+    }
+}
+
+fn close_loop(
+    program: &mut ProgramBuilder,
+    source: &SourceOperator,
+    m: &mut Metadata,
+    referenced_tables: &[BTreeTableReference],
+) -> Result<()> {
+    match source {
+        SourceOperator::Join {
+            id,
+            left,
+            right,
+            outer,
+            ..
+        } => {
+            close_loop(program, right, m, referenced_tables)?;
+
+            if *outer {
+                let lj_meta = m.left_joins.get(id).unwrap();
+                // If the left join match flag has been set to 1, we jump to the next row on the outer table (result row has been emitted already)
+                program.resolve_label(lj_meta.check_match_flag_label, program.offset());
+                program.emit_insn_with_label_dependency(
+                    Insn::IfPos {
+                        reg: lj_meta.match_flag_register,
+                        target_pc: lj_meta.on_match_jump_to_label,
+                        decrement_by: 0,
+                    },
+                    lj_meta.on_match_jump_to_label,
+                );
+                // If not, we set the right table cursor's "pseudo null bit" on, which means any Insn::Column will return NULL
+                let right_cursor_id = match right.as_ref() {
+                    SourceOperator::Scan {
+                        table_reference, ..
+                    } => program.resolve_cursor_id(&table_reference.table_identifier, None),
+                    SourceOperator::Search {
+                        table_reference, ..
+                    } => program.resolve_cursor_id(&table_reference.table_identifier, None),
+                    _ => unreachable!(),
+                };
+                program.emit_insn(Insn::NullRow {
+                    cursor_id: right_cursor_id,
+                });
+                // Jump to setting the left join match flag to 1 again, but this time the right table cursor will set everything to null
+                program.emit_insn_with_label_dependency(
+                    Insn::Goto {
+                        target_pc: lj_meta.set_match_flag_true_label,
+                    },
+                    lj_meta.set_match_flag_true_label,
+                );
+            }
+            let next_row_label = if *outer {
+                m.left_joins.get(id).unwrap().on_match_jump_to_label
+            } else {
+                *m.next_row_labels.get(&right.id()).unwrap()
+            };
+            // This points to the NextAsync instruction of the left table
+            program.resolve_label(next_row_label, program.offset());
+            close_loop(program, left, m, referenced_tables)?;
+
+            Ok(())
+        }
+        SourceOperator::Scan {
+            id,
+            table_reference,
+            iter_dir,
+            ..
+        } => {
+            let cursor_id = program.resolve_cursor_id(&table_reference.table_identifier, None);
+            program.resolve_label(*m.next_row_labels.get(id).unwrap(), program.offset());
+            if iter_dir
+                .as_ref()
+                .is_some_and(|dir| *dir == IterationDirection::Backwards)
+            {
+                program.emit_insn(Insn::PrevAsync { cursor_id });
+            } else {
+                program.emit_insn(Insn::NextAsync { cursor_id });
+            }
+            let jump_label = m.scan_loop_body_labels.pop().unwrap();
+
+            if iter_dir
+                .as_ref()
+                .is_some_and(|dir| *dir == IterationDirection::Backwards)
+            {
+                program.emit_insn_with_label_dependency(
+                    Insn::PrevAwait {
+                        cursor_id,
+                        pc_if_next: jump_label,
+                    },
+                    jump_label,
+                );
+            } else {
+                program.emit_insn_with_label_dependency(
+                    Insn::NextAwait {
+                        cursor_id,
+                        pc_if_next: jump_label,
+                    },
+                    jump_label,
+                );
+            }
+            Ok(())
+        }
+        SourceOperator::Search {
+            id,
+            table_reference,
+            search,
+            ..
+        } => {
+            if matches!(search, Search::PrimaryKeyEq { .. }) {
+                // Primary key equality search is handled with a SeekRowid instruction which does not loop, so there is no need to emit a NextAsync instruction.
+                return Ok(());
+            }
+            let cursor_id = match search {
+                Search::IndexSearch { index, .. } => program.resolve_cursor_id(&index.name, None),
+                Search::PrimaryKeySearch { .. } => {
+                    program.resolve_cursor_id(&table_reference.table_identifier, None)
+                }
+                Search::PrimaryKeyEq { .. } => unreachable!(),
+            };
+            program.resolve_label(*m.next_row_labels.get(id).unwrap(), program.offset());
+            program.emit_insn(Insn::NextAsync { cursor_id });
+            let jump_label = m.scan_loop_body_labels.pop().unwrap();
+            program.emit_insn_with_label_dependency(
+                Insn::NextAwait {
+                    cursor_id,
+                    pc_if_next: jump_label,
+                },
+                jump_label,
+            );
+
+            Ok(())
+        }
+        SourceOperator::Nothing => {
+            unreachable!()
+        }
+    }
+}
+
+fn sort_group_by(
+    program: &mut ProgramBuilder,
+    group_by: &Vec<ast::Expr>,
+    m: &mut Metadata,
+) -> Result<()> {
+    todo!()
+}
+
+fn finalize_group_by(
+    program: &mut ProgramBuilder,
+    group_by: &Vec<ast::Expr>,
+    m: &mut Metadata,
+) -> Result<()> {
+    todo!()
+}
+
+enum FinalizeGroupByEmitTarget {
+    OrderBySorter(usize),
+    ResultRow,
+}
+
+fn finalize_agg_without_group_by(
+    program: &mut ProgramBuilder,
+    aggregates: &Vec<Aggregate>,
+    m: &mut Metadata,
+) -> Result<()> {
+    let agg_start_reg = m
+        .aggregation_start_registers
+        .get(&AGG_WITHOUT_GROUP_BY_ID)
+        .unwrap();
+    for (i, agg) in aggregates.iter().enumerate() {
+        let agg_result_reg = *agg_start_reg + i;
+        program.emit_insn(Insn::AggFinal {
+            register: agg_result_reg,
+            func: agg.func.clone(),
+        });
+    }
+    let output_reg = program.alloc_registers(aggregates.len());
+    program.emit_insn(Insn::Copy {
+        src_reg: *agg_start_reg,
+        dst_reg: output_reg,
+        amount: aggregates.len() - 1,
+    });
+    // This always emits a ResultRow because currently it can only be used for a single row result
+    program.emit_insn(Insn::ResultRow {
+        start_reg: output_reg,
+        count: aggregates.len(),
+    });
+
+    Ok(())
+}
+
+fn sort_order_by(
+    program: &mut ProgramBuilder,
+    order_by: &Vec<(ast::Expr, Direction)>,
+    result_columns: &Vec<ResultSetColumn>,
+    limit: Option<usize>,
+    m: &mut Metadata,
+) -> Result<()> {
+    // TODO: DOESNT WORK YET
+    program.resolve_label(m.termination_label_stack.pop().unwrap(), program.offset());
+    let mut pseudo_columns = vec![];
+    for (i, _) in order_by.iter().enumerate() {
+        pseudo_columns.push(Column {
+            name: format!("sort_key_{}", i),
+            primary_key: false,
+            ty: crate::schema::Type::Null,
+        });
+    }
+    for expr in result_columns.iter() {
+        pseudo_columns.push(Column {
+            name: match expr {
+                ResultSetColumn::Scalar(expr) => expr.to_string(),
+                ResultSetColumn::Agg(agg) => agg.to_string(),
+                _ => unreachable!(),
+            },
+            primary_key: false,
+            ty: crate::schema::Type::Null,
+        });
+    }
+
+    let num_fields = pseudo_columns.len();
+
+    let pseudo_cursor = program.alloc_cursor_id(
+        None,
+        Some(Table::Pseudo(Rc::new(PseudoTable {
+            columns: pseudo_columns,
+        }))),
+    );
+    let sort_metadata = m.sorts.get(&ORDER_BY_ID).unwrap();
+
+    program.emit_insn(Insn::OpenPseudo {
+        cursor_id: pseudo_cursor,
+        content_reg: sort_metadata.sorter_data_register,
+        num_fields,
+    });
+
+    program.emit_insn_with_label_dependency(
+        Insn::SorterSort {
+            cursor_id: sort_metadata.sort_cursor,
+            pc_if_empty: sort_metadata.done_label,
+        },
+        sort_metadata.done_label,
+    );
+
+    program.defer_label_resolution(sort_metadata.sorter_data_label, program.offset() as usize);
+    program.emit_insn(Insn::SorterData {
+        cursor_id: sort_metadata.sort_cursor,
+        dest_reg: sort_metadata.sorter_data_register,
+        pseudo_cursor,
+    });
+
+    let sort_metadata = m.sorts.get_mut(&ORDER_BY_ID).unwrap();
+
+    sort_metadata.pseudo_table_cursor = pseudo_cursor;
+
+    // EMIT COLUMNS FROM SORTER AND EMIT ROW
+    let cursor_id = pseudo_cursor;
+    let pseudo_table = program.resolve_cursor_to_table(cursor_id).unwrap();
+    let start_column_offset = order_by.len();
+    let column_count = pseudo_table.columns().len() - start_column_offset;
+    let start_reg = program.alloc_registers(column_count);
+    for i in 0..column_count {
+        let reg = start_reg + i;
+        program.emit_insn(Insn::Column {
+            cursor_id,
+            column: start_column_offset + i,
+            dest: reg,
+        });
+    }
+    program.emit_insn(Insn::ResultRow {
+        start_reg,
+        count: column_count,
+    });
+
+    if let Some(limit) = limit {
+        let limit_reg = program.alloc_register();
+        program.emit_insn(Insn::Integer {
+            value: limit as i64,
+            dest: limit_reg,
+        });
+        program.mark_last_insn_constant();
+        program.emit_insn_with_label_dependency(
+            Insn::DecrJumpZero {
+                reg: limit_reg,
+                target_pc: sort_metadata.done_label,
+            },
+            sort_metadata.done_label,
+        );
+    }
+
+    program.emit_insn_with_label_dependency(
+        Insn::SorterNext {
+            cursor_id: sort_metadata.sort_cursor,
+            pc_if_next: sort_metadata.sorter_data_label,
+        },
+        sort_metadata.sorter_data_label,
+    );
+
+    program.resolve_label(sort_metadata.done_label, program.offset());
+
+    Ok(())
 }

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -87,11 +87,11 @@ pub struct Metadata {
     // for example, in a join with two nested scans, the inner loop will jump to its Next instruction when the join condition is false;
     // in a join with a scan and a seek, the seek will jump to the scan's Next instruction when the join condition is false.
     next_row_labels: HashMap<usize, BranchOffset>,
-    // labels for the Rewind instructions.
+    // labels for the instructions beginning the inner loop of a scan operator.
     scan_loop_body_labels: Vec<BranchOffset>,
     // metadata for the group by operator
     group_by_metadata: Option<GroupByMetadata>,
-    // mapping between Order operator id and associated metadata
+    // metadata for the order by operator
     sort_metadata: Option<SortMetadata>,
     // mapping between Join operator id and associated metadata (for left joins only)
     left_joins: HashMap<usize, LeftJoinMetadata>,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -207,7 +207,8 @@ pub fn emit_program(
 
     let mut order_by_necessary = plan.order_by.is_some();
 
-    // IF GROUP BY, SORT BY GROUPS AND DO AGGREGATION
+    // IF GROUP BY, SORT BY GROUPS AND DO AGGREGATION ETC
+    // EITHER EMITS RESULTROWS DIRECTLY OR INSERTS INTO ORDER BY SORTER
     if let Some(ref mut group_by) = plan.group_by {
         group_by_emit(
             &mut program,
@@ -233,7 +234,7 @@ pub fn emit_program(
         order_by_necessary = false;
     }
 
-    // IF ORDER BY, SORT BY ORDER BY
+    // EMIT RESULT ROWS FROM THE ORDER BY SORTER
     if let Some(ref mut order_by) = plan.order_by {
         if order_by_necessary {
             sort_order_by(
@@ -251,8 +252,6 @@ pub fn emit_program(
 
     Ok(program.build(database_header, connection))
 }
-
-const ORDER_BY_ID: usize = 0;
 
 fn init_order_by(
     program: &mut ProgramBuilder,

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -6,7 +6,6 @@ use sqlite3_parser::ast;
 
 use crate::schema::{Column, PseudoTable, Table};
 use crate::storage::sqlite3_ondisk::DatabaseHeader;
-use crate::translate::expr::resolve_ident_pseudo_table;
 use crate::translate::plan::{IterationDirection, Search};
 use crate::types::{OwnedRecord, OwnedValue};
 use crate::vdbe::builder::ProgramBuilder;
@@ -14,40 +13,11 @@ use crate::vdbe::{BranchOffset, Insn, Program};
 use crate::{Connection, Result};
 
 use super::expr::{
-    translate_aggregation, translate_condition_expr, translate_expr, translate_table_columns,
+    translate_aggregation, translate_aggregation_groupby, translate_condition_expr, translate_expr,
     ConditionMetadata,
 };
 use super::plan::{Aggregate, BTreeTableReference, Direction, Plan};
 use super::plan::{ResultSetColumn, SourceOperator};
-
-/**
- * The Emitter trait is used to emit bytecode instructions for a given operator in the query plan.
- *
- * - step: perform a single step of the operator, emitting bytecode instructions as needed,
-     and returning a result indicating whether the operator is ready to emit a result row
-*/
-// pub trait Emitter {
-//     fn step(
-//         &mut self,
-//         pb: &mut ProgramBuilder,
-//         m: &mut Metadata,
-//         referenced_tables: &[BTreeTableReference],
-//     ) -> Result<OpStepResult>;
-//     fn result_columns(
-//         &self,
-//         program: &mut ProgramBuilder,
-//         referenced_tables: &[BTreeTableReference],
-//         metadata: &mut Metadata,
-//         cursor_override: Option<&SortCursorOverride>,
-//     ) -> Result<usize>;
-//     fn result_row(
-//         &mut self,
-//         program: &mut ProgramBuilder,
-//         referenced_tables: &[BTreeTableReference],
-//         metadata: &mut Metadata,
-//         cursor_override: Option<&SortCursorOverride>,
-//     ) -> Result<()>;
-// }
 
 #[derive(Debug)]
 pub struct LeftJoinMetadata {
@@ -127,1499 +97,21 @@ pub struct Metadata {
     next_row_labels: HashMap<usize, BranchOffset>,
     // labels for the Rewind instructions.
     scan_loop_body_labels: Vec<BranchOffset>,
-    // mapping between Aggregation operator id and the register that holds the start of the aggregation result
-    aggregation_start_registers: HashMap<usize, usize>,
-    // mapping between Aggregation operator id and associated metadata (if the aggregation has a group by clause)
-    group_bys: HashMap<usize, GroupByMetadata>,
+    // metadata for the group by operator
+    group_by_metadata: Option<GroupByMetadata>,
     // mapping between Order operator id and associated metadata
     sorts: HashMap<usize, SortMetadata>,
     // mapping between Join operator id and associated metadata (for left joins only)
     left_joins: HashMap<usize, LeftJoinMetadata>,
-    // register holding the start of the result set
-    result_set_register_start: usize,
+    // First register of the aggregation results
+    pub aggregation_start_register: Option<usize>,
+    // We need to emit result columns in the order they are present in the SELECT, but they may not be in the same order in the ORDER BY sorter.
+    // This vector holds the indexes of the result columns in the ORDER BY sorter.
+    pub result_column_indexes_in_orderby_sorter: HashMap<usize, usize>,
+    // We might skip adding a SELECT result column into the ORDER BY sorter if it is an exact match in the ORDER BY keys.
+    // This vector holds the indexes of the result columns that we need to skip.
+    pub result_columns_to_skip_in_orderby_sorter: Option<Vec<usize>>,
 }
-
-// /// Emitters return one of three possible results from the step() method:
-// /// - Continue: the operator is not yet ready to emit a result row
-// /// - ReadyToEmit: the operator is ready to emit a result row
-// /// - Done: the operator has completed execution
-// ///   For example, a Scan operator will return Continue until it has opened a cursor, rewound it and applied any predicates.
-// ///   At that point, it will return ReadyToEmit.
-// ///   Finally, when the Scan operator has emitted a Next instruction, it will return Done.
-// ///
-// /// Parent operators are free to make decisions based on the result a child operator's step() method.
-// ///
-// /// When the root operator of a Plan returns ReadyToEmit, a ResultRow will always be emitted.
-// /// When the root operator returns Done, the bytecode plan is complete.
-// #[derive(Debug, PartialEq)]
-// pub enum OpStepResult {
-//     Continue,
-//     ReadyToEmit,
-//     Done,
-// }
-
-// impl Emitter for SourceOperator {
-//     fn step(
-//         &mut self,
-//         program: &mut ProgramBuilder,
-//         m: &mut Metadata,
-//         referenced_tables: &[BTreeTableReference],
-//     ) -> Result<OpStepResult> {
-//         let current_operator_column_count = self.column_count(referenced_tables);
-//         match self {
-//             SourceOperator::Scan {
-//                 table_reference,
-//                 id,
-//                 step,
-//                 predicates,
-//                 iter_dir,
-//             } => {
-//                 *step += 1;
-//                 const SCAN_OPEN_READ: usize = 1;
-//                 const SCAN_BODY: usize = 2;
-//                 const SCAN_NEXT: usize = 3;
-//                 let reverse = iter_dir
-//                     .as_ref()
-//                     .is_some_and(|iter_dir| *iter_dir == IterationDirection::Backwards);
-//                 match *step {
-//                     SCAN_OPEN_READ => {
-//                         let cursor_id = program.alloc_cursor_id(
-//                             Some(table_reference.table_identifier.clone()),
-//                             Some(Table::BTree(table_reference.table.clone())),
-//                         );
-//                         let root_page = table_reference.table.root_page;
-//                         let next_row_label = program.allocate_label();
-//                         m.next_row_labels.insert(*id, next_row_label);
-//                         program.emit_insn(Insn::OpenReadAsync {
-//                             cursor_id,
-//                             root_page,
-//                         });
-//                         program.emit_insn(Insn::OpenReadAwait);
-
-//                         Ok(OpStepResult::Continue)
-//                     }
-//                     SCAN_BODY => {
-//                         let cursor_id =
-//                             program.resolve_cursor_id(&table_reference.table_identifier, None);
-//                         if reverse {
-//                             program.emit_insn(Insn::LastAsync { cursor_id });
-//                         } else {
-//                             program.emit_insn(Insn::RewindAsync { cursor_id });
-//                         }
-//                         let scan_loop_body_label = program.allocate_label();
-//                         let halt_label = m.termination_label_stack.last().unwrap();
-//                         program.emit_insn_with_label_dependency(
-//                             if reverse {
-//                                 Insn::LastAwait {
-//                                     cursor_id,
-//                                     pc_if_empty: *halt_label,
-//                                 }
-//                             } else {
-//                                 Insn::RewindAwait {
-//                                     cursor_id,
-//                                     pc_if_empty: *halt_label,
-//                                 }
-//                             },
-//                             *halt_label,
-//                         );
-//                         m.scan_loop_body_labels.push(scan_loop_body_label);
-//                         program.defer_label_resolution(
-//                             scan_loop_body_label,
-//                             program.offset() as usize,
-//                         );
-
-//                         let jump_label = m.next_row_labels.get(id).unwrap_or(halt_label);
-//                         if let Some(preds) = predicates {
-//                             for expr in preds {
-//                                 let jump_target_when_true = program.allocate_label();
-//                                 let condition_metadata = ConditionMetadata {
-//                                     jump_if_condition_is_true: false,
-//                                     jump_target_when_true,
-//                                     jump_target_when_false: *jump_label,
-//                                 };
-//                                 translate_condition_expr(
-//                                     program,
-//                                     referenced_tables,
-//                                     expr,
-//                                     None,
-//                                     condition_metadata,
-//                                     m.result_set_register_start,
-//                                 )?;
-//                                 program.resolve_label(jump_target_when_true, program.offset());
-//                             }
-//                         }
-
-//                         Ok(OpStepResult::ReadyToEmit)
-//                     }
-//                     SCAN_NEXT => {
-//                         let cursor_id =
-//                             program.resolve_cursor_id(&table_reference.table_identifier, None);
-//                         program
-//                             .resolve_label(*m.next_row_labels.get(id).unwrap(), program.offset());
-//                         if reverse {
-//                             program.emit_insn(Insn::PrevAsync { cursor_id });
-//                         } else {
-//                             program.emit_insn(Insn::NextAsync { cursor_id });
-//                         }
-//                         let jump_label = m.scan_loop_body_labels.pop().unwrap();
-
-//                         if reverse {
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::PrevAwait {
-//                                     cursor_id,
-//                                     pc_if_next: jump_label,
-//                                 },
-//                                 jump_label,
-//                             );
-//                         } else {
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::NextAwait {
-//                                     cursor_id,
-//                                     pc_if_next: jump_label,
-//                                 },
-//                                 jump_label,
-//                             );
-//                         }
-//                         Ok(OpStepResult::Done)
-//                     }
-//                     _ => Ok(OpStepResult::Done),
-//                 }
-//             }
-//             SourceOperator::Search {
-//                 table_reference,
-//                 search,
-//                 predicates,
-//                 step,
-//                 id,
-//                 ..
-//             } => {
-//                 *step += 1;
-//                 const SEARCH_OPEN_READ: usize = 1;
-//                 const SEARCH_BODY: usize = 2;
-//                 const SEARCH_NEXT: usize = 3;
-//                 match *step {
-//                     SEARCH_OPEN_READ => {
-//                         let table_cursor_id = program.alloc_cursor_id(
-//                             Some(table_reference.table_identifier.clone()),
-//                             Some(Table::BTree(table_reference.table.clone())),
-//                         );
-
-//                         let next_row_label = program.allocate_label();
-
-//                         if !matches!(search, Search::PrimaryKeyEq { .. }) {
-//                             // Primary key equality search is handled with a SeekRowid instruction which does not loop, since it is a single row lookup.
-//                             m.next_row_labels.insert(*id, next_row_label);
-//                         }
-
-//                         let scan_loop_body_label = program.allocate_label();
-//                         m.scan_loop_body_labels.push(scan_loop_body_label);
-//                         program.emit_insn(Insn::OpenReadAsync {
-//                             cursor_id: table_cursor_id,
-//                             root_page: table_reference.table.root_page,
-//                         });
-//                         program.emit_insn(Insn::OpenReadAwait);
-
-//                         if let Search::IndexSearch { index, .. } = search {
-//                             let index_cursor_id = program.alloc_cursor_id(
-//                                 Some(index.name.clone()),
-//                                 Some(Table::Index(index.clone())),
-//                             );
-//                             program.emit_insn(Insn::OpenReadAsync {
-//                                 cursor_id: index_cursor_id,
-//                                 root_page: index.root_page,
-//                             });
-//                             program.emit_insn(Insn::OpenReadAwait);
-//                         }
-//                         Ok(OpStepResult::Continue)
-//                     }
-//                     SEARCH_BODY => {
-//                         let table_cursor_id =
-//                             program.resolve_cursor_id(&table_reference.table_identifier, None);
-
-//                         // Open the loop for the index search.
-//                         // Primary key equality search is handled with a SeekRowid instruction which does not loop, since it is a single row lookup.
-//                         if !matches!(search, Search::PrimaryKeyEq { .. }) {
-//                             let index_cursor_id = if let Search::IndexSearch { index, .. } = search
-//                             {
-//                                 Some(program.resolve_cursor_id(&index.name, None))
-//                             } else {
-//                                 None
-//                             };
-//                             let scan_loop_body_label = *m.scan_loop_body_labels.last().unwrap();
-//                             let cmp_reg = program.alloc_register();
-//                             let (cmp_expr, cmp_op) = match search {
-//                                 Search::IndexSearch {
-//                                     cmp_expr, cmp_op, ..
-//                                 } => (cmp_expr, cmp_op),
-//                                 Search::PrimaryKeySearch { cmp_expr, cmp_op } => (cmp_expr, cmp_op),
-//                                 Search::PrimaryKeyEq { .. } => unreachable!(),
-//                             };
-//                             // TODO this only handles ascending indexes
-//                             match cmp_op {
-//                                 ast::Operator::Equals
-//                                 | ast::Operator::Greater
-//                                 | ast::Operator::GreaterEquals => {
-//                                     translate_expr(
-//                                         program,
-//                                         Some(referenced_tables),
-//                                         cmp_expr,
-//                                         cmp_reg,
-//                                         None,
-//                                         m.result_set_register_start,
-//                                     )?;
-//                                 }
-//                                 ast::Operator::Less | ast::Operator::LessEquals => {
-//                                     program.emit_insn(Insn::Null {
-//                                         dest: cmp_reg,
-//                                         dest_end: None,
-//                                     });
-//                                 }
-//                                 _ => unreachable!(),
-//                             }
-//                             program.emit_insn_with_label_dependency(
-//                                 match cmp_op {
-//                                     ast::Operator::Equals | ast::Operator::GreaterEquals => {
-//                                         Insn::SeekGE {
-//                                             is_index: index_cursor_id.is_some(),
-//                                             cursor_id: index_cursor_id.unwrap_or(table_cursor_id),
-//                                             start_reg: cmp_reg,
-//                                             num_regs: 1,
-//                                             target_pc: *m.termination_label_stack.last().unwrap(),
-//                                         }
-//                                     }
-//                                     ast::Operator::Greater
-//                                     | ast::Operator::Less
-//                                     | ast::Operator::LessEquals => Insn::SeekGT {
-//                                         is_index: index_cursor_id.is_some(),
-//                                         cursor_id: index_cursor_id.unwrap_or(table_cursor_id),
-//                                         start_reg: cmp_reg,
-//                                         num_regs: 1,
-//                                         target_pc: *m.termination_label_stack.last().unwrap(),
-//                                     },
-//                                     _ => unreachable!(),
-//                                 },
-//                                 *m.termination_label_stack.last().unwrap(),
-//                             );
-//                             if *cmp_op == ast::Operator::Less
-//                                 || *cmp_op == ast::Operator::LessEquals
-//                             {
-//                                 translate_expr(
-//                                     program,
-//                                     Some(referenced_tables),
-//                                     cmp_expr,
-//                                     cmp_reg,
-//                                     None,
-//                                     m.result_set_register_start,
-//                                 )?;
-//                             }
-
-//                             program.defer_label_resolution(
-//                                 scan_loop_body_label,
-//                                 program.offset() as usize,
-//                             );
-//                             // TODO: We are currently only handling ascending indexes.
-//                             // For conditions like index_key > 10, we have already seeked to the first key greater than 10, and can just scan forward.
-//                             // For conditions like index_key < 10, we are at the beginning of the index, and will scan forward and emit IdxGE(10) with a conditional jump to the end.
-//                             // For conditions like index_key = 10, we have already seeked to the first key greater than or equal to 10, and can just scan forward and emit IdxGT(10) with a conditional jump to the end.
-//                             // For conditions like index_key >= 10, we have already seeked to the first key greater than or equal to 10, and can just scan forward.
-//                             // For conditions like index_key <= 10, we are at the beginning of the index, and will scan forward and emit IdxGT(10) with a conditional jump to the end.
-//                             // For conditions like index_key != 10, TODO. probably the optimal way is not to use an index at all.
-//                             //
-//                             // For primary key searches we emit RowId and then compare it to the seek value.
-
-//                             let abort_jump_target = *m
-//                                 .next_row_labels
-//                                 .get(id)
-//                                 .unwrap_or(m.termination_label_stack.last().unwrap());
-//                             match cmp_op {
-//                                 ast::Operator::Equals | ast::Operator::LessEquals => {
-//                                     if let Some(index_cursor_id) = index_cursor_id {
-//                                         program.emit_insn_with_label_dependency(
-//                                             Insn::IdxGT {
-//                                                 cursor_id: index_cursor_id,
-//                                                 start_reg: cmp_reg,
-//                                                 num_regs: 1,
-//                                                 target_pc: abort_jump_target,
-//                                             },
-//                                             abort_jump_target,
-//                                         );
-//                                     } else {
-//                                         let rowid_reg = program.alloc_register();
-//                                         program.emit_insn(Insn::RowId {
-//                                             cursor_id: table_cursor_id,
-//                                             dest: rowid_reg,
-//                                         });
-//                                         program.emit_insn_with_label_dependency(
-//                                             Insn::Gt {
-//                                                 lhs: rowid_reg,
-//                                                 rhs: cmp_reg,
-//                                                 target_pc: abort_jump_target,
-//                                             },
-//                                             abort_jump_target,
-//                                         );
-//                                     }
-//                                 }
-//                                 ast::Operator::Less => {
-//                                     if let Some(index_cursor_id) = index_cursor_id {
-//                                         program.emit_insn_with_label_dependency(
-//                                             Insn::IdxGE {
-//                                                 cursor_id: index_cursor_id,
-//                                                 start_reg: cmp_reg,
-//                                                 num_regs: 1,
-//                                                 target_pc: abort_jump_target,
-//                                             },
-//                                             abort_jump_target,
-//                                         );
-//                                     } else {
-//                                         let rowid_reg = program.alloc_register();
-//                                         program.emit_insn(Insn::RowId {
-//                                             cursor_id: table_cursor_id,
-//                                             dest: rowid_reg,
-//                                         });
-//                                         program.emit_insn_with_label_dependency(
-//                                             Insn::Ge {
-//                                                 lhs: rowid_reg,
-//                                                 rhs: cmp_reg,
-//                                                 target_pc: abort_jump_target,
-//                                             },
-//                                             abort_jump_target,
-//                                         );
-//                                     }
-//                                 }
-//                                 _ => {}
-//                             }
-
-//                             if let Some(index_cursor_id) = index_cursor_id {
-//                                 program.emit_insn(Insn::DeferredSeek {
-//                                     index_cursor_id,
-//                                     table_cursor_id,
-//                                 });
-//                             }
-//                         }
-
-//                         let jump_label = m
-//                             .next_row_labels
-//                             .get(id)
-//                             .unwrap_or(m.termination_label_stack.last().unwrap());
-
-//                         if let Search::PrimaryKeyEq { cmp_expr } = search {
-//                             let src_reg = program.alloc_register();
-//                             translate_expr(
-//                                 program,
-//                                 Some(referenced_tables),
-//                                 cmp_expr,
-//                                 src_reg,
-//                                 None,
-//                                 m.result_set_register_start,
-//                             )?;
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::SeekRowid {
-//                                     cursor_id: table_cursor_id,
-//                                     src_reg,
-//                                     target_pc: *jump_label,
-//                                 },
-//                                 *jump_label,
-//                             );
-//                         }
-//                         if let Some(predicates) = predicates {
-//                             for predicate in predicates.iter() {
-//                                 let jump_target_when_true = program.allocate_label();
-//                                 let condition_metadata = ConditionMetadata {
-//                                     jump_if_condition_is_true: false,
-//                                     jump_target_when_true,
-//                                     jump_target_when_false: *jump_label,
-//                                 };
-//                                 translate_condition_expr(
-//                                     program,
-//                                     referenced_tables,
-//                                     predicate,
-//                                     None,
-//                                     condition_metadata,
-//                                     m.result_set_register_start,
-//                                 )?;
-//                                 program.resolve_label(jump_target_when_true, program.offset());
-//                             }
-//                         }
-
-//                         Ok(OpStepResult::ReadyToEmit)
-//                     }
-//                     SEARCH_NEXT => {
-//                         if matches!(search, Search::PrimaryKeyEq { .. }) {
-//                             // Primary key equality search is handled with a SeekRowid instruction which does not loop, so there is no need to emit a NextAsync instruction.
-//                             return Ok(OpStepResult::Done);
-//                         }
-//                         let cursor_id = match search {
-//                             Search::IndexSearch { index, .. } => {
-//                                 program.resolve_cursor_id(&index.name, None)
-//                             }
-//                             Search::PrimaryKeySearch { .. } => {
-//                                 program.resolve_cursor_id(&table_reference.table_identifier, None)
-//                             }
-//                             Search::PrimaryKeyEq { .. } => unreachable!(),
-//                         };
-//                         program
-//                             .resolve_label(*m.next_row_labels.get(id).unwrap(), program.offset());
-//                         program.emit_insn(Insn::NextAsync { cursor_id });
-//                         let jump_label = m.scan_loop_body_labels.pop().unwrap();
-//                         program.emit_insn_with_label_dependency(
-//                             Insn::NextAwait {
-//                                 cursor_id,
-//                                 pc_if_next: jump_label,
-//                             },
-//                             jump_label,
-//                         );
-//                         Ok(OpStepResult::Done)
-//                     }
-//                     _ => Ok(OpStepResult::Done),
-//                 }
-//             }
-//             SourceOperator::Join {
-//                 left,
-//                 right,
-//                 outer,
-//                 predicates,
-//                 step,
-//                 id,
-//                 ..
-//             } => {
-//                 *step += 1;
-//                 const JOIN_INIT: usize = 1;
-//                 const JOIN_DO_JOIN: usize = 2;
-//                 const JOIN_END: usize = 3;
-//                 match *step {
-//                     JOIN_INIT => {
-//                         if *outer {
-//                             let lj_metadata = LeftJoinMetadata {
-//                                 match_flag_register: program.alloc_register(),
-//                                 set_match_flag_true_label: program.allocate_label(),
-//                                 check_match_flag_label: program.allocate_label(),
-//                                 on_match_jump_to_label: program.allocate_label(),
-//                             };
-//                             m.left_joins.insert(*id, lj_metadata);
-//                         }
-//                         left.step(program, m, referenced_tables)?;
-//                         right.step(program, m, referenced_tables)?;
-
-//                         Ok(OpStepResult::Continue)
-//                     }
-//                     JOIN_DO_JOIN => {
-//                         left.step(program, m, referenced_tables)?;
-
-//                         let mut jump_target_when_false = *m
-//                             .next_row_labels
-//                             .get(&right.id())
-//                             .or(m.next_row_labels.get(&left.id()))
-//                             .unwrap_or(m.termination_label_stack.last().unwrap());
-
-//                         if *outer {
-//                             let lj_meta = m.left_joins.get(id).unwrap();
-//                             program.emit_insn(Insn::Integer {
-//                                 value: 0,
-//                                 dest: lj_meta.match_flag_register,
-//                             });
-//                             jump_target_when_false = lj_meta.check_match_flag_label;
-//                         }
-//                         m.next_row_labels.insert(right.id(), jump_target_when_false);
-
-//                         right.step(program, m, referenced_tables)?;
-
-//                         if let Some(predicates) = predicates {
-//                             let jump_target_when_true = program.allocate_label();
-//                             let condition_metadata = ConditionMetadata {
-//                                 jump_if_condition_is_true: false,
-//                                 jump_target_when_true,
-//                                 jump_target_when_false,
-//                             };
-//                             for predicate in predicates.iter() {
-//                                 translate_condition_expr(
-//                                     program,
-//                                     referenced_tables,
-//                                     predicate,
-//                                     None,
-//                                     condition_metadata,
-//                                     m.result_set_register_start,
-//                                 )?;
-//                             }
-//                             program.resolve_label(jump_target_when_true, program.offset());
-//                         }
-
-//                         if *outer {
-//                             let lj_meta = m.left_joins.get(id).unwrap();
-//                             program.defer_label_resolution(
-//                                 lj_meta.set_match_flag_true_label,
-//                                 program.offset() as usize,
-//                             );
-//                             program.emit_insn(Insn::Integer {
-//                                 value: 1,
-//                                 dest: lj_meta.match_flag_register,
-//                             });
-//                         }
-
-//                         Ok(OpStepResult::ReadyToEmit)
-//                     }
-//                     JOIN_END => {
-//                         right.step(program, m, referenced_tables)?;
-
-//                         if *outer {
-//                             let lj_meta = m.left_joins.get(id).unwrap();
-//                             // If the left join match flag has been set to 1, we jump to the next row on the outer table (result row has been emitted already)
-//                             program.resolve_label(lj_meta.check_match_flag_label, program.offset());
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::IfPos {
-//                                     reg: lj_meta.match_flag_register,
-//                                     target_pc: lj_meta.on_match_jump_to_label,
-//                                     decrement_by: 0,
-//                                 },
-//                                 lj_meta.on_match_jump_to_label,
-//                             );
-//                             // If not, we set the right table cursor's "pseudo null bit" on, which means any Insn::Column will return NULL
-//                             let right_cursor_id = match right.as_ref() {
-//                                 SourceOperator::Scan {
-//                                     table_reference, ..
-//                                 } => program
-//                                     .resolve_cursor_id(&table_reference.table_identifier, None),
-//                                 SourceOperator::Search {
-//                                     table_reference, ..
-//                                 } => program
-//                                     .resolve_cursor_id(&table_reference.table_identifier, None),
-//                                 _ => unreachable!(),
-//                             };
-//                             program.emit_insn(Insn::NullRow {
-//                                 cursor_id: right_cursor_id,
-//                             });
-//                             // Jump to setting the left join match flag to 1 again, but this time the right table cursor will set everything to null
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::Goto {
-//                                     target_pc: lj_meta.set_match_flag_true_label,
-//                                 },
-//                                 lj_meta.set_match_flag_true_label,
-//                             );
-//                         }
-//                         let next_row_label = if *outer {
-//                             m.left_joins.get(id).unwrap().on_match_jump_to_label
-//                         } else {
-//                             *m.next_row_labels.get(&right.id()).unwrap()
-//                         };
-//                         // This points to the NextAsync instruction of the left table
-//                         program.resolve_label(next_row_label, program.offset());
-//                         left.step(program, m, referenced_tables)?;
-
-//                         Ok(OpStepResult::Done)
-//                     }
-//                     _ => Ok(OpStepResult::Done),
-//                 }
-//             }
-//             SourceOperator::Projection {
-//                 id,
-//                 source,
-//                 expressions,
-//                 aggregates,
-//                 group_by,
-//                 step,
-//                 ..
-//             } => {
-//                 *step += 1;
-
-//                 if !aggregates.is_empty() && group_by.is_none() {
-//                     const PROJECTION_WAIT_UNTIL_SOURCE_READY: usize = 1;
-//                     const PROJECTION_FINALIZE_SOURCE: usize = 2;
-//                     match *step {
-//                         PROJECTION_WAIT_UNTIL_SOURCE_READY => loop {
-//                             match source.step(program, m, referenced_tables)? {
-//                                 OpStepResult::Continue => continue,
-//                                 OpStepResult::ReadyToEmit | OpStepResult::Done => {
-//                                     return Ok(OpStepResult::ReadyToEmit);
-//                                 }
-//                             }
-//                         },
-//                         PROJECTION_FINALIZE_SOURCE => {
-//                             match source.step(program, m, referenced_tables)? {
-//                                 OpStepResult::Done => return Ok(OpStepResult::Done),
-//                                 _ => unreachable!(),
-//                             }
-//                         }
-//                         _ => return Ok(OpStepResult::Done),
-//                     }
-//                 }
-
-//                 // Group by aggregation eg. SELECT a, b, sum(c) FROM t GROUP BY a, b
-//                 if let Some(group_by) = group_by {
-//                     const GROUP_BY_INIT: usize = 1;
-//                     const GROUP_BY_INSERT_INTO_SORTER: usize = 2;
-//                     const GROUP_BY_SORT_AND_COMPARE: usize = 3;
-//                     const GROUP_BY_PREPARE_ROW: usize = 4;
-//                     const GROUP_BY_CLEAR_ACCUMULATOR_SUBROUTINE: usize = 5;
-//                     match *step {
-//                         GROUP_BY_INIT => {
-//                             let agg_final_label = program.allocate_label();
-//                             m.termination_label_stack.push(agg_final_label);
-//                             let num_aggs = aggregates.len();
-
-//                             let sort_cursor = program.alloc_cursor_id(None, None);
-
-//                             let abort_flag_register = program.alloc_register();
-//                             let data_in_accumulator_indicator_register = program.alloc_register();
-//                             let group_exprs_comparison_register =
-//                                 program.alloc_registers(group_by.len());
-//                             let group_exprs_accumulator_register =
-//                                 program.alloc_registers(group_by.len());
-//                             let agg_exprs_start_reg = program.alloc_registers(num_aggs);
-//                             m.aggregation_start_registers
-//                                 .insert(*id, agg_exprs_start_reg);
-//                             let sorter_key_register = program.alloc_register();
-
-//                             let subroutine_accumulator_clear_label = program.allocate_label();
-//                             let subroutine_accumulator_output_label = program.allocate_label();
-//                             let sorter_data_label = program.allocate_label();
-//                             let grouping_done_label = program.allocate_label();
-
-//                             let mut order = Vec::new();
-//                             const ASCENDING: i64 = 0;
-//                             for _ in group_by.iter() {
-//                                 order.push(OwnedValue::Integer(ASCENDING));
-//                             }
-//                             program.emit_insn(Insn::SorterOpen {
-//                                 cursor_id: sort_cursor,
-//                                 columns: current_operator_column_count,
-//                                 order: OwnedRecord::new(order),
-//                             });
-
-//                             program.add_comment(program.offset(), "clear group by abort flag");
-//                             program.emit_insn(Insn::Integer {
-//                                 value: 0,
-//                                 dest: abort_flag_register,
-//                             });
-
-//                             program.add_comment(
-//                                 program.offset(),
-//                                 "initialize group by comparison registers to NULL",
-//                             );
-//                             program.emit_insn(Insn::Null {
-//                                 dest: group_exprs_comparison_register,
-//                                 dest_end: if group_by.len() > 1 {
-//                                     Some(group_exprs_comparison_register + group_by.len() - 1)
-//                                 } else {
-//                                     None
-//                                 },
-//                             });
-
-//                             program.add_comment(
-//                                 program.offset(),
-//                                 "go to clear accumulator subroutine",
-//                             );
-
-//                             let subroutine_accumulator_clear_return_offset_register =
-//                                 program.alloc_register();
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::Gosub {
-//                                     target_pc: subroutine_accumulator_clear_label,
-//                                     return_reg: subroutine_accumulator_clear_return_offset_register,
-//                                 },
-//                                 subroutine_accumulator_clear_label,
-//                             );
-
-//                             m.group_bys.insert(
-//                                 *id,
-//                                 GroupByMetadata {
-//                                     sort_cursor,
-//                                     subroutine_accumulator_clear_label,
-//                                     subroutine_accumulator_clear_return_offset_register,
-//                                     subroutine_accumulator_output_label,
-//                                     subroutine_accumulator_output_return_offset_register: program
-//                                         .alloc_register(),
-//                                     accumulator_indicator_set_true_label: program.allocate_label(),
-//                                     sorter_data_label,
-//                                     grouping_done_label,
-//                                     abort_flag_register,
-//                                     data_in_accumulator_indicator_register,
-//                                     group_exprs_accumulator_register,
-//                                     group_exprs_comparison_register,
-//                                     sorter_key_register,
-//                                 },
-//                             );
-
-//                             loop {
-//                                 match source.step(program, m, referenced_tables)? {
-//                                     OpStepResult::Continue => continue,
-//                                     OpStepResult::ReadyToEmit => {
-//                                         return Ok(OpStepResult::Continue);
-//                                     }
-//                                     OpStepResult::Done => {
-//                                         return Ok(OpStepResult::Done);
-//                                     }
-//                                 }
-//                             }
-//                         }
-//                         GROUP_BY_INSERT_INTO_SORTER => {
-//                             let sort_keys_count = group_by.len();
-//                             let start_reg = program.alloc_registers(current_operator_column_count);
-//                             for (i, expr) in group_by.iter().enumerate() {
-//                                 let key_reg = start_reg + i;
-//                                 translate_expr(
-//                                     program,
-//                                     Some(referenced_tables),
-//                                     expr,
-//                                     key_reg,
-//                                     None,
-//                                     m.result_set_register_start,
-//                                 )?;
-//                             }
-//                             for (i, agg) in aggregates.iter().enumerate() {
-//                                 // TODO it's a hack to assume aggregate functions have exactly one argument.
-//                                 // Counterpoint e.g. GROUP_CONCAT(expr, separator).
-//                                 //
-//                                 // Here we are collecting scalars for the group by sorter, which will include
-//                                 // both the group by expressions and the aggregate arguments.
-//                                 // e.g. in `select u.first_name, sum(u.age) from users group by u.first_name`
-//                                 // the sorter will have two scalars: u.first_name and u.age.
-//                                 // these are then sorted by u.first_name, and for each u.first_name, we sum the u.age.
-//                                 // the actual aggregation is done later in GROUP_BY_SORT_AND_COMPARE below.
-//                                 //
-//                                 // This is why we take the first argument of each aggregate function currently.
-//                                 // It's mostly an artifact of the current architecture being a bit poor; we should recognize
-//                                 // which scalars are dependencies of aggregate functions and explicitly collect those.
-//                                 let expr = &agg.args[0];
-//                                 let agg_reg = start_reg + sort_keys_count + i;
-//                                 translate_expr(
-//                                     program,
-//                                     Some(referenced_tables),
-//                                     expr,
-//                                     agg_reg,
-//                                     None,
-//                                     m.result_set_register_start,
-//                                 )?;
-//                             }
-
-//                             let group_by_metadata = m.group_bys.get(id).unwrap();
-
-//                             program.emit_insn(Insn::MakeRecord {
-//                                 start_reg,
-//                                 count: current_operator_column_count,
-//                                 dest_reg: group_by_metadata.sorter_key_register,
-//                             });
-
-//                             let group_by_metadata = m.group_bys.get(id).unwrap();
-//                             program.emit_insn(Insn::SorterInsert {
-//                                 cursor_id: group_by_metadata.sort_cursor,
-//                                 record_reg: group_by_metadata.sorter_key_register,
-//                             });
-
-//                             return Ok(OpStepResult::Continue);
-//                         }
-//                         #[allow(clippy::never_loop)]
-//                         GROUP_BY_SORT_AND_COMPARE => {
-//                             loop {
-//                                 match source.step(program, m, referenced_tables)? {
-//                                     OpStepResult::Done => {
-//                                         break;
-//                                     }
-//                                     _ => unreachable!(),
-//                                 }
-//                             }
-
-//                             let group_by_metadata = m.group_bys.get_mut(id).unwrap();
-
-//                             let GroupByMetadata {
-//                                 group_exprs_comparison_register: comparison_register,
-//                                 subroutine_accumulator_output_return_offset_register,
-//                                 subroutine_accumulator_output_label,
-//                                 subroutine_accumulator_clear_return_offset_register,
-//                                 subroutine_accumulator_clear_label,
-//                                 data_in_accumulator_indicator_register,
-//                                 accumulator_indicator_set_true_label,
-//                                 group_exprs_accumulator_register: group_exprs_start_register,
-//                                 abort_flag_register,
-//                                 sorter_key_register,
-//                                 ..
-//                             } = *group_by_metadata;
-//                             let halt_label = *m.termination_label_stack.first().unwrap();
-
-//                             let mut column_names =
-//                                 Vec::with_capacity(current_operator_column_count);
-//                             for expr in group_by
-//                                 .iter()
-//                                 .chain(aggregates.iter().map(|agg| &agg.args[0]))
-//                             // FIXME: just blindly taking the first arg is a hack
-//                             {
-//                                 // Sorter column names for group by are now just determined by stringifying the expression, since the group by
-//                                 // columns and aggregations can be practically anything.
-//                                 // FIXME: either come up with something more robust, or make this something like expr.to_canonical_string() so that we can handle
-//                                 // things like `count(1)` and `COUNT(1)` the same way
-//                                 column_names.push(expr.to_string());
-//                             }
-//                             let pseudo_columns = column_names
-//                                 .iter()
-//                                 .map(|name| Column {
-//                                     name: name.clone(),
-//                                     primary_key: false,
-//                                     ty: crate::schema::Type::Null,
-//                                 })
-//                                 .collect::<Vec<_>>();
-
-//                             let pseudo_table = Rc::new(PseudoTable {
-//                                 columns: pseudo_columns,
-//                             });
-
-//                             let pseudo_cursor = program
-//                                 .alloc_cursor_id(None, Some(Table::Pseudo(pseudo_table.clone())));
-
-//                             program.emit_insn(Insn::OpenPseudo {
-//                                 cursor_id: pseudo_cursor,
-//                                 content_reg: sorter_key_register,
-//                                 num_fields: current_operator_column_count,
-//                             });
-
-//                             let group_by_metadata = m.group_bys.get(id).unwrap();
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::SorterSort {
-//                                     cursor_id: group_by_metadata.sort_cursor,
-//                                     pc_if_empty: group_by_metadata.grouping_done_label,
-//                                 },
-//                                 group_by_metadata.grouping_done_label,
-//                             );
-
-//                             program.defer_label_resolution(
-//                                 group_by_metadata.sorter_data_label,
-//                                 program.offset() as usize,
-//                             );
-//                             program.emit_insn(Insn::SorterData {
-//                                 cursor_id: group_by_metadata.sort_cursor,
-//                                 dest_reg: group_by_metadata.sorter_key_register,
-//                                 pseudo_cursor,
-//                             });
-
-//                             let groups_start_reg = program.alloc_registers(group_by.len());
-//                             for (i, expr) in group_by.iter().enumerate() {
-//                                 let sorter_column_index =
-//                                     resolve_ident_pseudo_table(&expr.to_string(), &pseudo_table)?;
-//                                 let group_reg = groups_start_reg + i;
-//                                 program.emit_insn(Insn::Column {
-//                                     cursor_id: pseudo_cursor,
-//                                     column: sorter_column_index,
-//                                     dest: group_reg,
-//                                 });
-//                             }
-
-//                             program.emit_insn(Insn::Compare {
-//                                 start_reg_a: comparison_register,
-//                                 start_reg_b: groups_start_reg,
-//                                 count: group_by.len(),
-//                             });
-
-//                             let agg_step_label = program.allocate_label();
-
-//                             program.add_comment(
-//                                 program.offset(),
-//                                 "start new group if comparison is not equal",
-//                             );
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::Jump {
-//                                     target_pc_lt: program.offset() + 1,
-//                                     target_pc_eq: agg_step_label,
-//                                     target_pc_gt: program.offset() + 1,
-//                                 },
-//                                 agg_step_label,
-//                             );
-
-//                             program.emit_insn(Insn::Move {
-//                                 source_reg: groups_start_reg,
-//                                 dest_reg: comparison_register,
-//                                 count: group_by.len(),
-//                             });
-
-//                             program.add_comment(
-//                                 program.offset(),
-//                                 "check if ended group had data, and output if so",
-//                             );
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::Gosub {
-//                                     target_pc: subroutine_accumulator_output_label,
-//                                     return_reg:
-//                                         subroutine_accumulator_output_return_offset_register,
-//                                 },
-//                                 subroutine_accumulator_output_label,
-//                             );
-
-//                             program.add_comment(program.offset(), "check abort flag");
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::IfPos {
-//                                     reg: abort_flag_register,
-//                                     target_pc: halt_label,
-//                                     decrement_by: 0,
-//                                 },
-//                                 m.termination_label_stack[0],
-//                             );
-
-//                             program
-//                                 .add_comment(program.offset(), "goto clear accumulator subroutine");
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::Gosub {
-//                                     target_pc: subroutine_accumulator_clear_label,
-//                                     return_reg: subroutine_accumulator_clear_return_offset_register,
-//                                 },
-//                                 subroutine_accumulator_clear_label,
-//                             );
-
-//                             program.resolve_label(agg_step_label, program.offset());
-//                             let start_reg = m.aggregation_start_registers.get(id).unwrap();
-//                             for (i, agg) in aggregates.iter().enumerate() {
-//                                 let agg_result_reg = start_reg + i;
-//                                 translate_aggregation(
-//                                     program,
-//                                     referenced_tables,
-//                                     agg,
-//                                     agg_result_reg,
-//                                     Some(pseudo_cursor),
-//                                 )?;
-//                             }
-
-//                             program.add_comment(
-//                                 program.offset(),
-//                                 "don't emit group columns if continuing existing group",
-//                             );
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::If {
-//                                     target_pc: accumulator_indicator_set_true_label,
-//                                     reg: data_in_accumulator_indicator_register,
-//                                     null_reg: 0, // unused in this case
-//                                 },
-//                                 accumulator_indicator_set_true_label,
-//                             );
-
-//                             for (i, expr) in group_by.iter().enumerate() {
-//                                 let key_reg = group_exprs_start_register + i;
-//                                 let sorter_column_index =
-//                                     resolve_ident_pseudo_table(&expr.to_string(), &pseudo_table)?;
-//                                 program.emit_insn(Insn::Column {
-//                                     cursor_id: pseudo_cursor,
-//                                     column: sorter_column_index,
-//                                     dest: key_reg,
-//                                 });
-//                             }
-
-//                             program.resolve_label(
-//                                 accumulator_indicator_set_true_label,
-//                                 program.offset(),
-//                             );
-//                             program.add_comment(program.offset(), "indicate data in accumulator");
-//                             program.emit_insn(Insn::Integer {
-//                                 value: 1,
-//                                 dest: data_in_accumulator_indicator_register,
-//                             });
-
-//                             return Ok(OpStepResult::Continue);
-//                         }
-//                         GROUP_BY_PREPARE_ROW => {
-//                             let group_by_metadata = m.group_bys.get(id).unwrap();
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::SorterNext {
-//                                     cursor_id: group_by_metadata.sort_cursor,
-//                                     pc_if_next: group_by_metadata.sorter_data_label,
-//                                 },
-//                                 group_by_metadata.sorter_data_label,
-//                             );
-
-//                             program.resolve_label(
-//                                 group_by_metadata.grouping_done_label,
-//                                 program.offset(),
-//                             );
-
-//                             program.add_comment(program.offset(), "emit row for final group");
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::Gosub {
-//                                     target_pc: group_by_metadata
-//                                         .subroutine_accumulator_output_label,
-//                                     return_reg: group_by_metadata
-//                                         .subroutine_accumulator_output_return_offset_register,
-//                                 },
-//                                 group_by_metadata.subroutine_accumulator_output_label,
-//                             );
-
-//                             program.add_comment(program.offset(), "group by finished");
-//                             let termination_label =
-//                                 m.termination_label_stack[m.termination_label_stack.len() - 2];
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::Goto {
-//                                     target_pc: termination_label,
-//                                 },
-//                                 termination_label,
-//                             );
-//                             program.emit_insn(Insn::Integer {
-//                                 value: 1,
-//                                 dest: group_by_metadata.abort_flag_register,
-//                             });
-//                             program.emit_insn(Insn::Return {
-//                                 return_reg: group_by_metadata
-//                                     .subroutine_accumulator_output_return_offset_register,
-//                             });
-
-//                             program.resolve_label(
-//                                 group_by_metadata.subroutine_accumulator_output_label,
-//                                 program.offset(),
-//                             );
-
-//                             program.add_comment(
-//                                 program.offset(),
-//                                 "output group by row subroutine start",
-//                             );
-//                             let termination_label = *m.termination_label_stack.last().unwrap();
-//                             program.emit_insn_with_label_dependency(
-//                                 Insn::IfPos {
-//                                     reg: group_by_metadata.data_in_accumulator_indicator_register,
-//                                     target_pc: termination_label,
-//                                     decrement_by: 0,
-//                                 },
-//                                 termination_label,
-//                             );
-//                             program.emit_insn(Insn::Return {
-//                                 return_reg: group_by_metadata
-//                                     .subroutine_accumulator_output_return_offset_register,
-//                             });
-
-//                             return Ok(OpStepResult::ReadyToEmit);
-//                         }
-//                         GROUP_BY_CLEAR_ACCUMULATOR_SUBROUTINE => {
-//                             let group_by_metadata = m.group_bys.get(id).unwrap();
-//                             program.emit_insn(Insn::Return {
-//                                 return_reg: group_by_metadata
-//                                     .subroutine_accumulator_output_return_offset_register,
-//                             });
-
-//                             program.add_comment(
-//                                 program.offset(),
-//                                 "clear accumulator subroutine start",
-//                             );
-//                             program.resolve_label(
-//                                 group_by_metadata.subroutine_accumulator_clear_label,
-//                                 program.offset(),
-//                             );
-//                             let start_reg = group_by_metadata.group_exprs_accumulator_register;
-//                             program.emit_insn(Insn::Null {
-//                                 dest: start_reg,
-//                                 dest_end: Some(start_reg + group_by.len() + aggregates.len() - 1),
-//                             });
-
-//                             program.emit_insn(Insn::Integer {
-//                                 value: 0,
-//                                 dest: group_by_metadata.data_in_accumulator_indicator_register,
-//                             });
-//                             program.emit_insn(Insn::Return {
-//                                 return_reg: group_by_metadata
-//                                     .subroutine_accumulator_clear_return_offset_register,
-//                             });
-//                         }
-//                         _ => {
-//                             return Ok(OpStepResult::Done);
-//                         }
-//                     }
-//                 }
-
-//                 // Non-grouped aggregation e.g. SELECT COUNT(*) FROM t
-
-//                 const AGGREGATE_INIT: usize = 1;
-//                 const AGGREGATE_WAIT_UNTIL_SOURCE_READY: usize = 2;
-//                 match *step {
-//                     AGGREGATE_INIT => {
-//                         let agg_final_label = program.allocate_label();
-//                         m.termination_label_stack.push(agg_final_label);
-//                         let num_aggs = aggregates.len();
-//                         let start_reg = program.alloc_registers(num_aggs);
-//                         m.aggregation_start_registers.insert(*id, start_reg);
-
-//                         Ok(OpStepResult::Continue)
-//                     }
-//                     AGGREGATE_WAIT_UNTIL_SOURCE_READY => loop {
-//                         match source.step(program, m, referenced_tables)? {
-//                             OpStepResult::Continue => {}
-//                             OpStepResult::ReadyToEmit => {
-//                                 let start_reg = m.aggregation_start_registers.get(id).unwrap();
-//                                 for (i, agg) in aggregates.iter().enumerate() {
-//                                     let agg_result_reg = start_reg + i;
-//                                     translate_aggregation(
-//                                         program,
-//                                         referenced_tables,
-//                                         agg,
-//                                         agg_result_reg,
-//                                         None,
-//                                     )?;
-//                                 }
-//                             }
-//                             OpStepResult::Done => {
-//                                 return Ok(OpStepResult::ReadyToEmit);
-//                             }
-//                         }
-//                     },
-//                     _ => Ok(OpStepResult::Done),
-//                 }
-//             }
-//             SourceOperator::Filter { .. } => unreachable!("predicates have been pushed down"),
-//             SourceOperator::Limit { source, step, .. } => {
-//                 *step += 1;
-//                 loop {
-//                     match source.step(program, m, referenced_tables)? {
-//                         OpStepResult::Continue => continue,
-//                         OpStepResult::ReadyToEmit => {
-//                             return Ok(OpStepResult::ReadyToEmit);
-//                         }
-//                         OpStepResult::Done => return Ok(OpStepResult::Done),
-//                     }
-//                 }
-//             }
-//             SourceOperator::Order {
-//                 id,
-//                 source,
-//                 key,
-//                 step,
-//             } => {
-//                 *step += 1;
-//                 const ORDER_INIT: usize = 1;
-//                 const ORDER_INSERT_INTO_SORTER: usize = 2;
-//                 const ORDER_SORT_AND_OPEN_LOOP: usize = 3;
-//                 const ORDER_NEXT: usize = 4;
-//                 match *step {
-//                     ORDER_INIT => {
-//                         m.termination_label_stack.push(program.allocate_label());
-//                         let sort_cursor = program.alloc_cursor_id(None, None);
-//                         m.sorts.insert(
-//                             *id,
-//                             SortMetadata {
-//                                 sort_cursor,
-//                                 pseudo_table_cursor: usize::MAX, // will be set later
-//                                 sorter_data_register: program.alloc_register(),
-//                                 sorter_data_label: program.allocate_label(),
-//                                 done_label: program.allocate_label(),
-//                             },
-//                         );
-//                         let mut order = Vec::new();
-//                         for (_, direction) in key.iter() {
-//                             order.push(OwnedValue::Integer(*direction as i64));
-//                         }
-//                         program.emit_insn(Insn::SorterOpen {
-//                             cursor_id: sort_cursor,
-//                             columns: key.len(),
-//                             order: OwnedRecord::new(order),
-//                         });
-
-//                         loop {
-//                             match source.step(program, m, referenced_tables)? {
-//                                 OpStepResult::Continue => continue,
-//                                 OpStepResult::ReadyToEmit => {
-//                                     return Ok(OpStepResult::Continue);
-//                                 }
-//                                 OpStepResult::Done => {
-//                                     return Ok(OpStepResult::Done);
-//                                 }
-//                             }
-//                         }
-//                     }
-//                     ORDER_INSERT_INTO_SORTER => {
-//                         let sort_keys_count = key.len();
-//                         let source_cols_count = source.column_count(referenced_tables);
-//                         let start_reg = program.alloc_registers(sort_keys_count);
-//                         source.result_columns(program, referenced_tables, m, None)?;
-
-//                         for (i, (expr, _)) in key.iter().enumerate() {
-//                             let key_reg = start_reg + i;
-//                             translate_expr(
-//                                 program,
-//                                 Some(referenced_tables),
-//                                 expr,
-//                                 key_reg,
-//                                 None,
-//                                 m.result_set_register_start,
-//                             )?;
-//                         }
-
-//                         let sort_metadata = m.sorts.get_mut(id).unwrap();
-//                         program.emit_insn(Insn::MakeRecord {
-//                             start_reg,
-//                             count: sort_keys_count + source_cols_count,
-//                             dest_reg: sort_metadata.sorter_data_register,
-//                         });
-
-//                         program.emit_insn(Insn::SorterInsert {
-//                             cursor_id: sort_metadata.sort_cursor,
-//                             record_reg: sort_metadata.sorter_data_register,
-//                         });
-
-//                         Ok(OpStepResult::Continue)
-//                     }
-//                     #[allow(clippy::never_loop)]
-//                     ORDER_SORT_AND_OPEN_LOOP => {
-//                         loop {
-//                             match source.step(program, m, referenced_tables)? {
-//                                 OpStepResult::Done => {
-//                                     break;
-//                                 }
-//                                 _ => unreachable!(),
-//                             }
-//                         }
-//                         program.resolve_label(
-//                             m.termination_label_stack.pop().unwrap(),
-//                             program.offset(),
-//                         );
-//                         let column_names = source.column_names();
-//                         let mut pseudo_columns = vec![];
-//                         for (i, _) in key.iter().enumerate() {
-//                             pseudo_columns.push(Column {
-//                                 name: format!("sort_key_{}", i),
-//                                 primary_key: false,
-//                                 ty: crate::schema::Type::Null,
-//                             });
-//                         }
-//                         for name in column_names {
-//                             pseudo_columns.push(Column {
-//                                 name: name.clone(),
-//                                 primary_key: false,
-//                                 ty: crate::schema::Type::Null,
-//                             });
-//                         }
-
-//                         let num_fields = pseudo_columns.len();
-
-//                         let pseudo_cursor = program.alloc_cursor_id(
-//                             None,
-//                             Some(Table::Pseudo(Rc::new(PseudoTable {
-//                                 columns: pseudo_columns,
-//                             }))),
-//                         );
-//                         let sort_metadata = m.sorts.get(id).unwrap();
-
-//                         program.emit_insn(Insn::OpenPseudo {
-//                             cursor_id: pseudo_cursor,
-//                             content_reg: sort_metadata.sorter_data_register,
-//                             num_fields,
-//                         });
-
-//                         program.emit_insn_with_label_dependency(
-//                             Insn::SorterSort {
-//                                 cursor_id: sort_metadata.sort_cursor,
-//                                 pc_if_empty: sort_metadata.done_label,
-//                             },
-//                             sort_metadata.done_label,
-//                         );
-
-//                         program.defer_label_resolution(
-//                             sort_metadata.sorter_data_label,
-//                             program.offset() as usize,
-//                         );
-//                         program.emit_insn(Insn::SorterData {
-//                             cursor_id: sort_metadata.sort_cursor,
-//                             dest_reg: sort_metadata.sorter_data_register,
-//                             pseudo_cursor,
-//                         });
-
-//                         let sort_metadata = m.sorts.get_mut(id).unwrap();
-
-//                         sort_metadata.pseudo_table_cursor = pseudo_cursor;
-
-//                         Ok(OpStepResult::ReadyToEmit)
-//                     }
-//                     ORDER_NEXT => {
-//                         let sort_metadata = m.sorts.get(id).unwrap();
-//                         program.emit_insn_with_label_dependency(
-//                             Insn::SorterNext {
-//                                 cursor_id: sort_metadata.sort_cursor,
-//                                 pc_if_next: sort_metadata.sorter_data_label,
-//                             },
-//                             sort_metadata.sorter_data_label,
-//                         );
-
-//                         program.resolve_label(sort_metadata.done_label, program.offset());
-
-//                         Ok(OpStepResult::Done)
-//                     }
-//                     _ => unreachable!(),
-//                 }
-//             }
-//             SourceOperator::Nothing => Ok(OpStepResult::Done),
-//         }
-//     }
-//     fn result_columns(
-//         &self,
-//         program: &mut ProgramBuilder,
-//         referenced_tables: &[BTreeTableReference],
-//         m: &mut Metadata,
-//         cursor_override: Option<&SortCursorOverride>,
-//     ) -> Result<usize> {
-//         let col_count = self.column_count(referenced_tables);
-//         match self {
-//             SourceOperator::Scan {
-//                 table_reference, ..
-//             } => {
-//                 let start_reg = program.alloc_registers(col_count);
-//                 let table = cursor_override
-//                     .map(|c| c.pseudo_table.clone())
-//                     .unwrap_or_else(|| Table::BTree(table_reference.table.clone()));
-//                 let cursor_id = cursor_override.map(|c| c.cursor_id).unwrap_or_else(|| {
-//                     program.resolve_cursor_id(&table_reference.table_identifier, None)
-//                 });
-//                 let start_column_offset = cursor_override.map(|c| c.sort_key_len).unwrap_or(0);
-//                 translate_table_columns(program, cursor_id, &table, start_column_offset, start_reg);
-
-//                 Ok(start_reg)
-//             }
-//             SourceOperator::Search {
-//                 table_reference, ..
-//             } => {
-//                 let start_reg = program.alloc_registers(col_count);
-//                 let table = cursor_override
-//                     .map(|c| c.pseudo_table.clone())
-//                     .unwrap_or_else(|| Table::BTree(table_reference.table.clone()));
-//                 let cursor_id = cursor_override.map(|c| c.cursor_id).unwrap_or_else(|| {
-//                     program.resolve_cursor_id(&table_reference.table_identifier, None)
-//                 });
-//                 let start_column_offset = cursor_override.map(|c| c.sort_key_len).unwrap_or(0);
-//                 translate_table_columns(program, cursor_id, &table, start_column_offset, start_reg);
-
-//                 Ok(start_reg)
-//             }
-//             SourceOperator::Join { left, right, .. } => {
-//                 let left_start_reg =
-//                     left.result_columns(program, referenced_tables, m, cursor_override)?;
-//                 right.result_columns(program, referenced_tables, m, cursor_override)?;
-
-//                 Ok(left_start_reg)
-//             }
-//             SourceOperator::Projection {
-//                 id,
-//                 expressions,
-//                 aggregates,
-//                 group_by,
-//                 ..
-//             } => {
-//                 if aggregates.is_empty() && group_by.is_none() {
-//                     let expr_count = expressions.len();
-//                     let start_reg = program.alloc_registers(expr_count);
-//                     let mut cur_reg = start_reg;
-//                     m.result_set_register_start = start_reg;
-//                     for expr in expressions {
-//                         translate_expr(
-//                             program,
-//                             Some(referenced_tables),
-//                             expr,
-//                             cur_reg,
-//                             cursor_override.map(|c| c.cursor_id),
-//                             m.result_set_register_start,
-//                         )?;
-//                         cur_reg += 1;
-//                     }
-
-//                     return Ok(start_reg);
-//                 }
-//                 let agg_start_reg = m.aggregation_start_registers.get(id).unwrap();
-//                 program.resolve_label(m.termination_label_stack.pop().unwrap(), program.offset());
-//                 for (i, agg) in aggregates.iter().enumerate() {
-//                     let agg_result_reg = *agg_start_reg + i;
-//                     program.emit_insn(Insn::AggFinal {
-//                         register: agg_result_reg,
-//                         func: agg.func.clone(),
-//                     });
-//                 }
-
-//                 if let Some(group_by) = group_by {
-//                     let output_row_start_reg =
-//                         program.alloc_registers(aggregates.len() + group_by.len());
-//                     let group_by_metadata = m.group_bys.get(id).unwrap();
-//                     program.emit_insn(Insn::Copy {
-//                         src_reg: group_by_metadata.group_exprs_accumulator_register,
-//                         dst_reg: output_row_start_reg,
-//                         amount: group_by.len() - 1,
-//                     });
-//                     program.emit_insn(Insn::Copy {
-//                         src_reg: *agg_start_reg,
-//                         dst_reg: output_row_start_reg + group_by.len(),
-//                         amount: aggregates.len() - 1,
-//                     });
-
-//                     Ok(output_row_start_reg)
-//                 } else {
-//                     Ok(*agg_start_reg)
-//                 }
-//             }
-//             SourceOperator::Filter { .. } => unreachable!("predicates have been pushed down"),
-//             SourceOperator::Limit { .. } => {
-//                 unimplemented!()
-//             }
-//             SourceOperator::Order { id, key, .. } => {
-//                 let cursor_id = m.sorts.get(id).unwrap().pseudo_table_cursor;
-//                 let pseudo_table = program.resolve_cursor_to_table(cursor_id).unwrap();
-//                 let start_column_offset = key.len();
-//                 let column_count = pseudo_table.columns().len() - start_column_offset;
-//                 let start_reg = program.alloc_registers(column_count);
-//                 translate_table_columns(
-//                     program,
-//                     cursor_id,
-//                     &pseudo_table,
-//                     start_column_offset,
-//                     start_reg,
-//                 );
-
-//                 Ok(start_reg)
-//             }
-//             SourceOperator::Projection {
-//                 expressions, id, ..
-//             } => {
-//                 let expr_count = expressions.len();
-//                 let start_reg = program.alloc_registers(expr_count);
-//                 let mut cur_reg = start_reg;
-//                 m.result_set_register_start = start_reg;
-//                 for expr in expressions {
-//                     translate_expr(
-//                         program,
-//                         Some(referenced_tables),
-//                         expr,
-//                         cur_reg,
-//                         cursor_override.map(|c| c.cursor_id),
-//                         m.result_set_register_start,
-//                     )?;
-//                     cur_reg += 1;
-//                 }
-
-//                 Ok(start_reg)
-//             }
-//             SourceOperator::Nothing => unimplemented!(),
-//         }
-//     }
-//     fn result_row(
-//         &mut self,
-//         program: &mut ProgramBuilder,
-//         referenced_tables: &[BTreeTableReference],
-//         m: &mut Metadata,
-//         cursor_override: Option<&SortCursorOverride>,
-//     ) -> Result<()> {
-//         match self {
-//             SourceOperator::Limit { source, limit, .. } => {
-//                 source.result_row(program, referenced_tables, m, cursor_override)?;
-//                 let limit_reg = program.alloc_register();
-//                 program.emit_insn(Insn::Integer {
-//                     value: *limit as i64,
-//                     dest: limit_reg,
-//                 });
-//                 program.mark_last_insn_constant();
-//                 let jump_label = m.termination_label_stack.first().unwrap();
-//                 program.emit_insn_with_label_dependency(
-//                     Insn::DecrJumpZero {
-//                         reg: limit_reg,
-//                         target_pc: *jump_label,
-//                     },
-//                     *jump_label,
-//                 );
-
-//                 Ok(())
-//             }
-//             operator => {
-//                 let start_reg =
-//                     operator.result_columns(program, referenced_tables, m, cursor_override)?;
-//                 program.emit_insn(Insn::ResultRow {
-//                     start_reg,
-//                     count: operator.column_count(referenced_tables),
-//                 });
-//                 Ok(())
-//             }
-//         }
-//     }
-// }
 
 fn prologue() -> Result<(ProgramBuilder, Metadata, BranchOffset, BranchOffset)> {
     let mut program = ProgramBuilder::new();
@@ -1637,13 +129,14 @@ fn prologue() -> Result<(ProgramBuilder, Metadata, BranchOffset, BranchOffset)> 
 
     let metadata = Metadata {
         termination_label_stack: vec![halt_label],
-        aggregation_start_registers: HashMap::new(),
-        group_bys: HashMap::new(),
+        group_by_metadata: None,
         left_joins: HashMap::new(),
         next_row_labels: HashMap::new(),
         scan_loop_body_labels: vec![],
         sorts: HashMap::new(),
-        result_set_register_start: 0,
+        aggregation_start_register: None,
+        result_column_indexes_in_orderby_sorter: HashMap::new(),
+        result_columns_to_skip_in_orderby_sorter: None,
     };
 
     Ok((program, metadata, init_label, start_offset))
@@ -1655,10 +148,8 @@ fn epilogue(
     init_label: BranchOffset,
     start_offset: BranchOffset,
 ) -> Result<()> {
-    program.resolve_label(
-        metadata.termination_label_stack.pop().unwrap(),
-        program.offset(),
-    );
+    let halt_label = metadata.termination_label_stack.pop().unwrap();
+    program.resolve_label(halt_label, program.offset());
     program.emit_insn(Insn::Halt {
         err_code: 0,
         description: String::new(),
@@ -1683,8 +174,6 @@ pub fn emit_program(
     connection: Weak<Connection>,
 ) -> Result<Program> {
     let (mut program, mut metadata, init_label, start_offset) = prologue()?;
-
-    let mut order_by_necessary = plan.order_by.is_some();
 
     // OPEN CURSORS ETC
     if let Some(ref mut order_by) = plan.order_by {
@@ -1716,13 +205,23 @@ pub fn emit_program(
         &plan.referenced_tables,
     )?;
 
+    let mut order_by_necessary = plan.order_by.is_some();
+
     // IF GROUP BY, SORT BY GROUPS AND DO AGGREGATION
     if let Some(ref mut group_by) = plan.group_by {
-        sort_group_by(&mut program, group_by, &mut metadata)?;
-        finalize_group_by(&mut program, group_by, &mut metadata)?;
+        group_by_emit(
+            &mut program,
+            &plan.result_columns,
+            group_by,
+            plan.order_by.as_ref(),
+            &plan.aggregates.as_ref().unwrap(),
+            plan.limit.clone(),
+            &plan.referenced_tables,
+            &mut metadata,
+        )?;
     } else if let Some(ref mut aggregates) = plan.aggregates {
         // Example: SELECT sum(x), count(*) FROM t;
-        finalize_agg_without_group_by(&mut program, aggregates, &mut metadata)?;
+        agg_without_group_by_emit(&mut program, aggregates, &mut metadata)?;
         // If we have an aggregate without a group by, we don't need an order by because currently
         // there can only be a single row result in those cases.
         order_by_necessary = false;
@@ -1797,8 +296,6 @@ fn init_group_by(
     let group_exprs_comparison_register = program.alloc_registers(group_by.len());
     let group_exprs_accumulator_register = program.alloc_registers(group_by.len());
     let agg_exprs_start_reg = program.alloc_registers(num_aggs);
-    m.aggregation_start_registers
-        .insert(GROUP_BY_ID, agg_exprs_start_reg);
     let sorter_key_register = program.alloc_register();
 
     let subroutine_accumulator_clear_label = program.allocate_label();
@@ -1847,24 +344,23 @@ fn init_group_by(
         subroutine_accumulator_clear_label,
     );
 
-    m.group_bys.insert(
-        GROUP_BY_ID,
-        GroupByMetadata {
-            sort_cursor,
-            subroutine_accumulator_clear_label,
-            subroutine_accumulator_clear_return_offset_register,
-            subroutine_accumulator_output_label,
-            subroutine_accumulator_output_return_offset_register: program.alloc_register(),
-            accumulator_indicator_set_true_label: program.allocate_label(),
-            sorter_data_label,
-            grouping_done_label,
-            abort_flag_register,
-            data_in_accumulator_indicator_register,
-            group_exprs_accumulator_register,
-            group_exprs_comparison_register,
-            sorter_key_register,
-        },
-    );
+    m.aggregation_start_register = Some(agg_exprs_start_reg);
+
+    m.group_by_metadata = Some(GroupByMetadata {
+        sort_cursor,
+        subroutine_accumulator_clear_label,
+        subroutine_accumulator_clear_return_offset_register,
+        subroutine_accumulator_output_label,
+        subroutine_accumulator_output_return_offset_register: program.alloc_register(),
+        accumulator_indicator_set_true_label: program.allocate_label(),
+        sorter_data_label,
+        grouping_done_label,
+        abort_flag_register,
+        data_in_accumulator_indicator_register,
+        group_exprs_accumulator_register,
+        group_exprs_comparison_register,
+        sorter_key_register,
+    });
     Ok(())
 }
 
@@ -2017,7 +513,7 @@ fn open_loop(
                         predicate,
                         None,
                         condition_metadata,
-                        m.result_set_register_start,
+                        None,
                     )?;
                 }
                 program.resolve_label(jump_target_when_true, program.offset());
@@ -2089,7 +585,7 @@ fn open_loop(
                         expr,
                         None,
                         condition_metadata,
-                        m.result_set_register_start,
+                        None,
                     )?;
                     program.resolve_label(jump_target_when_true, program.offset());
                 }
@@ -2135,7 +631,7 @@ fn open_loop(
                             cmp_expr,
                             cmp_reg,
                             None,
-                            m.result_set_register_start,
+                            None,
                         )?;
                     }
                     ast::Operator::Less | ast::Operator::LessEquals => {
@@ -2175,7 +671,7 @@ fn open_loop(
                         cmp_expr,
                         cmp_reg,
                         None,
-                        m.result_set_register_start,
+                        None,
                     )?;
                 }
 
@@ -2273,7 +769,7 @@ fn open_loop(
                     cmp_expr,
                     src_reg,
                     None,
-                    m.result_set_register_start,
+                    None,
                 )?;
                 program.emit_insn_with_label_dependency(
                     Insn::SeekRowid {
@@ -2298,7 +794,7 @@ fn open_loop(
                         predicate,
                         None,
                         condition_metadata,
-                        m.result_set_register_start,
+                        None,
                     )?;
                     program.resolve_label(jump_target_when_true, program.offset());
                 }
@@ -2395,46 +891,31 @@ fn inner_loop_source_emit(
         } => {
             // TODO: DOESNT WORK YET
             let sort_keys_count = group_by.len();
-            let column_count = sort_keys_count + aggregates.len();
+            let aggregate_arguments_count =
+                aggregates.iter().map(|agg| agg.args.len()).sum::<usize>();
+            let column_count = sort_keys_count + aggregate_arguments_count;
             let start_reg = program.alloc_registers(column_count);
-            for (i, expr) in group_by.iter().enumerate() {
-                let key_reg = start_reg + i;
-                translate_expr(
-                    program,
-                    Some(referenced_tables),
-                    expr,
-                    key_reg,
-                    None,
-                    m.result_set_register_start,
-                )?;
+            let mut cur_reg = start_reg;
+            for expr in group_by.iter() {
+                let key_reg = cur_reg;
+                cur_reg += 1;
+                translate_expr(program, Some(referenced_tables), expr, key_reg, None, None)?;
             }
-            for (i, agg) in aggregates.iter().enumerate() {
-                // TODO it's a hack to assume aggregate functions have exactly one argument.
-                // Counterpoint e.g. GROUP_CONCAT(expr, separator).
-                //
+            for agg in aggregates.iter() {
                 // Here we are collecting scalars for the group by sorter, which will include
                 // both the group by expressions and the aggregate arguments.
                 // e.g. in `select u.first_name, sum(u.age) from users group by u.first_name`
                 // the sorter will have two scalars: u.first_name and u.age.
                 // these are then sorted by u.first_name, and for each u.first_name, we sum the u.age.
-                // the actual aggregation is done later in GROUP_BY_SORT_AND_COMPARE below.
-                //
-                // This is why we take the first argument of each aggregate function currently.
-                // It's mostly an artifact of the current architecture being a bit poor; we should recognize
-                // which scalars are dependencies of aggregate functions and explicitly collect those.
-                let expr = &agg.args[0];
-                let agg_reg = start_reg + sort_keys_count + i;
-                translate_expr(
-                    program,
-                    Some(referenced_tables),
-                    expr,
-                    agg_reg,
-                    None,
-                    m.result_set_register_start,
-                )?;
+                // the actual aggregation is done later.
+                for expr in agg.args.iter() {
+                    let agg_reg = cur_reg;
+                    cur_reg += 1;
+                    translate_expr(program, Some(referenced_tables), expr, agg_reg, None, None)?;
+                }
             }
 
-            let group_by_metadata = m.group_bys.get(&GROUP_BY_ID).unwrap();
+            let group_by_metadata = m.group_by_metadata.as_ref().unwrap();
 
             program.emit_insn(Insn::MakeRecord {
                 start_reg,
@@ -2442,7 +923,6 @@ fn inner_loop_source_emit(
                 dest_reg: group_by_metadata.sorter_key_register,
             });
 
-            let group_by_metadata = m.group_bys.get(&GROUP_BY_ID).unwrap();
             program.emit_insn(Insn::SorterInsert {
                 cursor_id: group_by_metadata.sort_cursor,
                 record_reg: group_by_metadata.sorter_key_register,
@@ -2451,42 +931,90 @@ fn inner_loop_source_emit(
             Ok(())
         }
         InnerLoopEmitTarget::OrderBySorter { order_by } => {
-            // TODO: DOESNT WORK YET
-            let sort_keys_count = order_by.len();
-            let source_cols_count = result_columns.len();
-            let start_reg = program.alloc_registers(sort_keys_count + source_cols_count);
+            // We need to handle the case where we are emitting to sorter.
+            // In that case the first columns should be the sort key columns, and the rest is the result columns of the select.
+            // In case any of the sort keys are exactly equal to a result column, we need to skip emitting that result column.
+            // We need to do this before rewriting the result columns to registers because we need to know which columns to skip.
+            // Moreover, we need to keep track what index in the ORDER BY sorter the result columns have, because the result columns
+            // should be emitted in the SELECT clause order, not the ORDER BY clause order.
+            let mut result_columns_to_skip: Option<Vec<usize>> = None;
+            for (i, rc) in result_columns.iter().enumerate() {
+                match rc {
+                    ResultSetColumn::Scalar(expr) => {
+                        let found = order_by.iter().enumerate().find(|(_, (e, _))| e == expr);
+                        if let Some((j, _)) = found {
+                            if let Some(ref mut v) = result_columns_to_skip {
+                                v.push(i);
+                            } else {
+                                result_columns_to_skip = Some(vec![i]);
+                            }
+                            m.result_column_indexes_in_orderby_sorter.insert(i, j);
+                        }
+                    }
+                    ResultSetColumn::Agg(agg) => {
+                        let found = order_by
+                            .iter()
+                            .enumerate()
+                            .find(|(_, (expr, _))| expr == &agg.original_expr);
+                        if let Some((j, _)) = found {
+                            if let Some(ref mut v) = result_columns_to_skip {
+                                v.push(i);
+                            } else {
+                                result_columns_to_skip = Some(vec![i]);
+                            }
+                            m.result_column_indexes_in_orderby_sorter.insert(i, j);
+                        }
+                    }
+                    ResultSetColumn::ComputedAgg(_) => {
+                        unreachable!(
+                            "ComputedAgg should have been rewritten to a normal agg before emit"
+                        );
+                    }
+                }
+            }
+            let order_by_len = order_by.len();
+            let result_columns_to_skip_len = result_columns_to_skip
+                .as_ref()
+                .map(|v| v.len())
+                .unwrap_or(0);
+            let orderby_sorter_column_count =
+                order_by_len + result_columns.len() - result_columns_to_skip_len;
+            let start_reg = program.alloc_registers(orderby_sorter_column_count);
             for (i, (expr, _)) in order_by.iter().enumerate() {
                 let key_reg = start_reg + i;
-                translate_expr(
-                    program,
-                    Some(referenced_tables),
-                    expr,
-                    key_reg,
-                    None,
-                    m.result_set_register_start,
-                )?;
+                translate_expr(program, Some(referenced_tables), expr, key_reg, None, None)?;
             }
-            for (i, expr) in result_columns.iter().enumerate() {
-                match expr {
+            let mut cur_reg = start_reg + order_by_len;
+            let mut cur_idx_in_orderby_sorter = order_by_len;
+            for (i, rc) in result_columns.iter().enumerate() {
+                if let Some(ref v) = result_columns_to_skip {
+                    if v.contains(&i) {
+                        continue;
+                    }
+                }
+                match rc {
                     ResultSetColumn::Scalar(expr) => {
-                        let reg = start_reg + sort_keys_count + i;
                         translate_expr(
                             program,
                             Some(referenced_tables),
                             expr,
-                            reg,
+                            cur_reg,
                             None,
-                            m.result_set_register_start,
+                            None,
                         )?;
                     }
-                    other => todo!("{:?}", other),
+                    other => unreachable!("{:?}", other),
                 }
+                m.result_column_indexes_in_orderby_sorter
+                    .insert(i, cur_idx_in_orderby_sorter);
+                cur_idx_in_orderby_sorter += 1;
+                cur_reg += 1;
             }
 
             let sort_metadata = m.sorts.get_mut(&ORDER_BY_ID).unwrap();
             program.emit_insn(Insn::MakeRecord {
                 start_reg,
-                count: sort_keys_count + source_cols_count,
+                count: orderby_sorter_column_count,
                 dest_reg: sort_metadata.sorter_data_register,
             });
 
@@ -2503,8 +1031,7 @@ fn inner_loop_source_emit(
             m.termination_label_stack.push(agg_final_label);
             let num_aggs = aggregates.len();
             let start_reg = program.alloc_registers(result_columns.len());
-            m.aggregation_start_registers
-                .insert(AGG_WITHOUT_GROUP_BY_ID, start_reg);
+            m.aggregation_start_register = Some(start_reg);
             for (i, agg) in aggregates.iter().enumerate() {
                 let reg = start_reg + i;
                 translate_aggregation(program, referenced_tables, agg, reg, None)?;
@@ -2513,14 +1040,7 @@ fn inner_loop_source_emit(
                 match expr {
                     ResultSetColumn::Scalar(expr) => {
                         let reg = start_reg + num_aggs + i;
-                        translate_expr(
-                            program,
-                            Some(referenced_tables),
-                            expr,
-                            reg,
-                            None,
-                            m.result_set_register_start,
-                        )?;
+                        translate_expr(program, Some(referenced_tables), expr, reg, None, None)?;
                     }
                     ResultSetColumn::Agg(_) => { /* do nothing, aggregates are computed above */ }
                     other => unreachable!("Unexpected non-scalar result column: {:?}", other),
@@ -2535,16 +1055,12 @@ fn inner_loop_source_emit(
                 match expr {
                     ResultSetColumn::Scalar(expr) => {
                         let reg = start_reg + i;
-                        translate_expr(
-                            program,
-                            Some(referenced_tables),
-                            expr,
-                            reg,
-                            None,
-                            m.result_set_register_start,
-                        )?;
+                        translate_expr(program, Some(referenced_tables), expr, reg, None, None)?;
                     }
-                    other => unreachable!("Unexpected non-scalar result column: {:?}", other),
+                    other => unreachable!(
+                        "Unexpected non-scalar result column in inner loop: {:?}",
+                        other
+                    ),
                 }
             }
             program.emit_insn(Insn::ResultRow {
@@ -2703,44 +1219,461 @@ fn close_loop(
 
             Ok(())
         }
-        SourceOperator::Nothing => {
-            unreachable!()
-        }
+        SourceOperator::Nothing => Ok(()),
     }
 }
 
-fn sort_group_by(
+fn group_by_emit(
     program: &mut ProgramBuilder,
+    result_columns: &Vec<ResultSetColumn>,
     group_by: &Vec<ast::Expr>,
+    order_by: Option<&Vec<(ast::Expr, Direction)>>,
+    aggregates: &Vec<Aggregate>,
+    limit: Option<usize>,
+    referenced_tables: &[BTreeTableReference],
     m: &mut Metadata,
 ) -> Result<()> {
-    todo!()
+    let group_by_metadata = m.group_by_metadata.as_mut().unwrap();
+
+    let GroupByMetadata {
+        group_exprs_comparison_register: comparison_register,
+        subroutine_accumulator_output_return_offset_register,
+        subroutine_accumulator_output_label,
+        subroutine_accumulator_clear_return_offset_register,
+        subroutine_accumulator_clear_label,
+        data_in_accumulator_indicator_register,
+        accumulator_indicator_set_true_label,
+        group_exprs_accumulator_register: group_exprs_start_register,
+        abort_flag_register,
+        sorter_key_register,
+        ..
+    } = *group_by_metadata;
+    let halt_label = *m.termination_label_stack.first().unwrap();
+
+    // all group by columns and all arguments of agg functions are in the sorter.
+    // the sort keys are the group by columns (the aggregation within groups is done based on how long the sort keys remain the same)
+    let sorter_column_count =
+        group_by.len() + aggregates.iter().map(|agg| agg.args.len()).sum::<usize>();
+    // sorter column names do not matter
+    let pseudo_columns = (0..sorter_column_count)
+        .map(|i| Column {
+            name: i.to_string(),
+            primary_key: false,
+            ty: crate::schema::Type::Null,
+        })
+        .collect::<Vec<_>>();
+
+    // A pseudo table is a "fake" table to which we read one row at a time from the sorter
+    let pseudo_table = Rc::new(PseudoTable {
+        columns: pseudo_columns,
+    });
+
+    let pseudo_cursor = program.alloc_cursor_id(None, Some(Table::Pseudo(pseudo_table.clone())));
+
+    program.emit_insn(Insn::OpenPseudo {
+        cursor_id: pseudo_cursor,
+        content_reg: sorter_key_register,
+        num_fields: sorter_column_count,
+    });
+
+    // Sort the sorter based on the group by columns
+    program.emit_insn_with_label_dependency(
+        Insn::SorterSort {
+            cursor_id: group_by_metadata.sort_cursor,
+            pc_if_empty: group_by_metadata.grouping_done_label,
+        },
+        group_by_metadata.grouping_done_label,
+    );
+
+    program.defer_label_resolution(
+        group_by_metadata.sorter_data_label,
+        program.offset() as usize,
+    );
+    // Read a row from the sorted data in the sorter into the pseudo cursor
+    program.emit_insn(Insn::SorterData {
+        cursor_id: group_by_metadata.sort_cursor,
+        dest_reg: group_by_metadata.sorter_key_register,
+        pseudo_cursor,
+    });
+
+    // Read the group by columns from the pseudo cursor
+    let groups_start_reg = program.alloc_registers(group_by.len());
+    for (i, expr) in group_by.iter().enumerate() {
+        let sorter_column_index = i;
+        let group_reg = groups_start_reg + i;
+        program.emit_insn(Insn::Column {
+            cursor_id: pseudo_cursor,
+            column: sorter_column_index,
+            dest: group_reg,
+        });
+    }
+
+    // Compare the group by columns to the previous group by columns to see if we are at a new group or not
+    program.emit_insn(Insn::Compare {
+        start_reg_a: comparison_register,
+        start_reg_b: groups_start_reg,
+        count: group_by.len(),
+    });
+
+    let agg_step_label = program.allocate_label();
+
+    program.add_comment(
+        program.offset(),
+        "start new group if comparison is not equal",
+    );
+    // If we are at a new group, continue. If we are at the same group, jump to the aggregation step (i.e. accumulate more values into the aggregations)
+    program.emit_insn_with_label_dependency(
+        Insn::Jump {
+            target_pc_lt: program.offset() + 1,
+            target_pc_eq: agg_step_label,
+            target_pc_gt: program.offset() + 1,
+        },
+        agg_step_label,
+    );
+
+    // New group, move current group by columns into the comparison register
+    program.emit_insn(Insn::Move {
+        source_reg: groups_start_reg,
+        dest_reg: comparison_register,
+        count: group_by.len(),
+    });
+
+    program.add_comment(
+        program.offset(),
+        "check if ended group had data, and output if so",
+    );
+    program.emit_insn_with_label_dependency(
+        Insn::Gosub {
+            target_pc: subroutine_accumulator_output_label,
+            return_reg: subroutine_accumulator_output_return_offset_register,
+        },
+        subroutine_accumulator_output_label,
+    );
+
+    program.add_comment(program.offset(), "check abort flag");
+    program.emit_insn_with_label_dependency(
+        Insn::IfPos {
+            reg: abort_flag_register,
+            target_pc: halt_label,
+            decrement_by: 0,
+        },
+        m.termination_label_stack[0],
+    );
+
+    program.add_comment(program.offset(), "goto clear accumulator subroutine");
+    program.emit_insn_with_label_dependency(
+        Insn::Gosub {
+            target_pc: subroutine_accumulator_clear_label,
+            return_reg: subroutine_accumulator_clear_return_offset_register,
+        },
+        subroutine_accumulator_clear_label,
+    );
+
+    // Accumulate the values into the aggregations
+    program.resolve_label(agg_step_label, program.offset());
+    let start_reg = m.aggregation_start_register.unwrap();
+    let mut cursor_index = group_by.len();
+    for (i, agg) in aggregates.iter().enumerate() {
+        let agg_result_reg = start_reg + i;
+        translate_aggregation_groupby(
+            program,
+            referenced_tables,
+            pseudo_cursor,
+            cursor_index,
+            agg,
+            agg_result_reg,
+        )?;
+        cursor_index += agg.args.len();
+    }
+
+    // We only emit the group by columns if we are going to start a new group (i.e. the prev group will not accumulate any more values into the aggregations)
+    program.add_comment(
+        program.offset(),
+        "don't emit group columns if continuing existing group",
+    );
+    program.emit_insn_with_label_dependency(
+        Insn::If {
+            target_pc: accumulator_indicator_set_true_label,
+            reg: data_in_accumulator_indicator_register,
+            null_reg: 0, // unused in this case
+        },
+        accumulator_indicator_set_true_label,
+    );
+
+    // Read the group by columns for a finished group
+    for (i, expr) in group_by.iter().enumerate() {
+        let key_reg = group_exprs_start_register + i;
+        let sorter_column_index = i;
+        program.emit_insn(Insn::Column {
+            cursor_id: pseudo_cursor,
+            column: sorter_column_index,
+            dest: key_reg,
+        });
+    }
+
+    program.resolve_label(accumulator_indicator_set_true_label, program.offset());
+    program.add_comment(program.offset(), "indicate data in accumulator");
+    program.emit_insn(Insn::Integer {
+        value: 1,
+        dest: data_in_accumulator_indicator_register,
+    });
+
+    program.emit_insn_with_label_dependency(
+        Insn::SorterNext {
+            cursor_id: group_by_metadata.sort_cursor,
+            pc_if_next: group_by_metadata.sorter_data_label,
+        },
+        group_by_metadata.sorter_data_label,
+    );
+
+    program.resolve_label(group_by_metadata.grouping_done_label, program.offset());
+
+    program.add_comment(program.offset(), "emit row for final group");
+    program.emit_insn_with_label_dependency(
+        Insn::Gosub {
+            target_pc: group_by_metadata.subroutine_accumulator_output_label,
+            return_reg: group_by_metadata.subroutine_accumulator_output_return_offset_register,
+        },
+        group_by_metadata.subroutine_accumulator_output_label,
+    );
+
+    program.add_comment(program.offset(), "group by finished");
+    let termination_label = m.termination_label_stack[m.termination_label_stack.len() - 2];
+    program.emit_insn_with_label_dependency(
+        Insn::Goto {
+            target_pc: termination_label,
+        },
+        termination_label,
+    );
+    program.emit_insn(Insn::Integer {
+        value: 1,
+        dest: group_by_metadata.abort_flag_register,
+    });
+    program.emit_insn(Insn::Return {
+        return_reg: group_by_metadata.subroutine_accumulator_output_return_offset_register,
+    });
+
+    program.resolve_label(
+        group_by_metadata.subroutine_accumulator_output_label,
+        program.offset(),
+    );
+
+    program.add_comment(program.offset(), "output group by row subroutine start");
+    let termination_label = *m.termination_label_stack.last().unwrap();
+    program.emit_insn_with_label_dependency(
+        Insn::IfPos {
+            reg: group_by_metadata.data_in_accumulator_indicator_register,
+            target_pc: termination_label,
+            decrement_by: 0,
+        },
+        termination_label,
+    );
+    program.emit_insn(Insn::Return {
+        return_reg: group_by_metadata.subroutine_accumulator_output_return_offset_register,
+    });
+
+    let agg_start_reg = m.aggregation_start_register.unwrap();
+    program.resolve_label(m.termination_label_stack.pop().unwrap(), program.offset());
+    for (i, agg) in aggregates.iter().enumerate() {
+        let agg_result_reg = agg_start_reg + i;
+        program.emit_insn(Insn::AggFinal {
+            register: agg_result_reg,
+            func: agg.func.clone(),
+        });
+    }
+
+    // TODO handle result column expressions like LENGTH(SUM(x))
+    // we now have the group by columns in registers (group_exprs_start_register..group_exprs_start_register + group_by.len() - 1)
+    // and the agg results in (agg_start_reg..agg_start_reg + aggregates.len() - 1)
+    // we need to call translate_expr on each result column, but replace the expr with a register copy in case any part of the
+    // result column expression matches a) a group by column or b) an aggregation result.
+    let mut precomputed_exprs_to_register = Vec::with_capacity(aggregates.len() + group_by.len());
+    for (i, expr) in group_by.iter().enumerate() {
+        precomputed_exprs_to_register.push((expr, group_exprs_start_register + i));
+    }
+    for (i, agg) in aggregates.iter().enumerate() {
+        precomputed_exprs_to_register.push((&agg.original_expr, agg_start_reg + i));
+    }
+
+    // We need to handle the case where we are emitting to sorter.
+    // In that case the first columns should be the sort key columns, and the rest is the result columns of the select.
+    // In case any of the sort keys are exactly equal to a result column, we need to skip emitting that result column.
+    // We need to do this before rewriting the result columns to registers because we need to know which columns to skip.
+    // Moreover, we need to keep track what index in the ORDER BY sorter the result columns have, because the result columns
+    // should be emitted in the SELECT clause order, not the ORDER BY clause order.
+    let mut result_columns_to_skip: Option<Vec<usize>> = None;
+    if let Some(order_by) = order_by {
+        for (i, rc) in result_columns.iter().enumerate() {
+            match rc {
+                ResultSetColumn::Scalar(expr) => {
+                    let found = order_by.iter().enumerate().find(|(_, (e, _))| e == expr);
+                    if let Some((j, _)) = found {
+                        if let Some(ref mut v) = result_columns_to_skip {
+                            v.push(i);
+                        } else {
+                            result_columns_to_skip = Some(vec![i]);
+                        }
+                        m.result_column_indexes_in_orderby_sorter.insert(i, j);
+                    }
+                }
+                ResultSetColumn::Agg(agg) => {
+                    let found = order_by
+                        .iter()
+                        .enumerate()
+                        .find(|(_, (expr, _))| expr == &agg.original_expr);
+                    if let Some((j, _)) = found {
+                        if let Some(ref mut v) = result_columns_to_skip {
+                            v.push(i);
+                        } else {
+                            result_columns_to_skip = Some(vec![i]);
+                        }
+                        m.result_column_indexes_in_orderby_sorter.insert(i, j);
+                    }
+                }
+                ResultSetColumn::ComputedAgg(_) => {
+                    unreachable!(
+                        "ComputedAgg should have been rewritten to a normal agg before emit"
+                    );
+                }
+            }
+        }
+    }
+    let order_by_len = order_by.as_ref().map(|v| v.len()).unwrap_or(0);
+    let result_columns_to_skip_len = result_columns_to_skip
+        .as_ref()
+        .map(|v| v.len())
+        .unwrap_or(0);
+    let output_row_start_reg =
+        program.alloc_registers(result_columns.len() + order_by_len - result_columns_to_skip_len);
+    let mut cur_reg = output_row_start_reg;
+    if let Some(order_by) = order_by {
+        for (expr, _) in order_by.iter() {
+            translate_expr(
+                program,
+                Some(referenced_tables),
+                expr,
+                cur_reg,
+                None,
+                Some(&precomputed_exprs_to_register),
+            )?;
+            cur_reg += 1;
+        }
+    }
+    let mut res_col_idx_in_orderby_sorter = order_by_len;
+    for (i, rc) in result_columns.iter().enumerate() {
+        if let Some(ref v) = result_columns_to_skip {
+            if v.contains(&i) {
+                continue;
+            }
+        }
+        match rc {
+            ResultSetColumn::Scalar(expr) => {
+                translate_expr(
+                    program,
+                    Some(referenced_tables),
+                    expr,
+                    cur_reg,
+                    None,
+                    Some(&precomputed_exprs_to_register),
+                )?;
+            }
+            ResultSetColumn::Agg(agg) => {
+                let found = aggregates.iter().enumerate().find(|(_, a)| **a == *agg);
+                if let Some((i, _)) = found {
+                    program.emit_insn(Insn::Copy {
+                        src_reg: agg_start_reg + i,
+                        dst_reg: cur_reg,
+                        amount: 0,
+                    });
+                } else {
+                    unreachable!("agg {:?} not found", agg);
+                }
+            }
+            ResultSetColumn::ComputedAgg(agg) => {
+                unreachable!(
+                    "ComputedAgg should have been rewritten to a normal agg before emit: {:?}",
+                    agg
+                );
+            }
+        }
+        m.result_column_indexes_in_orderby_sorter
+            .insert(i, res_col_idx_in_orderby_sorter);
+        res_col_idx_in_orderby_sorter += 1;
+        cur_reg += 1;
+    }
+
+    match order_by {
+        None => {
+            if let Some(limit) = limit {
+                let limit_reg = program.alloc_register();
+                program.emit_insn(Insn::Integer {
+                    value: limit as i64,
+                    dest: limit_reg,
+                });
+                program.mark_last_insn_constant();
+                program.emit_insn(Insn::ResultRow {
+                    start_reg: output_row_start_reg,
+                    count: aggregates.len() + group_by.len(),
+                });
+                program.emit_insn_with_label_dependency(
+                    Insn::DecrJumpZero {
+                        reg: limit_reg,
+                        target_pc: *m.termination_label_stack.last().unwrap(),
+                    },
+                    *m.termination_label_stack.last().unwrap(),
+                );
+            }
+        }
+        Some(_) => {
+            program.emit_insn(Insn::MakeRecord {
+                start_reg: output_row_start_reg,
+                count: aggregates.len() + group_by.len(),
+                dest_reg: group_by_metadata.sorter_key_register,
+            });
+
+            program.emit_insn(Insn::SorterInsert {
+                cursor_id: m.sorts.get(&ORDER_BY_ID).unwrap().sort_cursor,
+                record_reg: group_by_metadata.sorter_key_register,
+            });
+        }
+    }
+
+    program.emit_insn(Insn::Return {
+        return_reg: group_by_metadata.subroutine_accumulator_output_return_offset_register,
+    });
+
+    program.add_comment(program.offset(), "clear accumulator subroutine start");
+    program.resolve_label(
+        group_by_metadata.subroutine_accumulator_clear_label,
+        program.offset(),
+    );
+    let start_reg = group_by_metadata.group_exprs_accumulator_register;
+    program.emit_insn(Insn::Null {
+        dest: start_reg,
+        dest_end: Some(start_reg + group_by.len() + aggregates.len() - 1),
+    });
+
+    program.emit_insn(Insn::Integer {
+        value: 0,
+        dest: group_by_metadata.data_in_accumulator_indicator_register,
+    });
+    program.emit_insn(Insn::Return {
+        return_reg: group_by_metadata.subroutine_accumulator_clear_return_offset_register,
+    });
+
+    m.result_columns_to_skip_in_orderby_sorter = result_columns_to_skip;
+
+    Ok(())
 }
 
-fn finalize_group_by(
-    program: &mut ProgramBuilder,
-    group_by: &Vec<ast::Expr>,
-    m: &mut Metadata,
-) -> Result<()> {
-    todo!()
-}
-
-enum FinalizeGroupByEmitTarget {
-    OrderBySorter(usize),
-    ResultRow,
-}
-
-fn finalize_agg_without_group_by(
+fn agg_without_group_by_emit(
     program: &mut ProgramBuilder,
     aggregates: &Vec<Aggregate>,
     m: &mut Metadata,
 ) -> Result<()> {
-    let agg_start_reg = m
-        .aggregation_start_registers
-        .get(&AGG_WITHOUT_GROUP_BY_ID)
-        .unwrap();
+    let agg_start_reg = m.aggregation_start_register.unwrap();
     for (i, agg) in aggregates.iter().enumerate() {
-        let agg_result_reg = *agg_start_reg + i;
+        let agg_result_reg = agg_start_reg + i;
         program.emit_insn(Insn::AggFinal {
             register: agg_result_reg,
             func: agg.func.clone(),
@@ -2748,7 +1681,7 @@ fn finalize_agg_without_group_by(
     }
     let output_reg = program.alloc_registers(aggregates.len());
     program.emit_insn(Insn::Copy {
-        src_reg: *agg_start_reg,
+        src_reg: agg_start_reg,
         dst_reg: output_reg,
         amount: aggregates.len() - 1,
     });
@@ -2778,7 +1711,12 @@ fn sort_order_by(
             ty: crate::schema::Type::Null,
         });
     }
-    for expr in result_columns.iter() {
+    for (i, expr) in result_columns.iter().enumerate() {
+        if let Some(ref v) = m.result_columns_to_skip_in_orderby_sorter {
+            if v.contains(&i) {
+                continue;
+            }
+        }
         pseudo_columns.push(Column {
             name: match expr {
                 ResultSetColumn::Scalar(expr) => expr.to_string(),
@@ -2790,7 +1728,11 @@ fn sort_order_by(
         });
     }
 
-    let num_fields = pseudo_columns.len();
+    let num_columns_in_sorter = order_by.len() + result_columns.len()
+        - m.result_columns_to_skip_in_orderby_sorter
+            .as_ref()
+            .map(|v| v.len())
+            .unwrap_or(0);
 
     let pseudo_cursor = program.alloc_cursor_id(
         None,
@@ -2803,7 +1745,7 @@ fn sort_order_by(
     program.emit_insn(Insn::OpenPseudo {
         cursor_id: pseudo_cursor,
         content_reg: sort_metadata.sorter_data_register,
-        num_fields,
+        num_fields: num_columns_in_sorter,
     });
 
     program.emit_insn_with_label_dependency(
@@ -2823,25 +1765,20 @@ fn sort_order_by(
 
     let sort_metadata = m.sorts.get_mut(&ORDER_BY_ID).unwrap();
 
-    sort_metadata.pseudo_table_cursor = pseudo_cursor;
-
     // EMIT COLUMNS FROM SORTER AND EMIT ROW
     let cursor_id = pseudo_cursor;
-    let pseudo_table = program.resolve_cursor_to_table(cursor_id).unwrap();
-    let start_column_offset = order_by.len();
-    let column_count = pseudo_table.columns().len() - start_column_offset;
-    let start_reg = program.alloc_registers(column_count);
-    for i in 0..column_count {
+    let start_reg = program.alloc_registers(result_columns.len());
+    for i in 0..result_columns.len() {
         let reg = start_reg + i;
         program.emit_insn(Insn::Column {
             cursor_id,
-            column: start_column_offset + i,
+            column: m.result_column_indexes_in_orderby_sorter[&i],
             dest: reg,
         });
     }
     program.emit_insn(Insn::ResultRow {
         start_reg,
-        count: column_count,
+        count: result_columns.len(),
     });
 
     if let Some(limit) = limit {

--- a/core/translate/emitter.rs
+++ b/core/translate/emitter.rs
@@ -1632,6 +1632,7 @@ fn sorter_insert(
     });
 }
 
+/// Emits the bytecode for inserting a row into an ORDER BY sorter.
 fn order_by_sorter_insert(
     program: &mut ProgramBuilder,
     referenced_tables: &[BTreeTableReference],
@@ -1642,7 +1643,7 @@ fn order_by_sorter_insert(
     precomputed_exprs_to_register: Option<&Vec<(&ast::Expr, usize)>>,
 ) -> Result<()> {
     let order_by_len = order_by.len();
-    let result_columns_to_skip = orderby_deduplicate_result_columns(order_by, result_columns);
+    let result_columns_to_skip = order_by_deduplicate_result_columns(order_by, result_columns);
     let result_columns_to_skip_len = result_columns_to_skip
         .as_ref()
         .map(|v| v.len())
@@ -1699,7 +1700,7 @@ fn order_by_sorter_insert(
 /// should be emitted in the SELECT clause order, not the ORDER BY clause order.
 ///
 /// If any result columsn can be skipped, returns list of 2-tuples of (SkippedResultColumnIndex: usize, ResultColumnIndexInOrderBySorter: usize)
-fn orderby_deduplicate_result_columns(
+fn order_by_deduplicate_result_columns(
     order_by: &Vec<(ast::Expr, Direction)>,
     result_columns: &Vec<ResultSetColumn>,
 ) -> Option<Vec<(usize, usize)>> {

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -3,7 +3,7 @@ use sqlite3_parser::ast::{self, UnaryOperator};
 #[cfg(feature = "json")]
 use crate::function::JsonFunc;
 use crate::function::{AggFunc, Func, FuncCtx, ScalarFunc};
-use crate::schema::{PseudoTable, Table, Type};
+use crate::schema::Type;
 use crate::util::normalize_ident;
 use crate::vdbe::{builder::ProgramBuilder, BranchOffset, Insn};
 use crate::Result;

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -21,7 +21,6 @@ pub fn translate_condition_expr(
     program: &mut ProgramBuilder,
     referenced_tables: &[BTreeTableReference],
     expr: &ast::Expr,
-    cursor_hint: Option<usize>,
     condition_metadata: ConditionMetadata,
     precomputed_exprs_to_registers: Option<&Vec<(&ast::Expr, usize)>>,
 ) -> Result<()> {
@@ -34,7 +33,6 @@ pub fn translate_condition_expr(
                 program,
                 referenced_tables,
                 lhs,
-                cursor_hint,
                 ConditionMetadata {
                     jump_if_condition_is_true: false,
                     ..condition_metadata
@@ -45,7 +43,6 @@ pub fn translate_condition_expr(
                 program,
                 referenced_tables,
                 rhs,
-                cursor_hint,
                 condition_metadata,
                 precomputed_exprs_to_registers,
             );
@@ -56,7 +53,6 @@ pub fn translate_condition_expr(
                 program,
                 referenced_tables,
                 lhs,
-                cursor_hint,
                 ConditionMetadata {
                     // If the first condition is true, we don't need to evaluate the second condition.
                     jump_if_condition_is_true: true,
@@ -70,7 +66,6 @@ pub fn translate_condition_expr(
                 program,
                 referenced_tables,
                 rhs,
-                cursor_hint,
                 condition_metadata,
                 precomputed_exprs_to_registers,
             );
@@ -82,7 +77,6 @@ pub fn translate_condition_expr(
                 Some(referenced_tables),
                 lhs,
                 lhs_reg,
-                cursor_hint,
                 precomputed_exprs_to_registers,
             );
             if let ast::Expr::Literal(_) = lhs.as_ref() {
@@ -94,7 +88,6 @@ pub fn translate_condition_expr(
                 Some(referenced_tables),
                 rhs,
                 rhs_reg,
-                cursor_hint,
                 precomputed_exprs_to_registers,
             );
             if let ast::Expr::Literal(_) = rhs.as_ref() {
@@ -343,7 +336,6 @@ pub fn translate_condition_expr(
                 Some(referenced_tables),
                 lhs,
                 lhs_reg,
-                cursor_hint,
                 precomputed_exprs_to_registers,
             )?;
 
@@ -373,7 +365,6 @@ pub fn translate_condition_expr(
                         Some(referenced_tables),
                         expr,
                         rhs_reg,
-                        cursor_hint,
                         precomputed_exprs_to_registers,
                     )?;
                     // If this is not the last condition, we need to jump to the 'jump_target_when_true' label if the condition is true.
@@ -417,7 +408,6 @@ pub fn translate_condition_expr(
                         Some(referenced_tables),
                         expr,
                         rhs_reg,
-                        cursor_hint,
                         precomputed_exprs_to_registers,
                     )?;
                     program.emit_insn_with_label_dependency(
@@ -463,7 +453,6 @@ pub fn translate_condition_expr(
                         Some(referenced_tables),
                         lhs,
                         column_reg,
-                        cursor_hint,
                         precomputed_exprs_to_registers,
                     )?;
                     if let ast::Expr::Literal(_) = lhs.as_ref() {
@@ -474,7 +463,6 @@ pub fn translate_condition_expr(
                         Some(referenced_tables),
                         rhs,
                         pattern_reg,
-                        cursor_hint,
                         precomputed_exprs_to_registers,
                     )?;
                     if let ast::Expr::Literal(_) = rhs.as_ref() {
@@ -547,7 +535,6 @@ pub fn translate_condition_expr(
                     program,
                     referenced_tables,
                     expr,
-                    cursor_hint,
                     condition_metadata,
                     precomputed_exprs_to_registers,
                 );
@@ -563,7 +550,6 @@ pub fn translate_expr(
     referenced_tables: Option<&[BTreeTableReference]>,
     expr: &ast::Expr,
     target_register: usize,
-    cursor_hint: Option<usize>,
     precomputed_exprs_to_registers: Option<&Vec<(&ast::Expr, usize)>>,
 ) -> Result<usize> {
     if let Some(precomputed_exprs_to_registers) = precomputed_exprs_to_registers {
@@ -590,7 +576,6 @@ pub fn translate_expr(
                 referenced_tables,
                 e1,
                 e1_reg,
-                cursor_hint,
                 precomputed_exprs_to_registers,
             )?;
             let e2_reg = program.alloc_register();
@@ -599,7 +584,6 @@ pub fn translate_expr(
                 referenced_tables,
                 e2,
                 e2_reg,
-                cursor_hint,
                 precomputed_exprs_to_registers,
             )?;
 
@@ -723,7 +707,6 @@ pub fn translate_expr(
                 referenced_tables,
                 expr,
                 reg_expr,
-                cursor_hint,
                 precomputed_exprs_to_registers,
             )?;
             let reg_type = program.alloc_register();
@@ -796,7 +779,6 @@ pub fn translate_expr(
                             referenced_tables,
                             &args[0],
                             regs,
-                            cursor_hint,
                             precomputed_exprs_to_registers,
                         )?;
                         program.emit_insn(Insn::Function {
@@ -823,7 +805,6 @@ pub fn translate_expr(
                                     referenced_tables,
                                     arg,
                                     reg,
-                                    cursor_hint,
                                     precomputed_exprs_to_registers,
                                 )?;
                             }
@@ -861,7 +842,6 @@ pub fn translate_expr(
                                     referenced_tables,
                                     arg,
                                     target_register,
-                                    cursor_hint,
                                     precomputed_exprs_to_registers,
                                 )?;
                                 if index < args.len() - 1 {
@@ -897,7 +877,6 @@ pub fn translate_expr(
                                     referenced_tables,
                                     arg,
                                     reg,
-                                    cursor_hint,
                                     precomputed_exprs_to_registers,
                                 )?;
                             }
@@ -930,7 +909,6 @@ pub fn translate_expr(
                                     referenced_tables,
                                     arg,
                                     reg,
-                                    cursor_hint,
                                     precomputed_exprs_to_registers,
                                 )?;
                             }
@@ -967,7 +945,6 @@ pub fn translate_expr(
                                 referenced_tables,
                                 &args[0],
                                 temp_reg,
-                                cursor_hint,
                                 precomputed_exprs_to_registers,
                             )?;
                             program.emit_insn(Insn::NotNull {
@@ -980,7 +957,6 @@ pub fn translate_expr(
                                 referenced_tables,
                                 &args[1],
                                 temp_reg,
-                                cursor_hint,
                                 precomputed_exprs_to_registers,
                             )?;
                             program.emit_insn(Insn::Copy {
@@ -1013,7 +989,6 @@ pub fn translate_expr(
                                     referenced_tables,
                                     arg,
                                     reg,
-                                    cursor_hint,
                                     precomputed_exprs_to_registers,
                                 )?;
                                 if let ast::Expr::Literal(_) = arg {
@@ -1061,7 +1036,6 @@ pub fn translate_expr(
                                 referenced_tables,
                                 &args[0],
                                 regs,
-                                cursor_hint,
                                 precomputed_exprs_to_registers,
                             )?;
                             program.emit_insn(Insn::Function {
@@ -1098,7 +1072,6 @@ pub fn translate_expr(
                                         referenced_tables,
                                         arg,
                                         target_reg,
-                                        cursor_hint,
                                         precomputed_exprs_to_registers,
                                     )?;
                                 }
@@ -1136,7 +1109,6 @@ pub fn translate_expr(
                                 referenced_tables,
                                 &args[0],
                                 str_reg,
-                                cursor_hint,
                                 precomputed_exprs_to_registers,
                             )?;
                             translate_expr(
@@ -1144,7 +1116,6 @@ pub fn translate_expr(
                                 referenced_tables,
                                 &args[1],
                                 start_reg,
-                                cursor_hint,
                                 precomputed_exprs_to_registers,
                             )?;
                             if args.len() == 3 {
@@ -1153,7 +1124,6 @@ pub fn translate_expr(
                                     referenced_tables,
                                     &args[2],
                                     length_reg,
-                                    cursor_hint,
                                     precomputed_exprs_to_registers,
                                 )?;
                             }
@@ -1183,7 +1153,6 @@ pub fn translate_expr(
                                 referenced_tables,
                                 &args[0],
                                 regs,
-                                cursor_hint,
                                 precomputed_exprs_to_registers,
                             )?;
                             program.emit_insn(Insn::Function {
@@ -1207,7 +1176,6 @@ pub fn translate_expr(
                                         referenced_tables,
                                         &args[0],
                                         arg_reg,
-                                        cursor_hint,
                                         precomputed_exprs_to_registers,
                                     )?;
                                     start_reg = arg_reg;
@@ -1232,7 +1200,6 @@ pub fn translate_expr(
                                         referenced_tables,
                                         arg,
                                         target_reg,
-                                        cursor_hint,
                                         precomputed_exprs_to_registers,
                                     )?;
                                 }
@@ -1272,7 +1239,6 @@ pub fn translate_expr(
                                     referenced_tables,
                                     arg,
                                     reg,
-                                    cursor_hint,
                                     precomputed_exprs_to_registers,
                                 )?;
                                 if let ast::Expr::Literal(_) = arg {
@@ -1305,7 +1271,6 @@ pub fn translate_expr(
                                     referenced_tables,
                                     arg,
                                     reg,
-                                    cursor_hint,
                                     precomputed_exprs_to_registers,
                                 )?;
                                 if let ast::Expr::Literal(_) = arg {
@@ -1339,7 +1304,6 @@ pub fn translate_expr(
                                     referenced_tables,
                                     arg,
                                     reg,
-                                    cursor_hint,
                                     precomputed_exprs_to_registers,
                                 )?;
                                 if let ast::Expr::Literal(_) = arg {
@@ -1377,7 +1341,6 @@ pub fn translate_expr(
                                 referenced_tables,
                                 &args[0],
                                 first_reg,
-                                cursor_hint,
                                 precomputed_exprs_to_registers,
                             )?;
                             let second_reg = program.alloc_register();
@@ -1386,7 +1349,6 @@ pub fn translate_expr(
                                 referenced_tables,
                                 &args[1],
                                 second_reg,
-                                cursor_hint,
                                 precomputed_exprs_to_registers,
                             )?;
                             program.emit_insn(Insn::Function {
@@ -1431,7 +1393,7 @@ pub fn translate_expr(
             is_rowid_alias: is_primary_key,
         } => {
             let tbl_ref = referenced_tables.as_ref().unwrap().get(*table).unwrap();
-            let cursor_id = program.resolve_cursor_id(&tbl_ref.table_identifier, cursor_hint);
+            let cursor_id = program.resolve_cursor_id(&tbl_ref.table_identifier);
             if *is_primary_key {
                 program.emit_insn(Insn::RowId {
                     cursor_id,
@@ -1518,7 +1480,6 @@ pub fn translate_expr(
                     referenced_tables,
                     &exprs[0],
                     target_register,
-                    cursor_hint,
                     precomputed_exprs_to_registers,
                 )?;
             } else {
@@ -1586,7 +1547,6 @@ pub fn translate_aggregation(
     referenced_tables: &[BTreeTableReference],
     agg: &Aggregate,
     target_register: usize,
-    cursor_hint: Option<usize>,
 ) -> Result<usize> {
     let dest = match agg.func {
         AggFunc::Avg => {
@@ -1595,14 +1555,7 @@ pub fn translate_aggregation(
             }
             let expr = &agg.args[0];
             let expr_reg = program.alloc_register();
-            let _ = translate_expr(
-                program,
-                Some(referenced_tables),
-                expr,
-                expr_reg,
-                cursor_hint,
-                None,
-            )?;
+            let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, None)?;
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: expr_reg,
@@ -1617,14 +1570,7 @@ pub fn translate_aggregation(
             } else {
                 let expr = &agg.args[0];
                 let expr_reg = program.alloc_register();
-                let _ = translate_expr(
-                    program,
-                    Some(referenced_tables),
-                    expr,
-                    expr_reg,
-                    cursor_hint,
-                    None,
-                );
+                let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, None);
                 expr_reg
             };
             program.emit_insn(Insn::AggStep {
@@ -1660,20 +1606,12 @@ pub fn translate_aggregation(
                 delimiter_expr = ast::Expr::Literal(ast::Literal::String(String::from("\",\"")));
             }
 
-            translate_expr(
-                program,
-                Some(referenced_tables),
-                expr,
-                expr_reg,
-                cursor_hint,
-                None,
-            )?;
+            translate_expr(program, Some(referenced_tables), expr, expr_reg, None)?;
             translate_expr(
                 program,
                 Some(referenced_tables),
                 &delimiter_expr,
                 delimiter_reg,
-                cursor_hint,
                 None,
             )?;
 
@@ -1692,14 +1630,7 @@ pub fn translate_aggregation(
             }
             let expr = &agg.args[0];
             let expr_reg = program.alloc_register();
-            let _ = translate_expr(
-                program,
-                Some(referenced_tables),
-                expr,
-                expr_reg,
-                cursor_hint,
-                None,
-            )?;
+            let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, None)?;
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: expr_reg,
@@ -1714,14 +1645,7 @@ pub fn translate_aggregation(
             }
             let expr = &agg.args[0];
             let expr_reg = program.alloc_register();
-            let _ = translate_expr(
-                program,
-                Some(referenced_tables),
-                expr,
-                expr_reg,
-                cursor_hint,
-                None,
-            )?;
+            let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, None)?;
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: expr_reg,
@@ -1751,20 +1675,12 @@ pub fn translate_aggregation(
                 _ => crate::bail_parse_error!("Incorrect delimiter parameter"),
             };
 
-            translate_expr(
-                program,
-                Some(referenced_tables),
-                expr,
-                expr_reg,
-                cursor_hint,
-                None,
-            )?;
+            translate_expr(program, Some(referenced_tables), expr, expr_reg, None)?;
             translate_expr(
                 program,
                 Some(referenced_tables),
                 &delimiter_expr,
                 delimiter_reg,
-                cursor_hint,
                 None,
             )?;
 
@@ -1783,14 +1699,7 @@ pub fn translate_aggregation(
             }
             let expr = &agg.args[0];
             let expr_reg = program.alloc_register();
-            let _ = translate_expr(
-                program,
-                Some(referenced_tables),
-                expr,
-                expr_reg,
-                cursor_hint,
-                None,
-            )?;
+            let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, None)?;
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: expr_reg,
@@ -1805,14 +1714,7 @@ pub fn translate_aggregation(
             }
             let expr = &agg.args[0];
             let expr_reg = program.alloc_register();
-            let _ = translate_expr(
-                program,
-                Some(referenced_tables),
-                expr,
-                expr_reg,
-                cursor_hint,
-                None,
-            )?;
+            let _ = translate_expr(program, Some(referenced_tables), expr, expr_reg, None)?;
             program.emit_insn(Insn::AggStep {
                 acc_reg: target_register,
                 col: expr_reg,
@@ -1897,7 +1799,6 @@ pub fn translate_aggregation_groupby(
                 &delimiter_expr,
                 delimiter_reg,
                 None,
-                None,
             )?;
 
             program.emit_insn(Insn::AggStep {
@@ -1963,7 +1864,6 @@ pub fn translate_aggregation_groupby(
                 Some(referenced_tables),
                 &delimiter_expr,
                 delimiter_reg,
-                None,
                 None,
             )?;
 

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -568,6 +568,9 @@ pub fn translate_expr(
 ) -> Result<usize> {
     if let Some(precomputed_exprs_to_registers) = precomputed_exprs_to_registers {
         for (precomputed_expr, reg) in precomputed_exprs_to_registers.iter() {
+            // TODO: implement a custom equality check for expressions
+            // there are lots of examples where this breaks, even simple ones like
+            // sum(x) != SUM(x)
             if expr == *precomputed_expr {
                 program.emit_insn(Insn::Copy {
                     src_reg: *reg,

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -98,7 +98,7 @@ pub fn translate_insert(
                                 expr,
                                 column_registers_start + col,
                                 None,
-                                None,
+                                0,
                             )?;
                         }
                         program.emit_insn(Insn::Yield {

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -98,7 +98,6 @@ pub fn translate_insert(
                                 expr,
                                 column_registers_start + col,
                                 None,
-                                None,
                             )?;
                         }
                         program.emit_insn(Insn::Yield {

--- a/core/translate/insert.rs
+++ b/core/translate/insert.rs
@@ -98,7 +98,7 @@ pub fn translate_insert(
                                 expr,
                                 column_registers_start + col,
                                 None,
-                                0,
+                                None,
                             )?;
                         }
                         program.emit_insn(Insn::Yield {

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -20,21 +20,7 @@ pub fn optimize_plan(mut select_plan: Plan) -> Result<Plan> {
         &mut select_plan.where_clause,
         &select_plan.referenced_tables,
     )?;
-    if eliminate_constants(&mut select_plan.source)?
-        == ConstantConditionEliminationResult::ImpossibleCondition
-    {
-        return Ok(Plan {
-            source: SourceOperator::Nothing,
-            aggregates: None,
-            result_columns: vec![],
-            where_clause: None,
-            group_by: None,
-            order_by: None,
-            limit: None,
-            referenced_tables: select_plan.referenced_tables,
-            available_indexes: select_plan.available_indexes,
-        });
-    }
+    eliminate_constants(&mut select_plan.source)?;
     use_indexes(
         &mut select_plan.source,
         &select_plan.referenced_tables,

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -90,12 +90,13 @@ fn eliminate_unnecessary_orderby(
         return Ok(());
     }
 
-    let (key, _) = o.first_mut().unwrap();
+    let (key, direction) = o.first_mut().unwrap();
 
     let already_ordered =
         _operator_is_already_ordered_by(operator, key, referenced_tables, available_indexes)?;
 
     if already_ordered {
+        push_scan_direction(operator, direction);
         *order_by = None;
     }
 

--- a/core/translate/optimizer.rs
+++ b/core/translate/optimizer.rs
@@ -25,7 +25,14 @@ pub fn optimize_plan(mut select_plan: Plan) -> Result<Plan> {
     {
         return Ok(Plan {
             source: SourceOperator::Nothing,
-            ..select_plan
+            aggregates: None,
+            result_columns: vec![],
+            where_clause: None,
+            group_by: None,
+            order_by: None,
+            limit: None,
+            referenced_tables: select_plan.referenced_tables,
+            available_indexes: select_plan.available_indexes,
         });
     }
     use_indexes(
@@ -478,7 +485,7 @@ impl Optimizable for ast::Expr {
             ast::Expr::Column {
                 table,
                 column,
-                is_primary_key,
+                is_rowid_alias: is_primary_key,
                 ..
             } => *is_primary_key && *table == table_index,
             _ => false,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -14,9 +14,11 @@ use crate::{
 
 #[derive(Debug)]
 pub enum ResultSetColumn {
-    Scalar(ast::Expr),
+    Expr {
+        expr: ast::Expr,
+        contains_aggregates: bool,
+    },
     Agg(Aggregate),
-    ComputedAgg(ast::Expr),
 }
 
 #[derive(Debug)]

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -13,12 +13,10 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub enum ResultSetColumn {
-    Expr {
-        expr: ast::Expr,
-        contains_aggregates: bool,
-    },
-    Agg(Aggregate),
+pub struct ResultSetColumn {
+    pub expr: ast::Expr,
+    // TODO: encode which aggregates (e.g. index bitmask of plan.aggregates) are present in this column
+    pub contains_aggregates: bool,
 }
 
 #[derive(Debug)]

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -21,14 +21,23 @@ pub struct ResultSetColumn {
 
 #[derive(Debug)]
 pub struct Plan {
+    /// A tree of sources (tables).
     pub source: SourceOperator,
+    /// the columns inside SELECT ... FROM
     pub result_columns: Vec<ResultSetColumn>,
+    /// where clause split into a vec at 'AND' boundaries.
     pub where_clause: Option<Vec<ast::Expr>>,
+    /// group by clause
     pub group_by: Option<Vec<ast::Expr>>,
+    /// order by clause
     pub order_by: Option<Vec<(ast::Expr, Direction)>>,
+    /// all the aggregates collected from the result columns, order by, and (TODO) having clauses
     pub aggregates: Option<Vec<Aggregate>>,
+    /// limit clause
     pub limit: Option<usize>,
+    /// all the tables referenced in the query
     pub referenced_tables: Vec<BTreeTableReference>,
+    /// all the indexes available
     pub available_indexes: Vec<Rc<Index>>,
 }
 

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -130,48 +130,6 @@ pub enum Search {
 }
 
 impl SourceOperator {
-    pub fn column_count(&self, referenced_tables: &[BTreeTableReference]) -> usize {
-        match self {
-            SourceOperator::Join { left, right, .. } => {
-                left.column_count(referenced_tables) + right.column_count(referenced_tables)
-            }
-            SourceOperator::Scan {
-                table_reference, ..
-            } => table_reference.table.columns.len(),
-            SourceOperator::Search {
-                table_reference, ..
-            } => table_reference.table.columns.len(),
-            SourceOperator::Nothing => 0,
-        }
-    }
-
-    pub fn column_names(&self) -> Vec<String> {
-        match self {
-            SourceOperator::Join { left, right, .. } => {
-                let mut names = left.column_names();
-                names.extend(right.column_names());
-                names
-            }
-            SourceOperator::Scan {
-                table_reference, ..
-            } => table_reference
-                .table
-                .columns
-                .iter()
-                .map(|c| c.name.clone())
-                .collect(),
-            SourceOperator::Search {
-                table_reference, ..
-            } => table_reference
-                .table
-                .columns
-                .iter()
-                .map(|c| c.name.clone())
-                .collect(),
-            SourceOperator::Nothing => vec![],
-        }
-    }
-
     pub fn id(&self) -> usize {
         match self {
             SourceOperator::Join { id, .. } => *id,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -54,17 +54,7 @@ pub enum IterationDirection {
 }
 
 /**
-  An Operator is a Node in the query plan.
-  Operators form a tree structure, with each having zero or more children.
-  For example, a query like `SELECT t1.foo FROM t1 ORDER BY t1.foo LIMIT 1` would have the following structure:
-    Limit
-      Order
-        Project
-          Scan
-
-  Operators also have a unique ID, which is used to identify them in the query plan and attach metadata.
-  They also have a step counter, which is used to track the current step in the operator's execution.
-  TODO: perhaps 'step' shouldn't be in this struct, since it's an execution time concept, not a plan time concept.
+  A SourceOperator is a Node in the query plan that reads data from a table.
 */
 #[derive(Clone, Debug)]
 pub enum SourceOperator {

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1,4 +1,6 @@
-use super::plan::{Aggregate, BTreeTableReference, Direction, Operator, Plan, ProjectionColumn};
+use super::plan::{
+    Aggregate, BTreeTableReference, Direction, Plan, ResultSetColumn, SourceOperator,
+};
 use crate::{function::Func, schema::Schema, util::normalize_ident, Result};
 use sqlite3_parser::ast::{self, FromClause, JoinType, ResultColumn};
 
@@ -66,6 +68,7 @@ fn bind_column_references(
     referenced_tables: &[BTreeTableReference],
 ) -> Result<()> {
     match expr {
+        ast::Expr::AggRef { .. } => unreachable!(),
         ast::Expr::Id(id) => {
             let mut match_result = None;
             for (tbl_idx, table) in referenced_tables.iter().enumerate() {
@@ -237,146 +240,157 @@ pub fn prepare_select_plan<'a>(schema: &Schema, select: ast::Select) -> Result<P
             let mut operator_id_counter = OperatorIdCounter::new();
 
             // Parse the FROM clause
-            let (mut operator, referenced_tables) =
+            let (mut source, referenced_tables) =
                 parse_from(schema, from, &mut operator_id_counter)?;
+
+            let mut plan = Plan {
+                source,
+                result_columns: vec![],
+                where_clause: None,
+                group_by: None,
+                order_by: None,
+                aggregates: None,
+                limit: None,
+                referenced_tables,
+                available_indexes: schema.indexes.clone().into_values().flatten().collect(),
+            };
 
             // Parse the WHERE clause
             if let Some(w) = where_clause {
                 let mut predicates = vec![];
                 break_predicate_at_and_boundaries(w, &mut predicates);
                 for expr in predicates.iter_mut() {
-                    bind_column_references(expr, &referenced_tables)?;
+                    bind_column_references(expr, &plan.referenced_tables)?;
                 }
-                operator = Operator::Filter {
-                    source: Box::new(operator),
-                    predicates,
-                    id: operator_id_counter.get_next_id(),
-                };
+                plan.where_clause = Some(predicates);
             }
 
-            // If there are aggregate functions, we aggregate + project the columns.
-            // If there are no aggregate functions, we can simply project the columns.
-            // For a simple SELECT *, the projection operator is skipped as well.
-            let is_select_star = col_count == 1 && matches!(columns[0], ast::ResultColumn::Star);
-            if !is_select_star {
-                let mut aggregate_expressions = Vec::new();
-                let mut projection_expressions = Vec::with_capacity(col_count);
-                for column in columns.clone() {
-                    match column {
-                        ast::ResultColumn::Star => {
-                            projection_expressions.push(ProjectionColumn::Star);
-                        }
-                        ast::ResultColumn::TableStar(name) => {
-                            let name_normalized = normalize_ident(name.0.as_str());
-                            let referenced_table = referenced_tables
-                                .iter()
-                                .find(|t| t.table_identifier == name_normalized);
-
-                            if referenced_table.is_none() {
-                                crate::bail_parse_error!("Table {} not found", name.0);
+            let mut aggregate_expressions = Vec::new();
+            for column in columns.clone() {
+                match column {
+                    ast::ResultColumn::Star => {
+                        for table_reference in plan.referenced_tables.iter() {
+                            for (idx, col) in table_reference.table.columns.iter().enumerate() {
+                                plan.result_columns.push(ResultSetColumn::Scalar(
+                                    ast::Expr::Column {
+                                        database: None, // TODO: support different databases
+                                        table: table_reference.table_index,
+                                        column: idx,
+                                        is_primary_key: col.primary_key,
+                                    },
+                                ));
                             }
-                            let table_reference = referenced_table.unwrap();
-                            projection_expressions
-                                .push(ProjectionColumn::TableStar(table_reference.clone()));
                         }
-                        ast::ResultColumn::Expr(mut expr, _) => {
-                            bind_column_references(&mut expr, &referenced_tables)?;
-                            projection_expressions.push(ProjectionColumn::Column(expr.clone()));
-                            match expr.clone() {
-                                ast::Expr::FunctionCall {
-                                    name,
-                                    distinctness: _,
-                                    args,
-                                    filter_over: _,
-                                    order_by: _,
-                                } => {
-                                    let args_count = if let Some(args) = &args {
-                                        args.len()
-                                    } else {
-                                        0
-                                    };
-                                    match Func::resolve_function(
-                                        normalize_ident(name.0.as_str()).as_str(),
-                                        args_count,
-                                    ) {
-                                        Ok(Func::Agg(f)) => {
-                                            aggregate_expressions.push(Aggregate {
-                                                func: f,
-                                                args: args.unwrap(),
-                                                original_expr: expr.clone(),
-                                            });
-                                        }
-                                        Ok(_) => {
-                                            resolve_aggregates(&expr, &mut aggregate_expressions);
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                                ast::Expr::FunctionCallStar {
-                                    name,
-                                    filter_over: _,
-                                } => {
-                                    if let Ok(Func::Agg(f)) = Func::resolve_function(
-                                        normalize_ident(name.0.as_str()).as_str(),
-                                        0,
-                                    ) {
-                                        aggregate_expressions.push(Aggregate {
+                    }
+                    ast::ResultColumn::TableStar(name) => {
+                        let name_normalized = normalize_ident(name.0.as_str());
+                        let referenced_table = plan
+                            .referenced_tables
+                            .iter()
+                            .find(|t| t.table_identifier == name_normalized);
+
+                        if referenced_table.is_none() {
+                            crate::bail_parse_error!("Table {} not found", name.0);
+                        }
+                        let table_reference = referenced_table.unwrap();
+                        for (idx, col) in table_reference.table.columns.iter().enumerate() {
+                            plan.result_columns
+                                .push(ResultSetColumn::Scalar(ast::Expr::Column {
+                                    database: None, // TODO: support different databases
+                                    table: table_reference.table_index,
+                                    column: idx,
+                                    is_primary_key: col.primary_key,
+                                }));
+                        }
+                    }
+                    ast::ResultColumn::Expr(mut expr, _) => {
+                        bind_column_references(&mut expr, &plan.referenced_tables)?;
+                        match &expr {
+                            ast::Expr::FunctionCall {
+                                name,
+                                distinctness: _,
+                                args,
+                                filter_over: _,
+                                order_by: _,
+                            } => {
+                                let args_count = if let Some(args) = &args {
+                                    args.len()
+                                } else {
+                                    0
+                                };
+                                match Func::resolve_function(
+                                    normalize_ident(name.0.as_str()).as_str(),
+                                    args_count,
+                                ) {
+                                    Ok(Func::Agg(f)) => {
+                                        let agg = Aggregate {
                                             func: f,
-                                            args: vec![ast::Expr::Literal(ast::Literal::Numeric(
-                                                "1".to_string(),
-                                            ))],
+                                            args: args.as_ref().unwrap().clone(),
                                             original_expr: expr.clone(),
-                                        });
+                                        };
+                                        aggregate_expressions.push(agg.clone());
+                                        plan.result_columns.push(ResultSetColumn::Agg(agg));
                                     }
+                                    Ok(_) => {
+                                        resolve_aggregates(&expr, &mut aggregate_expressions);
+                                    }
+                                    _ => {}
                                 }
-                                ast::Expr::Binary(lhs, _, rhs) => {
-                                    resolve_aggregates(&lhs, &mut aggregate_expressions);
-                                    resolve_aggregates(&rhs, &mut aggregate_expressions);
+                            }
+                            ast::Expr::FunctionCallStar {
+                                name,
+                                filter_over: _,
+                            } => {
+                                if let Ok(Func::Agg(f)) = Func::resolve_function(
+                                    normalize_ident(name.0.as_str()).as_str(),
+                                    0,
+                                ) {
+                                    let agg = Aggregate {
+                                        func: f,
+                                        args: vec![ast::Expr::Literal(ast::Literal::Numeric(
+                                            "1".to_string(),
+                                        ))],
+                                        original_expr: expr.clone(),
+                                    };
+                                    aggregate_expressions.push(agg.clone());
+                                    plan.result_columns.push(ResultSetColumn::Agg(agg));
+                                } else {
+                                    crate::bail_parse_error!(
+                                        "Invalid aggregate function: {}",
+                                        name.0
+                                    );
                                 }
-                                _ => {}
+                            }
+                            ast::Expr::Binary(lhs, _, rhs) => {
+                                resolve_aggregates(&lhs, &mut aggregate_expressions);
+                                resolve_aggregates(&rhs, &mut aggregate_expressions);
+                                plan.result_columns
+                                    .push(ResultSetColumn::Scalar(expr.clone()));
+                            }
+                            e => {
+                                plan.result_columns.push(ResultSetColumn::Scalar(e.clone()));
                             }
                         }
                     }
-                }
-                if let Some(group_by) = group_by.as_mut() {
-                    for expr in group_by.exprs.iter_mut() {
-                        bind_column_references(expr, &referenced_tables)?;
-                    }
-                    if aggregate_expressions.is_empty() {
-                        crate::bail_parse_error!(
-                            "GROUP BY clause without aggregate functions is not allowed"
-                        );
-                    }
-                    for scalar in projection_expressions.iter() {
-                        match scalar {
-                            ProjectionColumn::Column(_) => {}
-                            _ => {
-                                crate::bail_parse_error!(
-                                    "Only column references are allowed in the SELECT clause when using GROUP BY"
-                                );
-                            }
-                        }
-                    }
-                }
-                if !aggregate_expressions.is_empty() {
-                    operator = Operator::Aggregate {
-                        source: Box::new(operator),
-                        aggregates: aggregate_expressions,
-                        group_by: group_by.map(|g| g.exprs), // TODO: support HAVING
-                        id: operator_id_counter.get_next_id(),
-                        step: 0,
-                    }
-                }
-
-                if !projection_expressions.is_empty() {
-                    operator = Operator::Projection {
-                        source: Box::new(operator),
-                        expressions: projection_expressions,
-                        id: operator_id_counter.get_next_id(),
-                        step: 0,
-                    };
                 }
             }
+            if let Some(group_by) = group_by.as_mut() {
+                for expr in group_by.exprs.iter_mut() {
+                    bind_column_references(expr, &plan.referenced_tables)?;
+                }
+                if aggregate_expressions.is_empty() {
+                    crate::bail_parse_error!(
+                        "GROUP BY clause without aggregate functions is not allowed"
+                    );
+                }
+            }
+
+            plan.group_by = group_by.map(|g| g.exprs);
+            plan.aggregates = if aggregate_expressions.is_empty() {
+                None
+            } else {
+                Some(aggregate_expressions)
+            };
 
             // Parse the ORDER BY clause
             if let Some(order_by) = select.order_by {
@@ -402,7 +416,7 @@ pub fn prepare_select_plan<'a>(schema: &Schema, select: ast::Select) -> Result<P
                         o.expr
                     };
 
-                    bind_column_references(&mut expr, &referenced_tables)?;
+                    bind_column_references(&mut expr, &plan.referenced_tables)?;
 
                     key.push((
                         expr,
@@ -412,40 +426,22 @@ pub fn prepare_select_plan<'a>(schema: &Schema, select: ast::Select) -> Result<P
                         }),
                     ));
                 }
-                operator = Operator::Order {
-                    source: Box::new(operator),
-                    key,
-                    id: operator_id_counter.get_next_id(),
-                    step: 0,
-                };
+                plan.order_by = Some(key);
             }
 
             // Parse the LIMIT clause
             if let Some(limit) = &select.limit {
-                operator = match &limit.expr {
+                plan.limit = match &limit.expr {
                     ast::Expr::Literal(ast::Literal::Numeric(n)) => {
                         let l = n.parse()?;
-                        if l == 0 {
-                            Operator::Nothing
-                        } else {
-                            Operator::Limit {
-                                source: Box::new(operator),
-                                limit: l,
-                                id: operator_id_counter.get_next_id(),
-                                step: 0,
-                            }
-                        }
+                        Some(l)
                     }
                     _ => todo!(),
                 }
             }
 
             // Return the unoptimized query plan
-            Ok(Plan {
-                root_operator: operator,
-                referenced_tables,
-                available_indexes: schema.indexes.clone().into_values().flatten().collect(),
-            })
+            Ok(plan)
         }
         _ => todo!(),
     }
@@ -456,9 +452,9 @@ fn parse_from(
     schema: &Schema,
     from: Option<FromClause>,
     operator_id_counter: &mut OperatorIdCounter,
-) -> Result<(Operator, Vec<BTreeTableReference>)> {
+) -> Result<(SourceOperator, Vec<BTreeTableReference>)> {
     if from.as_ref().and_then(|f| f.select.as_ref()).is_none() {
-        return Ok((Operator::Nothing, vec![]));
+        return Ok((SourceOperator::Nothing, vec![]));
     }
 
     let from = from.unwrap();
@@ -484,11 +480,10 @@ fn parse_from(
         _ => todo!(),
     };
 
-    let mut operator = Operator::Scan {
+    let mut operator = SourceOperator::Scan {
         table_reference: first_table.clone(),
         predicates: None,
         id: operator_id_counter.get_next_id(),
-        step: 0,
         iter_dir: None,
     };
 
@@ -498,13 +493,12 @@ fn parse_from(
     for join in from.joins.unwrap_or_default().into_iter() {
         let (right, outer, predicates) =
             parse_join(schema, join, operator_id_counter, &mut tables, table_index)?;
-        operator = Operator::Join {
+        operator = SourceOperator::Join {
             left: Box::new(operator),
             right: Box::new(right),
             predicates,
             outer,
             id: operator_id_counter.get_next_id(),
-            step: 0,
         };
         table_index += 1;
     }
@@ -518,7 +512,7 @@ fn parse_join(
     operator_id_counter: &mut OperatorIdCounter,
     tables: &mut Vec<BTreeTableReference>,
     table_index: usize,
-) -> Result<(Operator, bool, Option<Vec<ast::Expr>>)> {
+) -> Result<(SourceOperator, bool, Option<Vec<ast::Expr>>)> {
     let ast::JoinedSelectTable {
         operator,
         table,
@@ -574,11 +568,10 @@ fn parse_join(
     }
 
     Ok((
-        Operator::Scan {
+        SourceOperator::Scan {
             table_reference: table.clone(),
             predicates: None,
             id: operator_id_counter.get_next_id(),
-            step: 0,
             iter_dir: None,
         },
         outer,

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -18,6 +18,5 @@ pub fn translate_select(
 ) -> Result<Program> {
     let select_plan = prepare_select_plan(schema, select)?;
     let optimized_plan = optimize_plan(select_plan)?;
-    // println!("optimized_plan: {:?}", optimized_plan);
     emit_program(database_header, optimized_plan, connection)
 }

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -17,12 +17,7 @@ pub fn translate_select(
     connection: Weak<Connection>,
 ) -> Result<Program> {
     let select_plan = prepare_select_plan(schema, select)?;
-    let (optimized_plan, expr_result_cache) = optimize_plan(select_plan)?;
-    println!("{:?}", expr_result_cache);
-    emit_program(
-        database_header,
-        optimized_plan,
-        expr_result_cache,
-        connection,
-    )
+    let optimized_plan = optimize_plan(select_plan)?;
+    // println!("optimized_plan: {:?}", optimized_plan);
+    emit_program(database_header, optimized_plan, connection)
 }

--- a/core/translate/select.rs
+++ b/core/translate/select.rs
@@ -18,6 +18,7 @@ pub fn translate_select(
 ) -> Result<Program> {
     let select_plan = prepare_select_plan(schema, select)?;
     let (optimized_plan, expr_result_cache) = optimize_plan(select_plan)?;
+    println!("{:?}", expr_result_cache);
     emit_program(
         database_header,
         optimized_plan,

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -343,14 +343,7 @@ impl ProgramBuilder {
     }
 
     // translate table to cursor id
-    pub fn resolve_cursor_id(
-        &self,
-        table_identifier: &str,
-        cursor_hint: Option<CursorID>,
-    ) -> CursorID {
-        if let Some(cursor_hint) = cursor_hint {
-            return cursor_hint;
-        }
+    pub fn resolve_cursor_id(&self, table_identifier: &str) -> CursorID {
         self.cursor_ref
             .iter()
             .position(|(t_ident, _)| {

--- a/core/vdbe/builder.rs
+++ b/core/vdbe/builder.rs
@@ -361,10 +361,6 @@ impl ProgramBuilder {
             .unwrap()
     }
 
-    pub fn resolve_cursor_to_table(&self, cursor_id: CursorID) -> Option<Table> {
-        self.cursor_ref[cursor_id].1.clone()
-    }
-
     pub fn resolve_deferred_labels(&mut self) {
         for i in 0..self.deferred_label_resolutions.len() {
             let (label, insn_reference) = self.deferred_label_resolutions[i];

--- a/testing/math.test
+++ b/testing/math.test
@@ -15,6 +15,18 @@ do_execsql_test add-int-float {
   SELECT 10 + 0.1
 } {10.1}
 
+do_execsql_test add-agg-int-agg-int {
+  SELECT sum(1) + sum(2)
+} {3}
+
+do_execsql_test add-agg-int-agg-float {
+  SELECT sum(1) + sum(2.5)
+} {3.5}
+
+do_execsql_test add-agg-float-agg-int {
+  SELECT sum(1.5) + sum(2)
+} {3.5}
+
 do_execsql_test subtract-int {
   SELECT 10 - 1
 } {9}
@@ -26,6 +38,18 @@ do_execsql_test subtract-float {
 do_execsql_test subtract-int-float {
   SELECT 10 - 0.1
 } {9.9}
+
+do_execsql_test subtract-agg-int-agg-int {
+  SELECT sum(3) - sum(1)
+} {2}
+
+do_execsql_test subtract-agg-int-agg-float {
+  SELECT sum(3) - sum(1.5)
+} {1.5}
+
+do_execsql_test subtract-agg-float-agg-int {
+  SELECT sum(3.5) - sum(1)
+} {2.5}
 
 do_execsql_test multiply-int {
   SELECT 10 * 2
@@ -42,6 +66,18 @@ do_execsql_test multiply-int-float {
 do_execsql_test multiply-float-int {
   SELECT 1.45 * 10
 } {14.5}
+
+do_execsql_test multiply-agg-int-agg-int {
+  SELECT sum(2) * sum(3)
+} {6}
+
+do_execsql_test multiply-agg-int-agg-float {
+  SELECT sum(2) * sum(3.5)
+} {7.0}
+
+do_execsql_test multiply-agg-float-agg-int {
+  SELECT sum(2.5) * sum(3)
+} {7.5}
 
 do_execsql_test divide-int {
   SELECT 10 / 2
@@ -79,6 +115,17 @@ do_execsql_test divide-null {
   SELECT null / null
 } {}
 
+do_execsql_test divide-agg-int-agg-int {
+  SELECT sum(4) / sum(2)
+} {2}
+
+do_execsql_test divide-agg-int-agg-float {
+  SELECT sum(4) / sum(2.0)
+} {2.0}
+
+do_execsql_test divide-agg-float-agg-int {
+  SELECT sum(4.0) / sum(2)
+} {2.0}
 
 
 do_execsql_test add-agg-int {

--- a/testing/orderby.test
+++ b/testing/orderby.test
@@ -116,3 +116,16 @@ Whitney|Walker|1
 Robert|Villanueva|1
 Cynthia|Thomas|1
 Brandon|Tate|1}
+
+do_execsql_test order-by-case-insensitive-aggregate {
+  select u.first_name, sum(u.age) from users u group by u.first_name order by SUM(u.aGe) desc limit 10;
+} {Michael|11204
+David|8758
+Robert|8109
+Jennifer|7700
+John|7299
+Christopher|6397
+James|5921
+Joseph|5711
+Brian|5059
+William|5047}

--- a/testing/orderby.test
+++ b/testing/orderby.test
@@ -129,3 +129,11 @@ James|5921
 Joseph|5711
 Brian|5059
 William|5047}
+
+do_execsql_test order-by-agg-not-mentioned-in-select {
+  select u.first_name, length(group_concat(u.last_name)) from users u group by u.first_name order by max(u.email) desc limit 5;
+} {Louis|65
+Carolyn|118
+Katelyn|40
+Erik|88
+Collin|15}

--- a/vendored/sqlite3-parser/src/parser/ast/fmt.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/fmt.rs
@@ -638,6 +638,7 @@ impl ToTokens for Expr {
             }
             Self::Id(id) => id.to_tokens(s),
             Self::Column { .. } => Ok(()),
+            Self::AggRef { .. } => Ok(()),
             Self::InList { lhs, not, rhs } => {
                 lhs.to_tokens(s)?;
                 if *not {

--- a/vendored/sqlite3-parser/src/parser/ast/fmt.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/fmt.rs
@@ -637,6 +637,7 @@ impl ToTokens for Expr {
                 Ok(())
             }
             Self::Id(id) => id.to_tokens(s),
+            Self::Column { .. } => Ok(()),
             Self::InList { lhs, not, rhs } => {
                 lhs.to_tokens(s)?;
                 if *not {

--- a/vendored/sqlite3-parser/src/parser/ast/fmt.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/fmt.rs
@@ -638,7 +638,6 @@ impl ToTokens for Expr {
             }
             Self::Id(id) => id.to_tokens(s),
             Self::Column { .. } => Ok(()),
-            Self::AggRef { .. } => Ok(()),
             Self::InList { lhs, not, rhs } => {
                 lhs.to_tokens(s)?;
                 if *not {

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -338,6 +338,11 @@ pub enum Expr {
         /// is the column a primary key
         is_primary_key: bool,
     },
+    /// AggRef is a reference to a computed aggregate
+    AggRef {
+        /// index of the aggregate in the aggregates vector parsed from the query
+        index: usize,
+    },
     /// `IN`
     InList {
         /// expression

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -327,6 +327,17 @@ pub enum Expr {
     },
     /// Identifier
     Id(Id),
+    /// Column
+    Column {
+        /// the x in `x.y.z`. index of the db in catalog.
+        database: Option<usize>,
+        /// the y in `x.y.z`. index of the table in catalog.
+        table: usize,
+        /// the z in `x.y.z`. index of the column in the table.
+        column: usize,
+        /// is the column a primary key
+        is_primary_key: bool,
+    },
     /// `IN`
     InList {
         /// expression

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -335,13 +335,8 @@ pub enum Expr {
         table: usize,
         /// the z in `x.y.z`. index of the column in the table.
         column: usize,
-        /// is the column a primary key
-        is_primary_key: bool,
-    },
-    /// AggRef is a reference to a computed aggregate
-    AggRef {
-        /// index of the aggregate in the aggregates vector parsed from the query
-        index: usize,
+        /// is the column a rowid alias
+        is_rowid_alias: bool,
     },
     /// `IN`
     InList {


### PR DESCRIPTION
# (another) refactor of read path query processing logic

This PR rewrites our select query processing architecture by moving away from the stateful operator-based execution model, back to a more direct bytecode generation approach that, IMO, is easier to follow. A large part of the bytecode emission itself (`program.emit_insn(...)`) is just copy-pasted from the old implementation (after all, it did _work_), but just structured differently.

## Main Changes

1. Removed the `step()` state machine from operators. Previously, each operator had internal state tracking its execution progress, and parent operators would call `.step()` on their children until they needed to do something else. Reading the code and trying to follow the execution was not very easy, and the abstraction was also too general: there was a lot of unnecessary pattern matching and special casing to make query execution fit the model, when honestly the evaluation of a SELECT without any CTEs or subqueries etc can only go a few different ways.

2. Because of the above change, the main codegen function `emit_program()` now contains a series of linear conditional steps instead of kicking off the state machines with `root_operator.step()`. These steps are just things like: "open the cursors", "open the loops", "emit a record into either the main output or a sorter", etc.

3. The `Plan` struct now (again) contains most of the familiar SELECT query components (WHERE clause, GROUP BY, ORDER BY, etc.) rather than having all of them embedded in a tree of operators. The operator tree now ONLY consists of operators that read from a source table in some way -- so it could just be called a join tree, I guess.

4. There's now `plan.result_columns` which is _ALWAYS_ evaluated to get the final results of a SELECT. Previously the operator state machine thing had a hodgepodge of different ways of arriving at the result row.

5. Removed operators:
   - Removed Filter operator (even in the previous version the Filter operator -- which is really the where clause -- had its predicates pushed down to the table loops, and it didn't really ever exist in the bytecode emission phase anymore)
   - Removed Projection operator (`plan.result_columns`)
   - Removed Limit operator (`plan.limit`)
   - Removed Aggregate operator (`plan.group_by` and `plan.aggregates`)
   - Removed Order operator (`plan.order_by`)

6. Added `ast::Expr::Column` to the vendored sqlite3 parser -- column resolution is now done as early as possible. This eliminates repeated string comparisons during execution. I.e. no need for `resolve_ident_table()` etc

7. Simplified expression result caching by removing the complex, and frankly weird, ExpressionResultCache apparatus. The refactored code handles this by tracking which cursor to read columns from at a given time, and copies values from existing registers if the expression is a computation that has already been done in a previous step of the execution. For example in:
```
limbo> select concat(u.first_name, '-LOL'), sum(u.age) from users u group by concat(u.first_name, '-LOL') order by sum(u.age) desc limit 10;
Michael-LOL|11204
David-LOL|8758
Robert-LOL|8109
Jennifer-LOL|7700
John-LOL|7299
Christopher-LOL|6397
James-LOL|5921
Joseph-LOL|5711
Brian-LOL|5059
William-LOL|5047
```
the query execution engine knows that `concat(u.first_name, '-LOL')` is the second column of the `ORDER_BY` sorter without any complex caching.

**HACK:** For deduplicating expressions in ORDER BY and the SELECT body, the code still relies on expression `==` equality to make those decisions which sucks (e.g. `sum(x) != SUM(x)` -- I've marked the parts where this is used with a TODO, we should have a custom expression equality comparison function instead...). This is not a correctness-breaking thing, but still.

## In short

- No more state machines
- The operator tree is now only a "join tree", pretty much
- No weird general purpose `ExpressionResultCache`
- More direct mapping between SQL operations and generated bytecode -- there's really no harm in carrying the "group by" etc concepts in the bytecode generation phase instead of burying them inside Operators
- When a ResultRow is emitted, it is _always_ done by evaluating `plan.result_columns`, instead of the special-casing and hacks that existed previously
- 600+ LOC removed