### PR TITLE
feat(core/translate): support HAVING

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -2,11 +2,16 @@
 
 This document describes the SQLite compatibility status of Limbo:
 
-* [Limitations](#limitations)
-* [SQL statements](#sql-statements)
-* [SQL functions](#sql-functions)
-* [SQLite API](#sqlite-api)
-* [SQLite VDBE opcodes](#sqlite-vdbe-opcodes)
+- [SQLite Compatibility](#sqlite-compatibility)
+  - [Limitations](#limitations)
+  - [SQL statements](#sql-statements)
+  - [SQL functions](#sql-functions)
+    - [Scalar functions](#scalar-functions)
+    - [Aggregate functions](#aggregate-functions)
+    - [Date and time functions](#date-and-time-functions)
+    - [JSON functions](#json-functions)
+  - [SQLite API](#sqlite-api)
+  - [SQLite VDBE opcodes](#sqlite-vdbe-opcodes)
 
 ## Limitations
 
@@ -51,6 +56,7 @@ This document describes the SQLite compatibility status of Limbo:
 | SELECT ... LIMIT             | Yes     |         |
 | SELECT ... ORDER BY          | Partial |         |
 | SELECT ... GROUP BY          | Partial |         |
+| SELECT ... HAVING            | Partial |         |
 | SELECT ... JOIN              | Partial |         |
 | SELECT ... CROSS JOIN        | Partial |         |
 | SELECT ... INNER JOIN        | Partial |         |

--- a/core/translate/expr.rs
+++ b/core/translate/expr.rs
@@ -871,7 +871,6 @@ pub fn translate_expr(
                             for arg in args.iter() {
                                 let reg = program.alloc_register();
                                 start_reg = Some(start_reg.unwrap_or(reg));
-
                                 translate_expr(
                                     program,
                                     referenced_tables,

--- a/core/translate/plan.rs
+++ b/core/translate/plan.rs
@@ -20,6 +20,13 @@ pub struct ResultSetColumn {
 }
 
 #[derive(Debug)]
+pub struct GroupBy {
+    pub exprs: Vec<ast::Expr>,
+    /// having clause split into a vec at 'AND' boundaries.
+    pub having: Option<Vec<ast::Expr>>,
+}
+
+#[derive(Debug)]
 pub struct Plan {
     /// A tree of sources (tables).
     pub source: SourceOperator,
@@ -28,7 +35,7 @@ pub struct Plan {
     /// where clause split into a vec at 'AND' boundaries.
     pub where_clause: Option<Vec<ast::Expr>>,
     /// group by clause
-    pub group_by: Option<Vec<ast::Expr>>,
+    pub group_by: Option<GroupBy>,
     /// order by clause
     pub order_by: Option<Vec<(ast::Expr, Direction)>>,
     /// all the aggregates collected from the result columns, order by, and (TODO) having clauses

--- a/core/translate/planner.rs
+++ b/core/translate/planner.rs
@@ -1,5 +1,5 @@
 use super::plan::{
-    Aggregate, BTreeTableReference, Direction, Plan, ResultSetColumn, SourceOperator,
+    Aggregate, BTreeTableReference, Direction, GroupBy, Plan, ResultSetColumn, SourceOperator,
 };
 use crate::{function::Func, schema::Schema, util::normalize_ident, Result};
 use sqlite3_parser::ast::{self, FromClause, JoinType, ResultColumn};
@@ -19,9 +19,9 @@ impl OperatorIdCounter {
     }
 }
 
-fn resolve_aggregates(expr: &ast::Expr, aggs: &mut Vec<Aggregate>) {
+fn resolve_aggregates(expr: &ast::Expr, aggs: &mut Vec<Aggregate>) -> bool {
     if aggs.iter().any(|a| a.original_expr == *expr) {
-        return;
+        return true;
     }
     match expr {
         ast::Expr::FunctionCall { name, args, .. } => {
@@ -31,17 +31,22 @@ fn resolve_aggregates(expr: &ast::Expr, aggs: &mut Vec<Aggregate>) {
                 0
             };
             match Func::resolve_function(normalize_ident(name.0.as_str()).as_str(), args_count) {
-                Ok(Func::Agg(f)) => aggs.push(Aggregate {
-                    func: f,
-                    args: args.clone().unwrap_or_default(),
-                    original_expr: expr.clone(),
-                }),
+                Ok(Func::Agg(f)) => {
+                    aggs.push(Aggregate {
+                        func: f,
+                        args: args.clone().unwrap_or_default(),
+                        original_expr: expr.clone(),
+                    });
+                    true
+                }
                 _ => {
+                    let mut contains_aggregates = false;
                     if let Some(args) = args {
                         for arg in args.iter() {
-                            resolve_aggregates(arg, aggs);
+                            contains_aggregates |= resolve_aggregates(arg, aggs);
                         }
                     }
+                    contains_aggregates
                 }
             }
         }
@@ -53,15 +58,20 @@ fn resolve_aggregates(expr: &ast::Expr, aggs: &mut Vec<Aggregate>) {
                     func: f,
                     args: vec![],
                     original_expr: expr.clone(),
-                })
+                });
+                true
+            } else {
+                false
             }
         }
         ast::Expr::Binary(lhs, _, rhs) => {
-            resolve_aggregates(lhs, aggs);
-            resolve_aggregates(rhs, aggs);
+            let mut contains_aggregates = false;
+            contains_aggregates |= resolve_aggregates(lhs, aggs);
+            contains_aggregates |= resolve_aggregates(rhs, aggs);
+            contains_aggregates
         }
         // TODO: handle other expressions that may contain aggregates
-        _ => {}
+        _ => false,
     }
 }
 
@@ -340,10 +350,8 @@ pub fn prepare_select_plan<'a>(schema: &Schema, select: ast::Select) -> Result<P
                                         });
                                     }
                                     Ok(_) => {
-                                        let cur_agg_count = aggregate_expressions.len();
-                                        resolve_aggregates(&expr, &mut aggregate_expressions);
                                         let contains_aggregates =
-                                            cur_agg_count != aggregate_expressions.len();
+                                            resolve_aggregates(&expr, &mut aggregate_expressions);
                                         plan.result_columns.push(ResultSetColumn {
                                             expr: expr.clone(),
                                             contains_aggregates,
@@ -380,10 +388,8 @@ pub fn prepare_select_plan<'a>(schema: &Schema, select: ast::Select) -> Result<P
                                 }
                             }
                             expr => {
-                                let cur_agg_count = aggregate_expressions.len();
-                                resolve_aggregates(expr, &mut aggregate_expressions);
                                 let contains_aggregates =
-                                    cur_agg_count != aggregate_expressions.len();
+                                    resolve_aggregates(expr, &mut aggregate_expressions);
                                 plan.result_columns.push(ResultSetColumn {
                                     expr: expr.clone(),
                                     contains_aggregates,
@@ -393,18 +399,37 @@ pub fn prepare_select_plan<'a>(schema: &Schema, select: ast::Select) -> Result<P
                     }
                 }
             }
-            if let Some(group_by) = group_by.as_mut() {
+            if let Some(mut group_by) = group_by {
                 for expr in group_by.exprs.iter_mut() {
                     bind_column_references(expr, &plan.referenced_tables)?;
                 }
-                if aggregate_expressions.is_empty() {
-                    crate::bail_parse_error!(
-                        "GROUP BY clause without aggregate functions is not allowed"
-                    );
-                }
+
+                plan.group_by = Some(GroupBy {
+                    exprs: group_by.exprs,
+                    having: if let Some(having) = group_by.having {
+                        let mut predicates = vec![];
+                        break_predicate_at_and_boundaries(having, &mut predicates);
+                        for expr in predicates.iter_mut() {
+                            bind_column_references(expr, &plan.referenced_tables)?;
+                            let contains_aggregates =
+                                resolve_aggregates(expr, &mut aggregate_expressions);
+                            if !contains_aggregates {
+                                // TODO: sqlite allows HAVING clauses with non aggregate expressions like
+                                // HAVING id = 5. We should support this too eventually (I guess).
+                                // sqlite3-parser does not support HAVING without group by though, so we'll
+                                // need to either make a PR or add it to our vendored version.
+                                crate::bail_parse_error!(
+                                    "HAVING clause must contain an aggregate function"
+                                );
+                            }
+                        }
+                        Some(predicates)
+                    } else {
+                        None
+                    },
+                });
             }
 
-            plan.group_by = group_by.map(|g| g.exprs);
             plan.aggregates = if aggregate_expressions.is_empty() {
                 None
             } else {

--- a/core/types.rs
+++ b/core/types.rs
@@ -124,7 +124,9 @@ impl PartialOrd<OwnedValue> for OwnedValue {
             (OwnedValue::Null, _) => Some(std::cmp::Ordering::Less),
             (_, OwnedValue::Null) => Some(std::cmp::Ordering::Greater),
             (OwnedValue::Agg(a), OwnedValue::Agg(b)) => a.partial_cmp(b),
-            _ => None,
+            (OwnedValue::Agg(a), other) => a.final_value().partial_cmp(other),
+            (other, OwnedValue::Agg(b)) => other.partial_cmp(b.final_value()),
+            other => todo!("{:?}", other),
         }
     }
 }

--- a/testing/groupby.test
+++ b/testing/groupby.test
@@ -131,3 +131,34 @@ do_execsql_test group_by_function_expression_ridiculous {
 do_execsql_test group_by_count_star {
   select u.first_name, count(*) from users u group by u.first_name limit 1;
 } {Aaron|41}
+
+do_execsql_test having {
+  select u.first_name, round(avg(u.age)) from users u group by u.first_name having avg(u.age) > 97 order by avg(u.age) desc limit 5;
+} {Nina|100.0
+Kurt|99.0
+Selena|98.0}
+
+do_execsql_test having_with_binary_cond {
+  select u.first_name, sum(u.age) from users u group by u.first_name having sum(u.age) + 1000 = 9109;
+} {Robert|8109}
+
+do_execsql_test having_with_scalar_fn_over_aggregate {
+  select u.first_name, concat(count(1), ' people with this name') from users u group by u.first_name having count(1) > 50 order by count(1) asc limit 5;
+} {"Angela|51 people with this name
+Justin|51 people with this name
+Rachel|52 people with this name
+Susan|52 people with this name
+Jeffrey|54 people with this name"}
+
+do_execsql_test having_with_multiple_conditions {
+  select u.first_name, count(*), round(avg(u.age)) as avg_age 
+  from users u 
+  group by u.first_name 
+  having count(*) > 40 and avg(u.age) > 40
+  order by count(*) desc, avg(u.age) desc
+  limit 5;
+} {Michael|228|49.0
+David|165|53.0
+Robert|159|51.0
+Jennifer|151|51.0
+John|145|50.0}


### PR DESCRIPTION
support the HAVING clause.

note that sqlite (and i think standard sql?) supports HAVING even without GROUP BY, but `sqlite3-parser` doesn't.

also fixes some issues with the PartialOrd implementation of OwnedValue and the implementations of `concat` and `round` which i discovered due to my HAVING tcl tests failing